### PR TITLE
Removed isBoolean from jsonParser and moved it to yamlParser

### DIFF
--- a/src/languageService/parser/jsonParser.ts
+++ b/src/languageService/parser/jsonParser.ts
@@ -130,9 +130,9 @@ export class ASTNode {
 		return collector.length;
 	}
 
-	public isBoolean(value): boolean {
-		let availableBooleans = ['y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'true', 'True', 'TRUE', 'false', 'False', 'FALSE', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
-		return availableBooleans.indexOf(value) !== -1;
+	public isBoolean(value: string): boolean {
+		let availableBooleans = ['true', 'false', 'True', 'False', 'TRUE', 'FALSE', 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
+		return availableBooleans.indexOf(value.toLowerCase()) !== -1;
 	}
 
 	public getNodeFromOffsetEndInclusive(offset: number): ASTNode {

--- a/src/languageService/parser/jsonParser.ts
+++ b/src/languageService/parser/jsonParser.ts
@@ -95,8 +95,6 @@ export class ASTNode {
 		return visitor(this);
 	}
 
-	
-
 	public getNodeFromOffset(offset: number): ASTNode {
 		let findNode = (node: ASTNode): ASTNode => {
 			if (offset >= node.start && offset < node.end) {
@@ -128,11 +126,6 @@ export class ASTNode {
 		};
 		let foundNode = findNode(this);
 		return collector.length;
-	}
-
-	public isBoolean(value: string): boolean {
-		let availableBooleans = ['true', 'false', 'True', 'False', 'TRUE', 'FALSE', 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
-		return availableBooleans.indexOf(value) !== -1;
 	}
 
 	public getNodeFromOffsetEndInclusive(offset: number): ASTNode {
@@ -179,19 +172,7 @@ export class ASTNode {
 			}
 		}
 		else if (schema.type) {
-
-			let isValid = true;
-			switch(schema.type){
-				case "boolean":
-					let val = this.getValue() !== null ? this.getValue().toString() : this.getValue(); 
-					isValid = this.isBoolean(val);
-					break;
-				default:
-					isValid = this.type === schema.type;
-					break;
-			}
-
-			if (!isValid) {
+			if (this.type !== schema.type) {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
@@ -389,9 +370,9 @@ export class NullASTNode extends ASTNode {
 
 export class BooleanASTNode extends ASTNode {
 
-	private value: boolean;
+	private value: boolean | string;
 
-	constructor(parent: ASTNode, name: Json.Segment, value: boolean, start: number, end?: number) {
+	constructor(parent: ASTNode, name: Json.Segment, value: boolean | string, start: number, end?: number) {
 		super(parent, 'boolean', name, start, end);
 		this.value = value;
 	}
@@ -399,6 +380,7 @@ export class BooleanASTNode extends ASTNode {
 	public getValue(): any {
 		return this.value;
 	}
+
 }
 
 export class ArrayASTNode extends ASTNode {
@@ -1301,6 +1283,7 @@ export function parse(text: string, config?: JSONDocumentConfig): JSONDocument {
 			case Json.SyntaxKind.FalseKeyword:
 				node = new BooleanASTNode(parent, name, false, scanner.getTokenOffset());
 				break;
+
 			default:
 				return null;
 		}

--- a/src/languageService/parser/jsonParser.ts
+++ b/src/languageService/parser/jsonParser.ts
@@ -132,7 +132,7 @@ export class ASTNode {
 
 	public isBoolean(value: string): boolean {
 		let availableBooleans = ['true', 'false', 'True', 'False', 'TRUE', 'FALSE', 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
-		return availableBooleans.indexOf(value.toLowerCase()) !== -1;
+		return availableBooleans.indexOf(value) !== -1;
 	}
 
 	public getNodeFromOffsetEndInclusive(offset: number): ASTNode {

--- a/src/languageService/parser/yamlParser.ts
+++ b/src/languageService/parser/yamlParser.ts
@@ -145,7 +145,8 @@ function recursivelyBuildAst(parent: ASTNode, node: Yaml.YAMLNode): ASTNode {
 			const name = null;
 			const value = instance.value;
 
-			let possibleBooleanValues = ['true', 'false', 'True', 'False', 'TRUE', 'FALSE', 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
+			//This is a patch for redirecting values with these strings to be boolean nodes because its not supported in the parser.
+			let possibleBooleanValues = ['y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
 			if(possibleBooleanValues.indexOf(value.toString()) !== -1){
 				return new BooleanASTNode(parent, name, value, node.startPosition, node.endPosition)
 			}

--- a/src/languageService/parser/yamlParser.ts
+++ b/src/languageService/parser/yamlParser.ts
@@ -145,6 +145,11 @@ function recursivelyBuildAst(parent: ASTNode, node: Yaml.YAMLNode): ASTNode {
 			const name = null;
 			const value = instance.value;
 
+			let possibleBooleanValues = ['true', 'false', 'True', 'False', 'TRUE', 'FALSE', 'y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO', 'on', 'On', 'ON', 'off', 'Off', 'OFF'];
+			if(possibleBooleanValues.indexOf(value.toString()) !== -1){
+				return new BooleanASTNode(parent, name, value, node.startPosition, node.endPosition)
+			}
+
 			switch (type) {
 				case Yaml.ScalarType.null: {
 					return new NullASTNode(parent, name, instance.startPosition, instance.endPosition);


### PR DESCRIPTION
- Removed isBoolean from jsonParser because its no longer needed.
- yamlParser now turns on, off etc etc into boolean nodes.
- isBoolean now puts true, false, True, False, TRUE, FALSE first as they are the most commonly used.