### PR TITLE
Correct capability to check rangeFormatting dynamic registration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -349,7 +349,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
     }
     workspaceFolders = params.workspaceFolders;
     hierarchicalDocumentSymbolSupport = !!capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport;
-    clientDynamicRegisterSupport = !!capabilities.workspace.symbol.dynamicRegistration;
+    clientDynamicRegisterSupport = !!(capabilities.textDocument.rangeFormatting && capabilities.textDocument.rangeFormatting.dynamicRegistration);
 
     return {
         capabilities: {


### PR DESCRIPTION
Use textDocument.rangeFormatting.dynamicRegistration instead of
workspace.symbol.dynamicRegistration.

Similar issue for VSCode JSON Language Server.
https://github.com/microsoft/vscode/issues/81592