### PR TITLE
Make prettier an optional dependency since it doesn't work with webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1570,7 +1570,8 @@
     "prettier": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz",
-      "integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg=="
+      "integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==",
+      "optional": true
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
   "dependencies": {
-    "prettier": "^1.17.1",
     "request-light": "^0.2.4",
     "vscode-json-languageservice": "3.2.0",
     "vscode-languageserver": "^5.2.1",
@@ -37,6 +36,9 @@
     "vscode-uri": "^2.0.2",
     "yaml-ast-parser-custom-tags": "0.0.43",
     "js-yaml": "^3.13.1"
+  },
+  "optionalDependencies": {
+    "prettier": "^1.17.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.48",

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -7,7 +7,6 @@
 
 import { TextDocument, Range, Position, TextEdit } from 'vscode-languageserver-types';
 import { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
-import * as prettier from 'prettier';
 
 export class YAMLFormatter {
 
@@ -25,11 +24,16 @@ export class YAMLFormatter {
             return [];
         }
 
-        const text = document.getText();
+        try {
+            const prettier = require('prettier');
+            const text = document.getText();
 
-        const formatted = prettier.format(text, Object.assign(options, { parser: 'yaml' as prettier.BuiltInParserName }));
+            const formatted = prettier.format(text, Object.assign(options, { parser: 'yaml' }));
 
-        return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
+            return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
+        } catch (error) {
+            return [];
+        }
     }
 
 }


### PR DESCRIPTION
This PR makes prettier an optional dependency because prettier does not play well with webpack.