### PR TITLE
Added printWidth setting

### DIFF
--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -93,9 +93,10 @@ export interface SchemaConfiguration {
 }
 
 export interface CustomFormatterOptions {
-	singleQuote?: boolean;
-	bracketSpacing?: boolean;
-	proseWrap?: string;
+  singleQuote?: boolean;
+  bracketSpacing?: boolean;
+  proseWrap?: string;
+  printWidth?: number;
 }
 
 export interface LanguageService {

--- a/src/server.ts
+++ b/src/server.ts
@@ -167,9 +167,7 @@ export let customLanguageService = getCustomLanguageService(schemaRequestService
 // The settings interface describes the server relevant settings part
 interface Settings {
 	yaml: {
-		format: CustomFormatterOptions & {
-			enable: boolean;
-		};
+		format: CustomFormatterOptions;
 		schemas: JSONSchemaSettings[];
 		validate: boolean;
 		hover: boolean;
@@ -200,7 +198,8 @@ let yamlShouldValidate = true;
 let yamlFormatterSettings = {
 	singleQuote: false,
 	bracketSpacing: true,
-	proseWrap: "preserve"
+	proseWrap: "preserve",
+	printWidth: 80
 } as CustomFormatterOptions;
 let yamlShouldHover = true;
 let yamlShouldCompletion = true;
@@ -225,7 +224,8 @@ connection.onDidChangeConfiguration((change) => {
 		if (settings.yaml.format) {
 			yamlFormatterSettings = {
 				singleQuote: settings.yaml.format.singleQuote || false,
-				proseWrap: settings.yaml.format.proseWrap || "preserve"
+				proseWrap: settings.yaml.format.proseWrap || "preserve",
+				printWidth: settings.yaml.format.printWidth || 80
 			};
 			if (settings.yaml.format.bracketSpacing === false) {
 				yamlFormatterSettings.bracketSpacing = false;

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -62,6 +62,16 @@ suite("Formatter Tests", () => {
                 assert.notEqual(edits.length, 0);
             });
 
+            it('Formatting wraps text', () => {
+                let content = `comments: >
+                test test test test test test test test test test test test`;
+                let testTextDocument = setup(content);
+                let edits = languageService.doFormat(testTextDocument, {
+                    printWidth: 20,
+                    proseWrap: "always"
+                });
+                assert.equal(edits[0].newText, "comments: >\n  test test test\n  test test test\n  test test test\n  test test test\n");
+            });
         });
 
     });


### PR DESCRIPTION
Adds printWidth setting so that users can specify what happens on format when their text goes over a certain length.

Fixes: https://github.com/redhat-developer/yaml-language-server/issues/117 and https://github.com/redhat-developer/vscode-yaml/issues/88 