### PR TITLE
Add `bin` stanza to create symlink for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,16 @@
     {
       "name": "Joshua Pinkney",
       "email": "joshpinkney@gmail.com"
+    },
+    {
+      "name": "Google LLC"
     }
   ],
   "engines": {
     "node": "*"
+  },
+  "bin": {
+    "yaml-language-server": "./out/server/src/server.js"
   },
   "keywords": [
     "yaml",


### PR DESCRIPTION
This adds a `bin` stanza to package.json, allowing npm to create a script
running the `yaml-language-server` on install.  While not necessary, this
avoids the need for users to manually invoke the server by hand.