### PR TITLE
Revert "Added trigger characters"

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 	return {
 		capabilities: {
 			textDocumentSync: documents.syncKind,
-			completionProvider: { triggerCharacters: [' '], resolveProvider: true },
+			completionProvider: { resolveProvider: true },
 			hoverProvider: true,
 			documentSymbolProvider: true,
 			documentFormattingProvider: true


### PR DESCRIPTION
Unfortunately adding the trigger characters made it so that in a few cases the autocompletion was recommending completion items that would end up causing errors. In order to maintain user experience, I am reverting this PR.

View: https://github.com/redhat-developer/yaml-language-server/issues/129 for more info.

Reverts redhat-developer/yaml-language-server#127