### PR TITLE
Only set CompletionItem.textEdit if it encompasses a single line

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -107,7 +107,7 @@ export class YAMLCompletion {
 				let existing = proposed[suggestion.label];
 				if (!existing) {
 					proposed[suggestion.label] = suggestion;
-					if (overwriteRange) {
+					if (overwriteRange && overwriteRange.isSingleLine) {
 						suggestion.textEdit = TextEdit.replace(overwriteRange, suggestion.insertText);
 					}
 					result.items.push(suggestion);

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -107,7 +107,7 @@ export class YAMLCompletion {
 				let existing = proposed[suggestion.label];
 				if (!existing) {
 					proposed[suggestion.label] = suggestion;
-					if (overwriteRange && overwriteRange.isSingleLine) {
+					if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
 						suggestion.textEdit = TextEdit.replace(overwriteRange, suggestion.insertText);
 					}
 					result.items.push(suggestion);

--- a/test/autoCompletion3.test.ts
+++ b/test/autoCompletion3.test.ts
@@ -65,6 +65,16 @@ suite("Auto Completion Tests", () => {
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
+
+			it('Array of enum autocomplete with multiline text', (done) => {
+				let content = "optionalUnityReferences:\n  - T\n    e\n";
+				let completion = parseSetup(content, 31);
+				completion.then(function(result){
+					assert.notEqual(result.items.length, 0);
+					// textEdit must be single line
+					assert.equal(result.items[0].textEdit, undefined)
+				}).then(done, done);
+			});
 		});
 	});
 });


### PR DESCRIPTION
This is a limitation imposed by the language server protocol. Doing otherwise will make some language protocol clients, such as VS Code, reject the completions. VS Code prints the following in the developer tools console for if you try and give it a multi-line `CompletionItem.textEdit`: `INVALID text edit -> must be single line and on the same line`, and it ignores all such completions, leading to it offering the default word completions instead.

See [LSP Spec - textDocument/completion](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion):
```ts
	/**
	 * An edit which is applied to a document when selecting this completion. When an edit is provided the value of
	 * `insertText` is ignored.
	 *
	 * *Note:* The range of the edit must be a single line range and it must contain the position at which completion
	 * has been requested.
	 */
	textEdit?: TextEdit;
```

Fixes redhat-developer/vscode-yaml#139

cc @fbricon 