### PR TITLE
DO NOT MERGE: Reverted regression in jsonParser testAlternatives

### DIFF
--- a/src/languageService/jsonSchema.ts
+++ b/src/languageService/jsonSchema.ts
@@ -34,6 +34,7 @@ export interface JSONSchema {
 	required?: string[];
 	$ref?: string;
 	anyOf?: JSONSchema[];
+	anyOfMatching?: JSONSchema[]; //This is a custom property that forces all nodes to be inside the properties/items/additionalProperties fields
 	allOf?: JSONSchema[];
 	oneOf?: JSONSchema[];
 	not?: JSONSchema;

--- a/src/languageService/kubernetesTransformer.ts
+++ b/src/languageService/kubernetesTransformer.ts
@@ -2,13 +2,13 @@ export class KubernetesTransformer {
 
     public static doTransformation(resolve_kubernetes_schema){
 
-        if(resolve_kubernetes_schema.anyOf === undefined){
+        if(resolve_kubernetes_schema.anyOfMatching === undefined){
             let props = resolve_kubernetes_schema.properties;
-            resolve_kubernetes_schema.anyOf = [];
+            resolve_kubernetes_schema.anyOfMatching = [];
 
             for(let prop in props){
                 let currProps = props[prop];
-                resolve_kubernetes_schema.anyOf.push(currProps);
+                resolve_kubernetes_schema.anyOfMatching.push(currProps);
             }
 
             resolve_kubernetes_schema.properties = {};

--- a/src/languageService/parser/jsonParser.ts
+++ b/src/languageService/parser/jsonParser.ts
@@ -259,6 +259,119 @@ export class ASTNode {
 			testAlternatives(schema.oneOf, true);
 		}
 
+		let testAlternativesMatching = (alternatives: JSONSchema[]) => {
+			let matches = [];
+			let allMatches = [];
+			let fallBackMatches = [];
+			// remember the best match that is used for error messages
+			let bestMatch: { schema: JSONSchema; validationResult: ValidationResult; matchingSchemas: ISchemaCollector; } = null;
+			let fallbackBestMatch: { schema: JSONSchema; validationResult: ValidationResult; matchingSchemas: ISchemaCollector; } = null;
+			alternatives.forEach((subSchema) => {
+				let subValidationResult = new ValidationResult();
+				let subMatchingSchemas = matchingSchemas.newSub();
+				this.validate(subSchema, subValidationResult, subMatchingSchemas);
+
+				let holderFound = false;
+				function isHolderFound(node){
+					if(!node || Object.keys(node).length === 0){
+						return;
+					}
+
+					Object.keys(node).forEach(key => {
+						let n: any = node[key];
+						if(key === "holder" && n === null){
+							holderFound = true;
+						}else if(typeof n === "object"){
+							isHolderFound(n);
+						}
+					});
+
+				}
+
+				isHolderFound(this.getValue());
+				
+				let numberOfSubSchemas = subMatchingSchemas.schemas.length - 1;
+				
+				//Case in which everything is valid
+				let firstArg = numberOfSubSchemas === this.getNodeCollectorCount(this.end); 
+				
+				//If holder is found then we can increase number of subschemas
+				let	secondArg = holderFound && numberOfSubSchemas+1 === this.getNodeCollectorCount(this.end);
+
+				if(firstArg || secondArg){
+					allMatches.push(subSchema);	
+					if (!subValidationResult.hasProblems()) {
+						matches.push(subSchema);
+					}
+					if (!bestMatch) {
+						bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+					} else {
+						if (!subValidationResult.hasProblems() && !bestMatch.validationResult.hasProblems()) {
+							// no errors, both are equally good matches
+							bestMatch.matchingSchemas.merge(subMatchingSchemas);
+							bestMatch.validationResult.propertiesMatches += subValidationResult.propertiesMatches;
+							bestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
+						} else {
+							let compareResult = subValidationResult.compare(bestMatch.validationResult);
+							if (compareResult > 0) {
+								// our node is the best matching so far
+								bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+							} else if (compareResult === 0) {
+								// there's already a best matching but we are as good
+								bestMatch.matchingSchemas.merge(subMatchingSchemas);
+								bestMatch.validationResult.mergeEnumValues(subValidationResult);
+							}
+						}
+					}
+				}
+
+				if(!(firstArg || secondArg)){
+					if (!subValidationResult.hasProblems()) {
+						fallBackMatches.push(subSchema);
+					}
+					if (!fallbackBestMatch) {
+						fallbackBestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+					} else {
+						if (!subValidationResult.hasProblems() && !fallbackBestMatch.validationResult.hasProblems()) {
+							// no errors, both are equally good matches
+							fallbackBestMatch.matchingSchemas.merge(subMatchingSchemas);
+							fallbackBestMatch.validationResult.propertiesMatches += subValidationResult.propertiesMatches;
+							fallbackBestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
+						} else {
+							let compareResult = subValidationResult.compare(fallbackBestMatch.validationResult);
+							if (compareResult > 0) {
+								// our node is the best matching so far
+								fallbackBestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+							} else if (compareResult === 0) {
+								// there's already a best matching but we are as good
+								fallbackBestMatch.matchingSchemas.merge(subMatchingSchemas);
+								fallbackBestMatch.validationResult.mergeEnumValues(subValidationResult);
+							}
+						}
+					}
+				}
+			});
+
+			if(matches.length === 0){
+				matches = allMatches;
+			}
+			if(matches.length === 0 && allMatches.length === 0){
+				matches = fallBackMatches;
+				bestMatch = fallbackBestMatch
+			}
+			if (bestMatch !== null) {
+				validationResult.merge(bestMatch.validationResult);
+				validationResult.propertiesMatches += bestMatch.validationResult.propertiesMatches;
+				validationResult.propertiesValueMatches += bestMatch.validationResult.propertiesValueMatches;
+				matchingSchemas.merge(bestMatch.matchingSchemas);
+			}
+			return matches.length;
+		};
+
+		if (Array.isArray(schema.anyOfMatching)){
+			testAlternativesMatching(schema.anyOfMatching);
+		}
+
 		if (Array.isArray(schema.enum)) {
 			let val = this.getValue();
 			let enumValueMatch = false;

--- a/src/languageService/parser/jsonParser.ts
+++ b/src/languageService/parser/jsonParser.ts
@@ -204,93 +204,34 @@ export class ASTNode {
 
 		let testAlternatives = (alternatives: JSONSchema[], maxOneMatch: boolean) => {
 			let matches = [];
-			let allMatches = [];
-			let fallBackMatches = [];
+
 			// remember the best match that is used for error messages
 			let bestMatch: { schema: JSONSchema; validationResult: ValidationResult; matchingSchemas: ISchemaCollector; } = null;
-			let fallbackBestMatch: { schema: JSONSchema; validationResult: ValidationResult; matchingSchemas: ISchemaCollector; } = null;
 			alternatives.forEach((subSchema) => {
 				let subValidationResult = new ValidationResult();
 				let subMatchingSchemas = matchingSchemas.newSub();
+
 				this.validate(subSchema, subValidationResult, subMatchingSchemas);
-
-				let holderFound = false;
-				function isHolderFound(node){
-					if(!node || Object.keys(node).length === 0){
-						return;
-					}
-
-					Object.keys(node).forEach(key => {
-						let n: any = node[key];
-						if(key === "holder" && n === null){
-							holderFound = true;
-						}else if(typeof n === "object"){
-							isHolderFound(n);
-						}
-					});
-
+				if (!subValidationResult.hasProblems()) {
+					matches.push(subSchema);
 				}
-
-				isHolderFound(this.getValue());
-				
-				let numberOfSubSchemas = subMatchingSchemas.schemas.length - 1;
-				
-				//Case in which everything is valid
-				let firstArg = numberOfSubSchemas === this.getNodeCollectorCount(this.end); 
-				
-				//If holder is found then we can increase number of subschemas
-				let	secondArg = holderFound && numberOfSubSchemas+1 === this.getNodeCollectorCount(this.end);
-
-				//Live type isn't working for kubernetes schema
-				if(firstArg || secondArg){
-					allMatches.push(subSchema);	
-					if (!subValidationResult.hasProblems()) {
-						matches.push(subSchema);
-					}
-					if (!bestMatch) {
-						bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+				if (!bestMatch) {
+					bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+				} else {
+					if (!maxOneMatch && !subValidationResult.hasProblems() && !bestMatch.validationResult.hasProblems()) {
+						// no errors, both are equally good matches
+						bestMatch.matchingSchemas.merge(subMatchingSchemas);
+						bestMatch.validationResult.propertiesMatches += subValidationResult.propertiesMatches;
+						bestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
 					} else {
-						if (!maxOneMatch && !subValidationResult.hasProblems() && !bestMatch.validationResult.hasProblems()) {
-							// no errors, both are equally good matches
+						let compareResult = subValidationResult.compare(bestMatch.validationResult);
+						if (compareResult > 0) {
+							// our node is the best matching so far
+							bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
+						} else if (compareResult === 0) {
+							// there's already a best matching but we are as good
 							bestMatch.matchingSchemas.merge(subMatchingSchemas);
-							bestMatch.validationResult.propertiesMatches += subValidationResult.propertiesMatches;
-							bestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
-						} else {
-							let compareResult = subValidationResult.compare(bestMatch.validationResult);
-							if (compareResult > 0) {
-								// our node is the best matching so far
-								bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
-							} else if (compareResult === 0) {
-								// there's already a best matching but we are as good
-								bestMatch.matchingSchemas.merge(subMatchingSchemas);
-								bestMatch.validationResult.mergeEnumValues(subValidationResult);
-							}
-						}
-					}
-				}
-
-				if(!(firstArg || secondArg)){
-					if (!subValidationResult.hasProblems()) {
-						fallBackMatches.push(subSchema);
-					}
-					if (!fallbackBestMatch) {
-						fallbackBestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
-					} else {
-						if (!maxOneMatch && !subValidationResult.hasProblems() && !fallbackBestMatch.validationResult.hasProblems()) {
-							// no errors, both are equally good matches
-							fallbackBestMatch.matchingSchemas.merge(subMatchingSchemas);
-							fallbackBestMatch.validationResult.propertiesMatches += subValidationResult.propertiesMatches;
-							fallbackBestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
-						} else {
-							let compareResult = subValidationResult.compare(fallbackBestMatch.validationResult);
-							if (compareResult > 0) {
-								// our node is the best matching so far
-								fallbackBestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
-							} else if (compareResult === 0) {
-								// there's already a best matching but we are as good
-								fallbackBestMatch.matchingSchemas.merge(subMatchingSchemas);
-								fallbackBestMatch.validationResult.mergeEnumValues(subValidationResult);
-							}
+							bestMatch.validationResult.mergeEnumValues(subValidationResult);
 						}
 					}
 				}
@@ -302,13 +243,6 @@ export class ASTNode {
 					severity: ProblemSeverity.Warning,
 					message: localize('oneOfWarning', "Matches multiple schemas when only one must validate.")
 				});
-			}
-			if(matches.length === 0){
-				matches = allMatches;
-			}
-			if(matches.length === 0 && allMatches.length === 0){
-				matches = fallBackMatches;
-				bestMatch = fallbackBestMatch
 			}
 			if (bestMatch !== null) {
 				validationResult.merge(bestMatch.validationResult);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -38,7 +38,7 @@ languageService.configure(languageSettings);
 suite("Kubernetes Integration Tests", () => {
 
 	// Tests for validator
-	describe('Validation with kubernetes', function() {
+	describe('Yaml Validation with kubernetes', function() {
 		
 		function setup(content: string){
 			return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);


### PR DESCRIPTION
Reverted regression from 2a8456a7e2e319aece0f9d05e5af087450cedf63 in jsonParser testAlternatives.

Reason: Kubernetes schema validation was correct according to the schema and didn't need to change.