### PR TITLE
Added registration for custom schema provider

### DIFF
--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -243,20 +243,24 @@ export class JSONSchemaService implements IJSONSchemaService {
 	private callOnDispose: Function[];
 	private requestService: SchemaRequestService;
 	private promiseConstructor: PromiseConstructor;
-	private customSchemaProvider: CustomSchemaProvider;
+	private customSchemaProvider: CustomSchemaProvider | undefined;
 
-	constructor(requestService: SchemaRequestService, contextService?: WorkspaceContextService, customSchemaProvider?: CustomSchemaProvider, promiseConstructor?: PromiseConstructor) {
+	constructor(requestService: SchemaRequestService, contextService?: WorkspaceContextService, promiseConstructor?: PromiseConstructor) {
 		this.contextService = contextService;
 		this.requestService = requestService;
 		this.promiseConstructor = promiseConstructor || Promise;
 		this.callOnDispose = [];
-		this.customSchemaProvider = customSchemaProvider;
+		this.customSchemaProvider = undefined;
 		this.contributionSchemas = {};
 		this.contributionAssociations = {};
 		this.schemasById = {};
 		this.filePatternAssociations = [];
 		this.filePatternAssociationById = {};
 		this.registeredSchemasIds = {};
+	}
+
+	registerCustomSchemaProvider(customSchemaProvider: CustomSchemaProvider) {
+		this.customSchemaProvider = customSchemaProvider;
 	}
 
 	public getRegisteredSchemaIds(filter?: (scheme) => boolean): string[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ import Strings = require('./languageservice/utils/strings');
 import { getLineOffsets, removeDuplicatesObj } from './languageservice/utils/arrUtils';
 import { getLanguageService as getCustomLanguageService, LanguageSettings } from './languageservice/yamlLanguageService';
 import * as nls from 'vscode-nls';
-import { FilePatternAssociation } from './languageservice/services/jsonSchemaService';
+import { FilePatternAssociation, CustomSchemaProvider } from './languageservice/services/jsonSchemaService';
 import { parse as parseYAML } from './languageservice/parser/yamlParser';
 import { JSONDocument } from './languageservice/parser/jsonParser';
 import { JSONSchema } from './languageservice/jsonSchema';
@@ -34,6 +34,10 @@ interface ISchemaAssociations {
 
 namespace SchemaAssociationNotification {
 	export const type: NotificationType<{}, {}> = new NotificationType('json/schemaAssociations');
+}
+
+namespace DynamicCustomSchemaRequestRegistration {
+	export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
 namespace VSCodeContentRequest {
@@ -167,8 +171,7 @@ let schemaRequestService = (uri: string): Thenable<string> => {
 
 export let KUBERNETES_SCHEMA_URL = "https://gist.githubusercontent.com/JPinkney/ccaf3909ef811e5657ca2e2e1fa05d76/raw/f85e51bfb67fdb99ab7653c2953b60087cc871ea/openshift_schema_all.json";
 export let KEDGE_SCHEMA_URL = "https://raw.githubusercontent.com/kedgeproject/json-schema/master/master/kedge-json-schema.json";
-export let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, [],
-	(resource) => connection.sendRequest(CustomSchemaRequest.type, resource));
+export let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, []);
 
 // The settings interface describes the server relevant settings part
 interface Settings {
@@ -285,6 +288,11 @@ connection.onNotification(SchemaAssociationNotification.type, associations => {
 	specificValidatorPaths = [];
 	setSchemaStoreSettingsIfNotSet();
 	updateConfiguration();
+});
+
+connection.onNotification(DynamicCustomSchemaRequestRegistration.type, () => {
+	const schemaProvider = ((resource) => connection.sendRequest(CustomSchemaRequest.type, resource)) as CustomSchemaProvider;
+	customLanguageService.registerCustomSchemaProvider(schemaProvider);
 });
 
 function updateConfiguration() {


### PR DESCRIPTION
This PR makes the custom schema provider feature needed to be registered in order to use. This occurs because some clients supporting LSP do not handle the case when a server sends a CustomSchemaRequest to the client and thus shows an error/does not allow them to use it.

See: https://github.com/redhat-developer/yaml-language-server/issues/56 and https://github.com/redhat-developer/yaml-language-server/issues/83

@andxu Can you review because it effects previous your work

VSCode-YAML side is here: https://github.com/redhat-developer/vscode-yaml/pull/121
