### PR TITLE
Catch errors that come from trying to resolve schema store schemas

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -136,7 +136,7 @@ function setSchemaStoreSettingsIfNotSet() {
         getSchemaStoreMatchingSchemas().then(schemaStore => {
             schemaStoreSettings = schemaStore.schemas;
             updateConfiguration();
-        });
+        }).catch((error: XHRResponse) => { });
     } else if (!schemaStoreEnabled) {
         schemaStoreSettings = [];
         updateConfiguration();
@@ -171,8 +171,6 @@ function getSchemaStoreMatchingSchemas() {
 
         return languageSettings;
 
-    }, (error: XHRResponse) => {
-        throw error;
     });
 }
 


### PR DESCRIPTION
This PR catches the case when a user sets a proxy and the schema store schemas cannot be resolved. Previously it was throwing an error that was uncaught.

Related issues:
https://github.com/redhat-developer/yaml-language-server/issues/182
https://github.com/redhat-developer/vscode-yaml/issues/127