### PR TITLE
Handle less-specified initialization

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -349,11 +349,16 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
     }
     workspaceFolders = params.workspaceFolders || [];
 
-    if (capabilities.textDocument) {
-      const { documentSymbol, rangeFormatting } = capabilities.textDocument;
-      hierarchicalDocumentSymbolSupport = !!(documentSymbol && documentSymbol.hierarchicalDocumentSymbolSupport);
-      clientDynamicRegisterSupport = !!(rangeFormatting && rangeFormatting.dynamicRegistration);
-    }
+    hierarchicalDocumentSymbolSupport = !!(
+      capabilities.textDocument &&
+      capabilities.textDocument.documentSymbol &&
+      capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport
+    );
+    clientDynamicRegisterSupport = !!(
+      capabilities.textDocument &&
+      capabilities.textDocument.rangeFormatting &&
+      capabilities.textDocument.rangeFormatting.dynamicRegistration
+    );
 
     return {
         capabilities: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -347,9 +347,12 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
     if (params.rootUri) {
         workspaceRoot = URI.parse(params.rootUri);
     }
-    workspaceFolders = params.workspaceFolders;
-    hierarchicalDocumentSymbolSupport = !!capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport;
-    clientDynamicRegisterSupport = !!(capabilities.textDocument.rangeFormatting && capabilities.textDocument.rangeFormatting.dynamicRegistration);
+    workspaceFolders = params.workspaceFolders || [];
+
+    const { documentSymbol, rangeFormatting } = capabilities.textDocument || {};
+
+    hierarchicalDocumentSymbolSupport = !!(documentSymbol && documentSymbol.hierarchicalDocumentSymbolSupport);
+    clientDynamicRegisterSupport = !!(rangeFormatting && rangeFormatting.dynamicRegistration);
 
     return {
         capabilities: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -349,10 +349,11 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
     }
     workspaceFolders = params.workspaceFolders || [];
 
-    const { documentSymbol, rangeFormatting } = capabilities.textDocument || {};
-
-    hierarchicalDocumentSymbolSupport = !!(documentSymbol && documentSymbol.hierarchicalDocumentSymbolSupport);
-    clientDynamicRegisterSupport = !!(rangeFormatting && rangeFormatting.dynamicRegistration);
+    if (capabilities.textDocument) {
+      const { documentSymbol, rangeFormatting } = capabilities.textDocument;
+      hierarchicalDocumentSymbolSupport = !!(documentSymbol && documentSymbol.hierarchicalDocumentSymbolSupport);
+      clientDynamicRegisterSupport = !!(rangeFormatting && rangeFormatting.dynamicRegistration);
+    }
 
     return {
         capabilities: {


### PR DESCRIPTION
For #192.

Clients need not specify textDocument or workspace capabilities when initializing ([spec](https://github.com/microsoft/language-server-protocol/blame/gh-pages/_specifications/specification-3-14.md#L1554)).

This PR handles these potentially absent values with ~~an existence check and a touch of destructuring and default values~~ really long existence check chains.