### PR TITLE
Pull json schemas from json schema store for well known yaml files

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -223,12 +223,8 @@ function getSchemaStoreMatchingSchemas(){
 		for(let schemaIndex in schemas.schemas){
 			
 			let schema = schemas.schemas[schemaIndex];
-			if(schema && schema.name){
-				
-				if(schema.name.indexOf('.yml') !== -1 || schema.name.indexOf('.yaml') !== -1){
-					languageSettings.schemas.push({ uri: schema.url, fileMatch: schema.fileMatch });
-				}
-			
+			if(schema && schema.name && schema.name.indexOf('.yml') !== -1 || schema.name.indexOf('.yaml') !== -1){
+				languageSettings.schemas.push({ uri: schema.url, fileMatch: schema.fileMatch });
 			}
 
 		}

--- a/src/server.ts
+++ b/src/server.ts
@@ -239,7 +239,7 @@ function getSchemaStoreMatchingSchemas(){
 		return languageSettings;
 
 	}, (error: XHRResponse) => {
-		return Promise.reject(error.responseText || getErrorStatusDescription(error.status) || error.toString());
+		throw error;
 	});
 
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -162,7 +162,6 @@ let formatterRegistration: Thenable<Disposable> = null;
 let specificValidatorPaths = [];
 let schemaConfigurationSettings = [];
 let yamlShouldValidate = true;
-let hasSchemaStoreBeenAdded = false;
 let schemaStoreSettings = [];
 
 connection.onDidChangeConfiguration((change) => {
@@ -202,12 +201,11 @@ connection.onDidChangeConfiguration((change) => {
 });
 
 function setSchemaStoreSettingsIfNotSet(){
-	if(!hasSchemaStoreBeenAdded){
+	if(schemaStoreSettings.length === 0){
 		getSchemaStoreMatchingSchemas().then(schemaStore => {
 			schemaStoreSettings = schemaStore.schemas;
 			updateConfiguration();
 		});
-		hasSchemaStoreBeenAdded = true;
 	}
 }
 
@@ -223,8 +221,17 @@ function getSchemaStoreMatchingSchemas(){
 		for(let schemaIndex in schemas.schemas){
 			
 			let schema = schemas.schemas[schemaIndex];
-			if(schema && schema.name && schema.name.indexOf('.yml') !== -1 || schema.name.indexOf('.yaml') !== -1){
-				languageSettings.schemas.push({ uri: schema.url, fileMatch: schema.fileMatch });
+			if(schema && schema.fileMatch){
+
+				for(let fileMatch in schema.fileMatch){
+					let currFileMatch = schema.fileMatch[fileMatch];
+
+					if(currFileMatch.indexOf('.yml') !== -1 || currFileMatch.indexOf('.yaml') !== -1){
+						languageSettings.schemas.push({ uri: schema.url, fileMatch: [currFileMatch] });
+					}
+
+				}
+				
 			}
 
 		}


### PR DESCRIPTION
This PR gets json schemas from the json schema store api [catalog endpoint](http://schemastore.org/api/json/catalog.json).

The question is whether we want to have this intergrated as a feature, especially if we can't verify the quality of the yaml files on the json schema store.