### PR TITLE
Fix for validation with multiple enums 

### DIFF
--- a/src/languageservice/parser/jsonParser04.ts
+++ b/src/languageservice/parser/jsonParser04.ts
@@ -926,7 +926,7 @@ export class ValidationResult {
         if (propertyValidationResult.enumValueMatch || !this.hasProblems() && propertyValidationResult.propertiesMatches) {
             this.propertiesValueMatches++;
         }
-        if (propertyValidationResult.enumValueMatch && propertyValidationResult.enumValues && propertyValidationResult.enumValues.length === 1) {
+        if (propertyValidationResult.enumValueMatch && propertyValidationResult.enumValues) {
             this.primaryValueMatches++;
         }
     }
@@ -950,7 +950,7 @@ export class ValidationResult {
 
     public compareKubernetes(other: ValidationResult): number {
         const hasProblems = this.hasProblems();
-        if (this.propertiesMatches !== other.propertiesMatches){
+        if (this.propertiesMatches !== other.propertiesMatches) {
             return this.propertiesMatches - other.propertiesMatches;
         }
         if (this.enumValueMatch !== other.enumValueMatch) {

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -251,7 +251,7 @@ export class ValidationResult {
         if (propertyValidationResult.enumValueMatch || !propertyValidationResult.hasProblems() && propertyValidationResult.propertiesMatches) {
             this.propertiesValueMatches++;
         }
-        if (propertyValidationResult.enumValueMatch && propertyValidationResult.enumValues && propertyValidationResult.enumValues.length === 1) {
+        if (propertyValidationResult.enumValueMatch && propertyValidationResult.enumValues) {
             this.primaryValueMatches++;
         }
     }


### PR DESCRIPTION
This PR solves two issues:
1. Autocomplete will now work on a value when there are multiple enums available.

Previously it wouldn't show anything when we have something like this as a subschema:
```
{
  "type": "object",
  "properties": {
       "kind": {
            "type": "string",
            "enum": [
                 "Test1",
                 "Test2"
            ]
        }
   }
}
```
and tried to autocomplete on kind.

2. It will show the correct validation when a key has an associated null value.

Previously when you had:
```
kind: 
```
and looked at the problems you would get an error saying something like
``` 
Value is not accepted. Valid values: "MutatingWebhookConfiguration" 
```

With this change you will now get 
```
Value is not accepted. Valid values: "MutatingWebhookConfiguration", "MutatingWebhookConfigurationList", "ValidatingWebhookConfiguration", "ValidatingWebhookConfigurationList", "ControllerRevision", "ControllerRevisionList", "DaemonSet", "DaemonSetList", "Deployment", "DeploymentList", "ReplicaSet", "ReplicaSetList", "StatefulSet", "StatefulSetList", "DeploymentRollback", "Scale", "AuditSink", "AuditSinkList", "TokenReview", "LocalSubjectAccessReview", "SelfSubjectAccessReview", "SelfSubjectRulesReview", "SubjectAccessReview", "HorizontalPodAutoscaler", "HorizontalPodAutoscalerList", "Job", "JobList", "CronJob", "CronJobList", "CertificateSigningRequest", "CertificateSigningRequestList", "Lease", "LeaseList", "Binding", "ComponentStatus", "ComponentStatusList", "ConfigMap", "ConfigMapList", "Endpoints", "EndpointsList", "Event", "EventList", "LimitRange", "LimitRangeList", "Namespace", "NamespaceList", "Node", "NodeList", "PersistentVolume", "PersistentVolumeClaim", "PersistentVolumeClaimList", "PersistentVolumeList", "Pod", "PodList", "PodTemplate", "PodTemplateList", "ReplicationController", "ReplicationControllerList", "ResourceQuota", "ResourceQuotaList", "Secret", "SecretList", "Service", "ServiceAccount", "ServiceAccountList", "ServiceList", "Ingress", "IngressList", "NetworkPolicy", "NetworkPolicyList", "PodSecurityPolicy", "PodSecurityPolicyList", "RuntimeClass", "RuntimeClassList", "Eviction", "PodDisruptionBudget", "PodDisruptionBudgetList", "ClusterRole", "ClusterRoleBinding", "ClusterRoleBindingList", "ClusterRoleList", "Role", "RoleBinding", "RoleBindingList", "RoleList", "PriorityClass", "PriorityClassList", "PodPreset", "PodPresetList", "StorageClass", "StorageClassList", "VolumeAttachment", "VolumeAttachmentList", "CSIDriver", "CSIDriverList", "CSINode", "CSINodeList", "CustomResourceDefinition", "CustomResourceDefinitionList", "APIGroup", "APIGroupList", "APIResourceList", "APIVersions", "DeleteOptions", "Status", "APIService", "APIServiceList".
```

