### PR TITLE
fix: syntax error should start from col 0 and end at mark position

### DIFF
--- a/src/languageservice/parser/yamlParser.ts
+++ b/src/languageservice/parser/yamlParser.ts
@@ -200,7 +200,7 @@ function recursivelyBuildAst(parent: ASTNode, node: Yaml.YAMLNode): ASTNode {
 }
 
 function convertError(e: Yaml.YAMLException) {
-	return { message: `${e.reason}`, location: { start: e.mark.position, end: e.mark.position + e.mark.column, code: ErrorCode.Undefined } }
+	return { message: `${e.reason}`, location: { start: e.mark.position - e.mark.column, end: e.mark.position, code: ErrorCode.Undefined } }
 }
 
 function createJSONDocument(yamlDoc: Yaml.YAMLNode, startPositions: number[], text: string) {


### PR DESCRIPTION
YAML syntax error position was not correctly reported like this:
<img width="296" alt="20181213152021" src="https://user-images.githubusercontent.com/584378/49922140-b2c72c80-feea-11e8-984f-8ae9fb44e129.png">

Since we can only get error's starting position from parsing from yaml-ast-parser, I guess the solution here is to mark the error from line start and end at the parsing position.

After the fix:

<img width="308" alt="20181213152610" src="https://user-images.githubusercontent.com/584378/49922386-7fd16880-feeb-11e8-8a6b-4f8331924929.png">
