### PR TITLE
Mocha should be a dev dependency and not a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,8 @@
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
   "dependencies": {
-    "@types/mocha": "2.2.41",
     "deep-equal": "^1.0.1",
     "jsonc-parser": "^0.4.2",
-    "mocha": "3.4.2",
     "request-light": "^0.2.0",
     "vscode-json-languageservice": "2.0.16",
     "vscode-languageserver": "3.1.0",
@@ -35,7 +33,9 @@
     "yaml-ast-parser": "0.0.36"
   },
   "devDependencies": {
+    "@types/mocha": "2.2.41",
     "@types/node": "^6.0.52",
+    "mocha": "3.4.2",
     "coveralls": "^3.0.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^11.2.1",


### PR DESCRIPTION
As Mocha is only used for testing and not for the actual execution of the language server, it should be listed in the `devDependencies` section of the package.json file instead of the `dependencies` section.