### PR TITLE
Remove unused dependency to deep-equal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -268,11 +268,6 @@
         "ms": "2.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
   "dependencies": {
-    "deep-equal": "^1.0.1",
     "js-yaml": "^3.11.0",
     "jsonc-parser": "^1.0.3",
     "request-light": "^0.2.2",


### PR DESCRIPTION
The dependency to `deep-equal` was originally added in 43ad74318733836099bc11111d4099890a7b9075 but was then removed in a66bb66b466ccee95f49100c4c351d3d457deb89 during the 0.0.2 release. It remains unused and can be removed from the package.json file.