### PR TITLE
Correct capability for checking formatting dynamic registration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -92,7 +92,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 	}
 
 	hasWorkspaceFolderCapability = capabilities.workspace && !!capabilities.workspace.workspaceFolders;
-	clientDynamicRegisterSupport = hasClientCapability('workspace', 'symbol', 'dynamicRegistration');
+	clientDynamicRegisterSupport = hasClientCapability('textDocument', 'formatting', 'dynamicRegistration');
 	return {
 		capabilities: {
 			textDocumentSync: documents.syncKind,


### PR DESCRIPTION
Use textDocument.formatting.dynamicRegistration to check whether formatting
supports dynamic registration.

Fixes #74