### PR TITLE
Return promises that resolve to null

### DIFF
--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -518,7 +518,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 					return entry.getCombinedSchema(this).getResolvedSchema();
 				}
 			}
-			return null;
+			return this.promise.resolve(null);
 		};
 		if (this.customSchemaProvider) {
 			return this.customSchemaProvider(resource).then(schemaUri => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -279,4 +279,14 @@ suite('JSON Schema', () => {
 			testDone(error);
 		});
 	});
+
+	test('Null Schema', function (testDone) {
+		let service = new SchemaService.JSONSchemaService(requestServiceMock, workspaceContext);
+
+		service.getSchemaForResource('test.json').then((schema) => {
+			assert.equal(schema, null);
+		}).then(() => testDone(), (error) => {
+			testDone(error);
+		});
+	});
 });


### PR DESCRIPTION
Promise-based code is meant to be chained. Instead of returning `null` for an asynchronous function, returning a promise that resolves to `null` would be more intuitive and easier to handle for clients.