### PR TITLE
Use document selector schemes in formatter registration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -440,7 +440,12 @@ connection.onDidChangeConfiguration(change => {
 
         if (enableFormatter) {
             if (!formatterRegistration) {
-                formatterRegistration = connection.client.register(DocumentRangeFormattingRequest.type, { documentSelector: [{ language: 'yaml' }] });
+                formatterRegistration = connection.client.register(DocumentRangeFormattingRequest.type, {
+                    documentSelector: [
+                        { language: 'yaml', scheme: 'file' },
+                        { language: 'yaml', scheme: 'untitled' }
+                    ]
+                });
             }
         } else if (formatterRegistration) {
             formatterRegistration.then(r => r.dispose());


### PR DESCRIPTION
Running `yaml-language-server` with the `vscode-yaml` extension keeps giving warnings in the editor, such as this one:
```
Extension 'redhat.vscode-yaml' uses a document selector without scheme. Learn more about this: https://go.microsoft.com/fwlink/?linkid=872305
```
Adding in the 'file' and 'untitled' schemes should keep it working with all files but now without the warnings.