### PR TITLE
Add support for loading YAML schema files

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -9,6 +9,11 @@ import { JSONSchema } from '../jsonSchema07';
 import { SchemaRequestService, WorkspaceContextService, PromiseConstructor, Thenable } from '../yamlLanguageService';
 import { UnresolvedSchema, ResolvedSchema, JSONSchemaService,
     SchemaDependencies, FilePatternAssociation, ISchemaContributions } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
+import * as yaml from 'js-yaml';
+
+import { URI }  from 'vscode-uri';
+import * as nls from 'vscode-nls';
+const localize = nls.loadMessageBundle();
 
 export declare type CustomSchemaProvider = (uri: string) => Thenable<string>;
 
@@ -16,10 +21,12 @@ export class YAMLSchemaService extends JSONSchemaService {
 
     private customSchemaProvider: CustomSchemaProvider | undefined;
     private filePatternAssociations: FilePatternAssociation[];
+    private requestService: SchemaRequestService
 
     constructor(requestService: SchemaRequestService, contextService?: WorkspaceContextService, promiseConstructor?: PromiseConstructor) {
         super(requestService, contextService, promiseConstructor);
         this.customSchemaProvider = undefined;
+        this.requestService = requestService;
     }
 
     registerCustomSchemaProvider(customSchemaProvider: CustomSchemaProvider) {
@@ -64,6 +71,42 @@ export class YAMLSchemaService extends JSONSchemaService {
         }
     }
 
+    loadSchema(schemaUri: string): Thenable<UnresolvedSchema> {
+        const requestService = this.requestService;
+        return super.loadSchema(schemaUri).then((unresolvedJsonSchema: UnresolvedSchema) => {
+            // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
+            if (unresolvedJsonSchema.errors && unresolvedJsonSchema.schema === undefined) {
+                return requestService(schemaUri).then(
+                    content => {
+                        if (!content) {
+                            let errorMessage = localize('json.schema.nocontent', 'Unable to load schema from \'{0}\': No content.', toDisplayString(schemaUri));
+                            return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
+                        }
+
+                        try {
+                            const schemaContent: JSONSchema = yaml.safeLoad(content);
+                            return new UnresolvedSchema(schemaContent, []);
+                        } catch (yamlError) {
+                            let errorMessage = localize('json.schema.invalidFormat', "Unable to parse content from '{0}': {1}.", toDisplayString(schemaUri), yamlError)
+                            return new UnresolvedSchema(<JSONSchema>{}, [errorMessage])
+                        }
+                    },
+                    (error: any) => {
+                        let errorMessage = error.toString();
+                        let errorSplit = error.toString().split('Error: ');
+                        if (errorSplit.length > 1) {
+                            // more concise error message, URL and context are attached by caller anyways
+                            errorMessage = errorSplit[1];
+                        }
+                        return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
+                    }
+                )
+            }
+
+            return unresolvedJsonSchema
+        });
+    }
+
     /**
      * Everything below here is needed because we're importing from vscode-json-languageservice umd and we need
      * to provide a wrapper around the javascript methods we are calling since they have no type
@@ -71,11 +114,6 @@ export class YAMLSchemaService extends JSONSchemaService {
 
     resolveSchemaContent(schemaToResolve: UnresolvedSchema, schemaURL: string, dependencies: SchemaDependencies): Thenable<ResolvedSchema> {
         return super.resolveSchemaContent(schemaToResolve, schemaURL, dependencies);
-    }
-
-    // tslint:disable-next-line: no-any
-    loadSchema(schemaUri: string): Thenable<any> {
-        return super.loadSchema(schemaUri);
     }
 
     registerExternalSchema(uri: string, filePatterns?: string[], unresolvedSchema?: JSONSchema) {
@@ -101,4 +139,16 @@ export class YAMLSchemaService extends JSONSchemaService {
     onResourceChange(uri: string): boolean {
         return super.onResourceChange(uri);
     }
+}
+
+function toDisplayString(url: string) {
+	try {
+		let uri = URI.parse(url);
+		if (uri.scheme === 'file') {
+			return uri.fsPath;
+		}
+	} catch (e) {
+		// ignore
+	}
+	return url;
 }


### PR DESCRIPTION
This is the re-write of #189 to better make use of the changes introduced whereby JSON schema are loaded as part of the `vscode-json-languageservice` package rather than duplicate that functionality here.

A tradeoff has been made in that the YAML file will be queried twice before data is read however, as the logic relies on the full JSON parsing function to complete before then attempting the same flow but parsing as YAML instead.