### PR TITLE
support associate schemas with files in a regular expression

### DIFF
--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -104,7 +104,7 @@ export class FilePatternAssociation {
 	constructor(pattern: string) {
 		this.combinedSchemaId = 'schemaservice://combinedSchema/' + encodeURIComponent(pattern);
 		try {
-			this.patternRegExp = new RegExp(Strings.convertSimple2RegExpPattern(pattern) + '$');
+			this.patternRegExp = Strings.convertSimple2RegExp(pattern);
 		} catch (e) {
 			// invalid pattern
 			this.patternRegExp = null;

--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -32,6 +32,16 @@ export function endsWith(haystack: string, needle: string): boolean {
 	}
 }
 
-export function convertSimple2RegExpPattern(pattern: string): string {
-	return pattern.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&').replace(/[\*]/g, '.*');
+export function convertSimple2RegExp(pattern: string): RegExp {
+	var match = pattern.match(new RegExp('^/(.*?)/([gimy]*)$'));
+	return match ? convertRegexString2RegExp(match[1], match[2])
+		:  convertGlobalPattern2RegExp(pattern)
+}
+
+function convertGlobalPattern2RegExp(pattern: string): RegExp {
+	return new RegExp(pattern.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&').replace(/[\*]/g, '.*') + '$');
+}
+
+function convertRegexString2RegExp(pattern: string, flag: string): RegExp {
+	return new RegExp(pattern, flag);
 }

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {startsWith, endsWith, convertSimple2RegExpPattern} from '../src/languageservice/utils/strings';
+import {startsWith, endsWith, convertSimple2RegExp} from '../src/languageservice/utils/strings';
 var assert = require('assert');
 
 suite("String Tests", () => {
@@ -75,12 +75,22 @@ suite("String Tests", () => {
 
         });
         
-        describe('convertSimple2RegExpPattern', function(){
+        describe('convertSimple2RegExp', function(){
 
-			it('Test of convertSimple2RegExpPattern', () => {
+			it('Test of convertRegexString2RegExp', () => {
 
-                var result = convertSimple2RegExpPattern("/*");
-                assert.equal(result, "/.*");
+                var result = convertSimple2RegExp("/toc\\.yml/i").test("TOC.yml");
+                assert.equal(result, true);
+
+            });
+
+            it('Test of convertGlobalPattern2RegExp', () => {
+
+                var result = convertSimple2RegExp("toc.yml").test("toc.yml");
+                assert.equal(result, true);
+
+                result = convertSimple2RegExp("toc.yml").test("TOC.yml");
+                assert.equal(result, false);
 
             });
 


### PR DESCRIPTION

e.g. case-insensitive pattern

```yaml
yaml.schemas: {
    "kubernetes": "/myYamlFile\\.yaml/i"
}
```