### PR TITLE
Allow replacing "kedge" keyword to JSON Schema URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@
 ```
 yaml.schemas: {
     "url": "globPattern",
-    "kubernetes": "globPattern"
+    "kubernetes": "globPattern",
+    "kedge": "globPattern"
 }
 ```
-kubernetes is an optional field. It does not require a url as the language server will provide that. You just need the key word kubernetes and a glob pattern.
+kubernetes and kedge are optional fields. They do not require URLs as the language server will provide that. You just need the keywords kubernetes/kedge and a glob pattern.
 
 ## Clients
 This repository only contains the server implementation. Here are some known clients consuming this server:

--- a/src/server.ts
+++ b/src/server.ts
@@ -160,6 +160,7 @@ export let languageService = getLanguageService({
 });
 
 export let KUBERNETES_SCHEMA_URL = "http://central.maven.org/maven2/io/fabric8/kubernetes-model/2.0.0/kubernetes-model-2.0.0-schema.json";
+export let KEDGE_SCHEMA_URL = "https://raw.githubusercontent.com/kedgeproject/json-schema/master/master/kedge-json-schema.json";
 export let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, []);
 
 // The settings interface describes the server relevant settings part
@@ -323,6 +324,9 @@ function configureSchemas(uri, fileMatch, schema, languageSettings){
 
 	if(uri.toLowerCase().trim() === "kubernetes"){
 		uri = KUBERNETES_SCHEMA_URL;	
+	}
+	if(uri.toLowerCase().trim() === "kedge"){
+		uri = KEDGE_SCHEMA_URL;
 	}
 
 	if(schema === null){


### PR DESCRIPTION
This commit lets an end user specify something like
"yaml.schemas": {
    "kedge": "globPattern"
},
in their VS Code user settings, and it expands the keyword "kedge"
to the location of the Kedge JSON Schema, hence enabling the
auto-completion and syntax validation goodness for Kedge in the
yaml-language-server itself.

Also adds docs.