### PR TITLE
Added the formatter from prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yaml-language-server",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3766,6 +3766,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
+      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg=="
     },
     "punycode": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "js-yaml": "^3.12.0",
     "jsonc-parser": "^1.0.3",
+    "prettier": "^1.14.3",
     "request-light": "^0.2.3",
     "vscode-json-languageservice": "3.0.12",
     "vscode-languageserver": "^4.0.0",

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -5,43 +5,13 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import * as jsyaml from 'js-yaml';
-import * as Yaml from 'yaml-ast-parser'
-import { EOL } from 'os';
 import { TextDocument, Range, Position, FormattingOptions, TextEdit } from 'vscode-languageserver-types';
+const prettier = require("prettier");
 
 export function format(document: TextDocument, options: FormattingOptions, customTags: Array<String>): TextEdit[] {
     const text = document.getText();
 
-    let schemaWithAdditionalTags = jsyaml.Schema.create(customTags.map((tag) => {
-		const typeInfo = tag.split(' ');
-		return new jsyaml.Type(typeInfo[0], { kind: typeInfo[1] || 'scalar' });
-	}));
+	const formatted = prettier.format(text, { parser: "yaml"});
 
-	//We need compiledTypeMap to be available from schemaWithAdditionalTags before we add the new custom properties
-	customTags.map((tag) => {
-		const typeInfo = tag.split(' ');
-		schemaWithAdditionalTags.compiledTypeMap[typeInfo[0]] = new jsyaml.Type(typeInfo[0], { kind: typeInfo[1] || 'scalar' });
-	});
-
-	let additionalOptions: Yaml.LoadOptions = {
-		schema: schemaWithAdditionalTags
-	}
-
-    const documents = []
-    jsyaml.loadAll(text, doc => documents.push(doc), additionalOptions)
-
-    const dumpOptions = { indent: options.tabSize, noCompatMode: true };
-
-    let newText;
-    if (documents.length == 1) {
-        const yaml = documents[0]
-        newText = jsyaml.safeDump(yaml, dumpOptions)
-    }
-    else {
-        const formatted = documents.map(d => jsyaml.safeDump(d, dumpOptions))
-        newText = '%YAML 1.2' + EOL + '---' + EOL + formatted.join('...' + EOL + '---' + EOL) + '...' + EOL
-    }
-
-    return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), newText)]
+    return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
 }

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -5,13 +5,14 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { TextDocument, Range, Position, FormattingOptions, TextEdit } from 'vscode-languageserver-types';
+import { TextDocument, Range, Position, TextEdit } from 'vscode-languageserver-types';
+import { CustomFormatterOptions } from '../yamlLanguageService';
 const prettier = require("prettier");
 
-export function format(document: TextDocument, options: FormattingOptions, customTags: Array<String>): TextEdit[] {
+export function format(document: TextDocument, options: CustomFormatterOptions): TextEdit[] {
     const text = document.getText();
 
-	const formatted = prettier.format(text, { parser: "yaml"});
+	const formatted = prettier.format(text, Object.assign(options, { parser: "yaml" }));
 
     return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
 }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -4,7 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { JSONSchemaService } from './services/jsonSchemaService'
-import { TextDocument, Position, CompletionList, FormattingOptions, Diagnostic } from 'vscode-languageserver-types';
+import { TextDocument, Position, CompletionList, Diagnostic } from 'vscode-languageserver-types';
 import { JSONSchema } from './jsonSchema';
 import { YAMLDocumentSymbols } from './services/documentSymbols';
 import { YAMLCompletion } from "./services/yamlCompletion";
@@ -90,15 +90,21 @@ export interface SchemaConfiguration {
 	schema?: JSONSchema;
 }
 
+export interface CustomFormatterOptions {
+	singleQuote?: boolean;
+	bracketSpacing?: boolean;
+	proseWrap?: string;
+}
+
 export interface LanguageService {
   configure(settings): void;
-	doComplete(document: TextDocument, position: Position, doc): Thenable<CompletionList>;
+  doComplete(document: TextDocument, position: Position, doc): Thenable<CompletionList>;
   doValidation(document: TextDocument, yamlDocument): Thenable<Diagnostic[]>;
   doHover(document: TextDocument, position: Position, doc);
   findDocumentSymbols(document: TextDocument, doc);
   doResolve(completionItem);
   resetSchema(uri: string): boolean;
-  doFormat(document: TextDocument, options: FormattingOptions, customTags: Array<String>);
+  doFormat(document: TextDocument, options: CustomFormatterOptions);
 }
 
 export function getLanguageService(schemaRequestService, workspaceContext, contributions, customSchemaProvider, promiseConstructor?): LanguageService {

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import URI from './languageservice/utils/uri';
 import * as URL from 'url';
 import Strings = require('./languageservice/utils/strings');
 import { getLineOffsets, removeDuplicatesObj } from './languageservice/utils/arrUtils';
-import { getLanguageService as getCustomLanguageService, LanguageSettings } from './languageservice/yamlLanguageService';
+import { getLanguageService as getCustomLanguageService, LanguageSettings, CustomFormatterOptions } from './languageservice/yamlLanguageService';
 import * as nls from 'vscode-nls';
 import { FilePatternAssociation } from './languageservice/services/jsonSchemaService';
 import { parse as parseYAML } from './languageservice/parser/yamlParser';
@@ -173,7 +173,9 @@ export let customLanguageService = getCustomLanguageService(schemaRequestService
 // The settings interface describes the server relevant settings part
 interface Settings {
 	yaml: {
-		format: { enable: boolean; };
+		format: CustomFormatterOptions & {
+			enable: boolean;
+		};
 		schemas: JSONSchemaSettings[];
 		validate: boolean;
 		customTags: Array<String>;
@@ -196,6 +198,11 @@ let formatterRegistration: Thenable<Disposable> = null;
 let specificValidatorPaths = [];
 let schemaConfigurationSettings = [];
 let yamlShouldValidate = true;
+let yamlFormatterSettings = {
+	singleQuote: false,
+	bracketSpacing: true,
+	proseWrap: "preserve"
+} as CustomFormatterOptions;
 let schemaStoreSettings = [];
 let customTags = [];
 
@@ -208,6 +215,11 @@ connection.onDidChangeConfiguration((change) => {
 	yamlShouldValidate = settings.yaml && settings.yaml.validate;
 	schemaConfigurationSettings = [];
 	customTags = settings.yaml && settings.yaml.customTags ? settings.yaml.customTags : [];
+	yamlFormatterSettings = settings.yaml && {
+		singleQuote: settings.yaml.format.singleQuote || false,
+		bracketSpacing: settings.yaml.format.bracketSpacing || true,
+		proseWrap: settings.yaml.format.proseWrap || "preserve"	
+	};
 
 	for(let url in yamlConfigurationSettings){
 		let globPattern = yamlConfigurationSettings[url];
@@ -443,7 +455,7 @@ connection.onDidChangeWatchedFiles((change) => {
 
 connection.onCompletion(textDocumentPosition =>  {
 	let textDocument = documents.get(textDocumentPosition.textDocument.uri);
-	
+
 	let result: CompletionList = {
 		items: [],
 		isIncomplete: false
@@ -452,7 +464,7 @@ connection.onCompletion(textDocumentPosition =>  {
 	if(!textDocument){
 		return Promise.resolve(result);
 	}
-	
+
 	let completionFix = completionHelper(textDocument, textDocumentPosition.position);
 	let newText = completionFix.newText;
 	let jsonDocument = parseYAML(newText);
@@ -525,7 +537,7 @@ connection.onCompletionResolve(completionItem => {
 
 connection.onHover(textDocumentPositionParams => {
 	let document = documents.get(textDocumentPositionParams.textDocument.uri);
-	
+
 	if(!document){
 		return Promise.resolve(void 0);
 	}
@@ -553,7 +565,7 @@ connection.onDocumentFormatting(formatParams => {
 		return;
 	}
 
-	return customLanguageService.doFormat(document, formatParams.options, customTags);
+	return customLanguageService.doFormat(document, yamlFormatterSettings);
 });
 
 connection.listen();

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -50,10 +50,7 @@ suite("Formatter Tests", () => {
             it('Formatting works without custom tags', () => {
                 let content = `cwd: test`;
                 let testTextDocument = setup(content);
-                let edits = languageService.doFormat(testTextDocument, {
-                    insertSpaces: true,
-                    tabSize: 4
-                }, languageSettings.customTags);
+                let edits = languageService.doFormat(testTextDocument, {});
                 assert.notEqual(edits.length, 0);
                 assert.equal(edits[0].newText, "cwd: test\n");
             });
@@ -61,10 +58,7 @@ suite("Formatter Tests", () => {
             it('Formatting works without custom tags', () => {
                 let content = `cwd:       !Test test`;
                 let testTextDocument = setup(content);
-                let edits = languageService.doFormat(testTextDocument, {
-                    insertSpaces: true,
-                    tabSize: 4
-                }, languageSettings.customTags);
+                let edits = languageService.doFormat(testTextDocument, {});
                 assert.notEqual(edits.length, 0);
             });
 


### PR DESCRIPTION
This PR introduces the YAML formatter from [prettier](https://prettier.io). The prettier yaml formatter makes use of a different parser that allows comments in YAML and is pretty heavily maintained.