### PR TITLE
Validate settings.yaml.format before setting

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -224,13 +224,15 @@ connection.onDidChangeConfiguration((change) => {
 		yamlShouldHover = settings.yaml.hover;
 		yamlShouldCompletion = settings.yaml.completion;
 		customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
-		yamlFormatterSettings = {
-			singleQuote: settings.yaml.format.singleQuote || false,
-			proseWrap: settings.yaml.format.proseWrap || "preserve"
-		};
-		if (settings.yaml.format.bracketSpacing === false) {
-			yamlFormatterSettings.bracketSpacing = false;
-		}
+		if (settings.yaml.format) {
+			yamlFormatterSettings = {
+				singleQuote: settings.yaml.format.singleQuote || false,
+				proseWrap: settings.yaml.format.proseWrap || "preserve"
+			};
+			if (settings.yaml.format.bracketSpacing === false) {
+				yamlFormatterSettings.bracketSpacing = false;
+			}
+		}		
 	}
 	schemaConfigurationSettings = [];
 


### PR DESCRIPTION
This PR fixes https://github.com/redhat-developer/yaml-language-server/issues/111 by checking to see if the settings.yaml.format was defined before trying to set settings.yaml.format.singleQuote etc. 