### PR TITLE
Fix for redhat-developer/yaml-language-server#34

### DIFF
--- a/src/languageService/yamlLanguageService.ts
+++ b/src/languageService/yamlLanguageService.ts
@@ -87,6 +87,7 @@ export interface LanguageService {
   doHover(document: TextDocument, position: Position, doc, isKubernetes: Boolean);
   findDocumentSymbols(document: TextDocument, doc);
   doResolve(completionItem);
+  resetSchema(uri: string): boolean;
 }
 
 export function getLanguageService(schemaRequestService, workspaceContext, contributions, promiseConstructor?): LanguageService {
@@ -113,6 +114,7 @@ export function getLanguageService(schemaRequestService, workspaceContext, contr
       doResolve: completer.doResolve.bind(completer),
       doValidation: yamlValidation.doValidation.bind(yamlValidation),
       doHover: hover.doHover.bind(hover),
-      findDocumentSymbols: yamlDocumentSymbols.findDocumentSymbols.bind(yamlDocumentSymbols)
+      findDocumentSymbols: yamlDocumentSymbols.findDocumentSymbols.bind(yamlDocumentSymbols),
+      resetSchema: (uri: string) => schemaService.onResourceChange(uri)
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -381,7 +381,7 @@ connection.onDidChangeWatchedFiles((change) => {
 	// Monitored files have changed in VSCode
 	let hasChanges = false;
 	change.changes.forEach(c => {
-		if (languageService.resetSchema(c.uri)) {
+		if (customLanguageService.resetSchema(c.uri)) {
 			hasChanges = true;
 		}
 	});


### PR DESCRIPTION
This fix allows the custom language service to use reset schema. Combined with https://github.com/redhat-developer/vscode-yaml/pull/53. It will make it so modified json files are reloaded when editing.