### PR TITLE
Updating kube schema location to new instrumenta org

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -29,7 +29,7 @@ nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
 /****************
  * Constants
  ****************/
-const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
+const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
 const JSON_SCHEMASTORE_URL = 'http://schemastore.org/api/json/catalog.json';
 
 /**************************

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,7 +9,7 @@ import { MarkedString } from '../src';
 
 const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
 
-const uri = 'https://raw.githubusercontent.com/garethr/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
+const uri = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
 const languageSettings: LanguageSettings = {
     schemas: [],
     validate: true,


### PR DESCRIPTION
The `kubernetes-json-schema` repository has moved to the `instrumenta` GH organization now:
<https://github.com/instrumenta/kubernetes-json-schema>

Also the original repository has not been updated from `1.14` with new versions `1.15` and `1.16`:
<https://github.com/garethr/kubernetes-json-schema/>

For this PR I have pointed at the same `1.14` version, tests still pass.
I have also tried bumping to `1.16` and the tests still pass, I can add that to this PR too if you'd like.

Resolves #207