### PR TITLE
Make `yaml-launguage-server` command executable format

### DIFF
--- a/bin/yaml-language-server
+++ b/bin/yaml-language-server
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../out/server/src/server.js');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": "*"
   },
   "bin": {
-    "yaml-language-server": "./out/server/src/server.js"
+    "yaml-language-server": "./bin/yaml-language-server"
   },
   "keywords": [
     "yaml",


### PR DESCRIPTION
Related in https://github.com/redhat-developer/yaml-language-server/pull/98

Make `yaml-launguage-server` command executable format.
(I referred to the [tsserver](https://github.com/Microsoft/TypeScript/blob/f776bead4f1c28f375bf2f7676a277a47745bb48/bin/tsserver) command)

With this, we can execute as follows.

```
$ npm i -g yaml-language-server
$ yaml-language-server --stdio
```