### PR TITLE
Fix for FilePathAssociation when trying to use kubernetes schema

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -8,12 +8,41 @@
 import { JSONSchema, JSONSchemaMap, JSONSchemaRef } from '../jsonSchema07';
 import { SchemaRequestService, WorkspaceContextService, PromiseConstructor, Thenable } from '../yamlLanguageService';
 import { UnresolvedSchema, ResolvedSchema, JSONSchemaService,
-    SchemaDependencies, FilePatternAssociation, ISchemaContributions } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
+    SchemaDependencies, ISchemaContributions } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 
 import * as nls from 'vscode-nls';
+import { convertSimple2RegExpPattern } from '../utils/strings';
 const localize = nls.loadMessageBundle();
 
 export declare type CustomSchemaProvider = (uri: string) => Thenable<string>;
+
+export class FilePatternAssociation {
+
+    private schemas: string[];
+    private patternRegExp: RegExp;
+
+    constructor(pattern: string) {
+        try {
+            this.patternRegExp = new RegExp(convertSimple2RegExpPattern(pattern) + '$');
+        } catch (e) {
+            // invalid pattern
+            this.patternRegExp = null;
+        }
+        this.schemas = [];
+    }
+
+    public addSchema(id: string) {
+        this.schemas.push(id);
+    }
+
+    public matchesPattern(fileName: string): boolean {
+        return this.patternRegExp && this.patternRegExp.test(fileName);
+    }
+
+    public getSchemas() {
+        return this.schemas;
+    }
+}
 
 export class YAMLSchemaService extends JSONSchemaService {
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,13 +16,12 @@ import * as URL from 'url';
 import { removeDuplicatesObj } from './languageservice/utils/arrUtils';
 import { getLanguageService as getCustomLanguageService, LanguageSettings, CustomFormatterOptions, WorkspaceContextService } from './languageservice/yamlLanguageService';
 import * as nls from 'vscode-nls';
-import { CustomSchemaProvider } from './languageservice/services/yamlSchemaService';
+import { CustomSchemaProvider, FilePatternAssociation } from './languageservice/services/yamlSchemaService';
 import { JSONSchema } from './languageservice/jsonSchema04';
 import { SchemaAssociationNotification, DynamicCustomSchemaRequestRegistration, CustomSchemaRequest } from './requestTypes';
 import { schemaRequestHandler } from './languageservice/services/schemaRequestHandler';
 import { isRelativePath, relativeToAbsolutePath } from './languageservice/utils/paths';
 import { URI } from 'vscode-uri';
-import { FilePatternAssociation } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 
 // tslint:disable-next-line: no-any
 nls.config(process.env['VSCODE_NLS_CONFIG'] as any);


### PR DESCRIPTION
Fixes: https://github.com/redhat-developer/yaml-language-server/issues/202

Problem was that the json schema service did not export FilePathAssociation so while that worked when using it as a type it didn't work when trying to construct it.