### PR TITLE
Change URI tests to be cross-platform

### DIFF
--- a/test/uri.test.ts
+++ b/test/uri.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import URI from '../src/languageService/utils/uri';
+var path = require('path');
 var assert = require('assert');
 
 suite("URI Tests", () => {
@@ -12,7 +13,7 @@ suite("URI Tests", () => {
             var result = URI.parse("http://www.foo.com/bar.html?name=hello#123");
             assert.equal(result.authority, "www.foo.com");
             assert.equal(result.fragment, "123");
-            assert.equal(result.fsPath, "/bar.html");
+            assert.equal(result.fsPath, path.sep + "bar.html");
             assert.equal(result.path, "/bar.html");
             assert.equal(result.query, "name=hello");
             assert.equal(result.scheme, "http");
@@ -24,7 +25,7 @@ suite("URI Tests", () => {
             var result = URI.create("http", "www.foo.com", "/bar.html", "name=hello", "123");
             assert.equal(result.authority, "www.foo.com");
             assert.equal(result.fragment, "123");
-            assert.equal(result.fsPath, "/bar.html");
+            assert.equal(result.fsPath, path.sep + "bar.html");
             assert.equal(result.path, "/bar.html");
             assert.equal(result.query, "name=hello");
             assert.equal(result.scheme, "http");
@@ -35,7 +36,7 @@ suite("URI Tests", () => {
         it('Basic', () => {
             var result = URI.file("../uri.test.ts");
             assert.equal(result.fragment, "");
-            assert.equal(result.fsPath, "/../uri.test.ts");
+            assert.equal(result.fsPath, path.sep + ".." + path.sep + "uri.test.ts");
             assert.equal(result.path, "/../uri.test.ts");
             assert.equal(result.query, "");
             assert.equal(result.scheme, "file");
@@ -83,7 +84,7 @@ suite("URI Tests", () => {
             assert.equal(result["authority"], "");
             assert.equal(result["external"], "file:///c%3A/test.txt");
             assert.equal(result["fragment"], "");
-            assert.equal(result["fsPath"], "c:/test.txt");
+            assert.equal(result["fsPath"], "c:" + path.sep + "test.txt");
             assert.equal(result["path"], "/C:/test.txt");
             assert.equal(result["query"], "");
             assert.equal(result["scheme"], "file");


### PR DESCRIPTION
I've changed the URI tests to use `path.sep` for the separator character so that the tests will be cross-platform.

This fixes #30.