### PR TITLE
WIP - Fixing issue with registerContributor API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yaml-language-server",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -8,14 +8,15 @@
 import { parse as parseYAML } from '../parser/yamlParser07';
 
 import { SymbolInformation, TextDocument, DocumentSymbol } from 'vscode-languageserver-types';
-import { LanguageService } from 'vscode-json-languageservice';
+import { JSONSchemaService } from './jsonSchemaService';
+import { JSONDocumentSymbols } from 'vscode-json-languageservice/lib/umd/services/jsonDocumentSymbols';
 
 export class YAMLDocumentSymbols {
 
-    private jsonLanguageService: LanguageService;
+    private jsonDocumentSymbols;
 
-    constructor(jsonLanguageService: LanguageService) {
-        this.jsonLanguageService = jsonLanguageService;
+    constructor(schemaService: JSONSchemaService) {
+        this.jsonDocumentSymbols = new JSONDocumentSymbols(schemaService);
     }
 
     public findDocumentSymbols(document: TextDocument): SymbolInformation[] {
@@ -28,7 +29,7 @@ export class YAMLDocumentSymbols {
         let results = [];
         for (const yamlDoc of doc['documents']) {
             if (yamlDoc.root) {
-                results = results.concat(this.jsonLanguageService.findDocumentSymbols(document, yamlDoc));
+                results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols(document, yamlDoc));
             }
         }
 
@@ -44,7 +45,7 @@ export class YAMLDocumentSymbols {
         let results = [];
         for (const yamlDoc of doc['documents']) {
             if (yamlDoc.root) {
-                results = results.concat(this.jsonLanguageService.findDocumentSymbols2(document, yamlDoc));
+                results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols2(document, yamlDoc));
             }
         }
 

--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -545,8 +545,8 @@ export class JSONSchemaService implements IJSONSchemaService {
                                return resolveSchema();
                            }
 
-                           this.loadSchema(schemaUri)
-                               .then(unsolvedSchema => this.resolveSchemaContent(unsolvedSchema, schemaUri))
+                           return this.loadSchema(schemaUri)
+                               .then(unsolvedSchema => this.resolveSchemaContent(unsolvedSchema, schemaUri));
                         })
                        .then(schema => schema, err => resolveSchema());
         } else {

--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -528,7 +528,7 @@ export class JSONSchemaService implements IJSONSchemaService {
         return resolveRefs(schema, schema, schemaURL).then(_ => new ResolvedSchema(schema, resolveErrors));
     }
 
-    public getSchemaForResource(resource: string, doc): Thenable<ResolvedSchema> {
+    public getSchemaForResource(resource: string, doc = undefined): Thenable<ResolvedSchema> {
         const resolveSchema = () => {
             // check for matching file names, last to first
             for (let i = this.filePatternAssociations.length - 1; i >= 0; i--) {

--- a/src/languageservice/services/jsonSchemaService.ts
+++ b/src/languageservice/services/jsonSchemaService.ts
@@ -56,7 +56,8 @@ export interface IJSONSchemaService {
     /**
      * Looks up the appropriate schema for the given URI
      */
-    getSchemaForResource(resource: string): Thenable<ResolvedSchema>;
+    // tslint:disable-next-line: no-any
+    getSchemaForResource(resource: string, document?: any): Thenable<ResolvedSchema>;
 
     /**
      * Returns all registered schema ids
@@ -527,7 +528,7 @@ export class JSONSchemaService implements IJSONSchemaService {
         return resolveRefs(schema, schema, schemaURL).then(_ => new ResolvedSchema(schema, resolveErrors));
     }
 
-    public getSchemaForResource(resource: string ): Thenable<ResolvedSchema> {
+    public getSchemaForResource(resource: string, doc): Thenable<ResolvedSchema> {
         const resolveSchema = () => {
             // check for matching file names, last to first
             for (let i = this.filePatternAssociations.length - 1; i >= 0; i--) {

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -45,14 +45,16 @@ export class YAMLHover {
 
         if (this.customSchemaProvider) {
             return this.customSchemaProvider(document.uri).then(schemaURI => {
-                this.jsonLanguageService.configure({
-                    schemas: [
-                        {
-                            fileMatch: ['*.yaml', '*.yml'],
-                            uri: schemaURI
-                        }
-                    ]
-                });
+                if (schemaURI) {
+                    this.jsonLanguageService.configure({
+                        schemas: [
+                            {
+                                fileMatch: ['*.yaml', '*.yml'],
+                                uri: schemaURI
+                            }
+                        ]
+                    });
+                }
                 return this.jsonLanguageService.doHover(document, position, currentDoc);
             });
         }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -47,15 +47,17 @@ export class YAMLValidation {
 
             if (this.customSchemaProvider) {
                 const uri = await this.customSchemaProvider(textDocument.uri);
-                this.jsonLanguageService.configure({
-                    validate: true,
-                    schemas: [
-                        {
-                            fileMatch: ['*.yaml', '*.yml'],
-                            uri: uri
-                        }
-                    ]
-                });
+                if (uri) {
+                    this.jsonLanguageService.configure({
+                        validate: true,
+                        schemas: [
+                            {
+                                fileMatch: ['*.yaml', '*.yml'],
+                                uri: uri
+                            }
+                        ]
+                    });
+                }
             }
             const validation = await this.jsonLanguageService.doValidation(textDocument, currentYAMLDoc);
             const syd = currentYAMLDoc as unknown as SingleYAMLDocument;

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -154,6 +154,8 @@ export function getLanguageService(schemaRequestService: SchemaRequestService,
       },
       registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => {
         schemaService.registerCustomSchemaProvider(schemaProvider);
+        hover.customSchemaProvider = schemaProvider;
+        yamlValidation.customSchemaProvider = schemaProvider;
       },
       doComplete: completer.doComplete.bind(completer),
       doResolve: completer.doResolve.bind(completer),


### PR DESCRIPTION
This is a WIP PR that seeks to fix the issues with the registerContributor API. As far as I can see the only way we can trigger https://github.com/redhat-developer/yaml-language-server/blob/master/src/languageservice/services/schemaRequestHandler.ts#L68 from inside of the json language service is to call jsonLanguageService.configure() before we actually handle the hover and validation requests.

Hover and validation are the only requests that would need this as auto completion still uses code inside of the project, rather than delegating to the json language service, and document symbols does not need a schema.