### PR TITLE
First draft of server side snippets

### DIFF
--- a/src/languageservice/services/yamlSnippetRegistry.ts
+++ b/src/languageservice/services/yamlSnippetRegistry.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { YAMLSnippet } from '../yamlLanguageService';
+
+/**
+ * Creates a snippet registry that holds all the server side snippets.
+ */
+export class YAMLSnippetRegistry {
+
+    private snippetStore = new Map<string, YAMLSnippet>();
+
+    /**
+     * Add a snippet to the registry. When autocompletion happens the snippet will appear depending on the context
+     *
+     * @param snippetTitle The name of the snippet that will appear during autocompletion
+     * @param snippet  The snippet itself
+     */
+    addSnippet(snippetTitle: string, snippet: YAMLSnippet) {
+        this.snippetStore.set(snippetTitle, snippet);
+    }
+
+    /**
+     * Remove a snippet from the registry
+     *
+     * @param snippetTitle The title of the snippet you want to remove
+     */
+    removeSnippet(snippetTitle: string) {
+        this.snippetStore.delete(snippetTitle);
+    }
+
+    getSnippets() {
+        return this.snippetStore;
+    }
+}

--- a/src/languageservice/utils/completion-utils.ts
+++ b/src/languageservice/utils/completion-utils.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getLineOffsets } from './arrUtils';
+import { TextDocument, Position } from 'vscode-languageserver-types';
+import { parse as parseYAML } from '../parser/yamlParser04';
+
+/**
+ * The function takes in a document and position and parses the 'fixed' version of the document that
+ * corrects simple syntax mistakes so that its possible to parse the document correctly even if a semicolon
+ * is missing
+ *
+ * @param document The text document you want to parse
+ * @param textDocumentPosition The position that you want to perform completion on
+ */
+export function parseFixedYAML(document: TextDocument, textDocumentPosition: Position) {
+    const completionFix = completionHelper(document, textDocumentPosition);
+    const newText = completionFix.newText;
+    return parseYAML(newText);
+}
+
+/**
+ * Corrects simple syntax mistakes to load possible nodes even if a semicolon is missing
+ */
+export function completionHelper(document: TextDocument, textDocumentPosition: Position) {
+    // Get the string we are looking at via a substring
+    const linePos = textDocumentPosition.line;
+    const position = textDocumentPosition;
+    const lineOffset = getLineOffsets(document.getText());
+    const start = lineOffset[linePos]; // Start of where the autocompletion is happening
+    let end = 0; // End of where the autocompletion is happening
+
+    if (lineOffset[linePos + 1]) {
+        end = lineOffset[linePos + 1];
+    } else {
+        end = document.getText().length;
+    }
+
+    while (end - 1 >= 0 && is_EOL(document.getText().charCodeAt(end - 1))) {
+        end--;
+    }
+
+    const textLine = document.getText().substring(start, end);
+
+    // Check if the string we are looking at is a node
+    if (textLine.indexOf(':') === -1) {
+        // We need to add the ":" to load the nodes
+        let newText = '';
+
+        // This is for the empty line case
+        const trimmedText = textLine.trim();
+        if (trimmedText.length === 0 || (trimmedText.length === 1 && trimmedText[0] === '-')) {
+            // Add a temp node that is in the document but we don't use at all.
+            newText = document.getText().substring(0, start + textLine.length) +
+                (trimmedText[0] === '-' && !textLine.endsWith(' ') ? ' ' : '') + 'holder:\r\n' +
+                document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
+
+            // For when missing semi colon case
+        } else {
+            // Add a semicolon to the end of the current line so we can validate the node
+            newText = document.getText().substring(0, start + textLine.length) + ':\r\n' + document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
+        }
+
+        return {
+            'newText': newText,
+            'newPosition': textDocumentPosition
+        };
+    } else {
+        // All the nodes are loaded
+        position.character = position.character - 1;
+
+        return {
+            'newText': document.getText(),
+            'newPosition': position
+        };
+    }
+}
+
+function is_EOL(c: number) {
+    return (c === 0x0A/* LF */) || (c === 0x0D/* CR */);
+}

--- a/src/languageservice/utils/node-contexts.ts
+++ b/src/languageservice/utils/node-contexts.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as Parser from '../parser/jsonParser04';
+
+export function determineNodeContext(node: Parser.ASTNode): string | undefined {
+    if ((node.type === 'string' && node.getValue() === 'holder') || (node.type === 'property' && node.location === null)) {
+        return 'object';
+    } else  if (node.type === 'null' && node.parent && node.parent.type === 'object') {
+        return 'scalar';
+    } else if (node.type === 'array' && node.parent && node.parent.location === null) {
+        return 'array';
+    }
+    return undefined;
+}

--- a/test/serverSideSnippets.test.ts
+++ b/test/serverSideSnippets.test.ts
@@ -1,0 +1,198 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { TextDocument } from 'vscode-languageserver';
+import { getLanguageService, SnippetContext } from '../src/languageservice/yamlLanguageService';
+import { schemaRequestService, workspaceContext } from './utils/testHelper';
+import { matchOffsetToDocument } from '../src/languageservice/utils/arrUtils';
+import { parseFixedYAML } from '../src/languageservice/utils/completion-utils';
+import { determineNodeContext } from '../src/languageservice/utils/node-contexts';
+import assert = require('assert');
+
+const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
+
+suite('Auto Completion Tests', () => {
+
+    function setup(content: string) {
+        return TextDocument.create('file://~/Desktop/vscode-k8s/test.yaml', 'yaml', 0, content);
+    }
+
+    function parseSetup(content: string, position) {
+        const testTextDocument = setup(content);
+        return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), false);
+    }
+
+    function createNode(content: string, offset: number) {
+        const testTextDocument = setup(content);
+        const doc = parseFixedYAML(testTextDocument, testTextDocument.positionAt(offset));
+        const currentDoc = matchOffsetToDocument(offset, doc);
+        return currentDoc.getNodeFromOffsetEndInclusive(offset);
+    }
+
+    describe('Determine the correct context for each scenario', function () {
+
+        describe('Detecting OBJECT context', () => {
+
+            it('When content is none it should be OBJECT context', () => {
+                const createdNode = createNode('', 0);
+                const nodeContext = determineNodeContext(createdNode);
+                assert.equal(nodeContext, 'object', 'The node context was NOT an object when one was expected');
+            });
+
+            it('When key is NOT NONE AND ATTEMPTING TO AUTOCOMPLETE ON NEXT LINE it should be OBJECT context', () => {
+                const createdNode = createNode('hello:\n  ', 7);
+                const nodeContext = determineNodeContext(createdNode);
+                assert.equal(nodeContext, 'object', 'The node context was NOT an object when one was expected');
+            });
+
+            it('When DEEP key is NOT NONE AND ATTEMPTING TO AUTOCOMPLETE ON NEXT LINE it should be OBJECT context', () => {
+                const createdNode = createNode('hello:\n  hello2:\n    ', 19);
+                const nodeContext = determineNodeContext(createdNode);
+                assert.equal(nodeContext, 'object', 'The node context was NOT an object when one was expected');
+            });
+        });
+
+        describe('Detecting SCALAR context', () => {
+            it('When key is NOT NONE it should be SCALAR context', () => {
+                const createdNode = createNode('hello: ', 6);
+                const nodeContext = determineNodeContext(createdNode);
+                assert.equal(nodeContext, 'scalar', 'The node context was NOT an scalar when one was expected');
+            });
+        });
+
+        describe('Detecting ARRAY context', () => {
+            it('When key is NOT NONE AND ATTEMPTING TO AUTOCOMPLETE ON NEXT LINE THAT HAS - it should be ARRAY context', () => {
+                const createdNode = createNode('hello:\n- ', 7);
+                const nodeContext = determineNodeContext(createdNode);
+                assert.equal(nodeContext, 'array', 'The node context was NOT an array when one was expected');
+            });
+        });
+    });
+
+    describe('Snippets on no schema', function () {
+        it('Test that all snippets are returned when you have no content', done => {
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.object
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = '';
+            const completion = parseSetup(content, 0);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 1);
+            }).then(done, done);
+        });
+
+        it('Test that only scalar snippets are returned when we are in an object', done => {
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.scalar
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = 'hello: ';
+            const completion = parseSetup(content, 7);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 1);
+            }).then(done, done);
+        });
+
+        it('Test that object/array snippets are returned when we are underneath an object', done => {
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.object
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = 'hello:\n  ';
+            const completion = parseSetup(content, 7);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 1);
+            }).then(done, done);
+        });
+
+        it('Test that array snippets are returned when - is present in array node', done => {
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.array
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = 'hello:\n- ';
+            const completion = parseSetup(content, 7);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 1);
+            }).then(done, done);
+        });
+    });
+
+    describe('Snippets on basic schemas', function () {
+        it('Test that snippets are returned when they match the schema', done => {
+            const schema = {
+                    'type': 'object',
+                    'properties': {
+                        'hello': {
+                            'type': 'string'
+                        }
+                    }
+            };
+            languageService.configure({
+                schemas: [{
+                    uri: 'file://test.yaml',
+                    fileMatch: ['*.yaml', '*.yml'],
+                    schema
+                }],
+                completion: true
+            });
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.scalar
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = 'hello: ';
+            const completion = parseSetup(content, 7);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 1);
+            }).then(done, done);
+        });
+
+        it('Test that snippets are not returned when they dont match the schema', done => {
+            const schema = {
+                    'type': 'object',
+                    'properties': {
+                        'hello': {
+                            'type': 'object'
+                        }
+                    }
+            };
+            languageService.configure({
+                schemas: [{
+                    uri: 'file://test.yaml',
+                    fileMatch: ['*.yaml', '*.yml'],
+                    schema
+                }],
+                completion: true
+            });
+            languageService.addSnippet('test', {
+                snippet: 'test_snippet',
+                context: SnippetContext.scalar
+            });
+            languageService.configure({
+                completion: true
+            });
+            const content = 'hello: ';
+            const completion = parseSetup(content, 7);
+            completion.then(function (result) {
+                assert.equal(result.items.length, 0);
+            }).then(done, done);
+        });
+    });
+});


### PR DESCRIPTION
This is the first draft of server side snippet support.

The basic idea is that we want the snippets to produce valid yaml without or with a schema involved. In the first case, without a schema, it's pretty simple. You can just ask the user who is adding/creating the snippet which context that the snippet should appear in:
```
export enum SnippetContext {
  any = 'any',
  scalar = 'scalar',
  object = 'object',
  array = 'array'
}
```
and then when you are performing auto completion you can determine the context of your current cursor position and grab a list of snippets associated with that context.

Showing snippets when you have a schema associated with the yaml file is a lot more complicated. This is because you have to determine whether the snippet matches the context of the schema and the context of the autocompletion.

E.g. if you want a snippet for "{hello: $1\ngoodbye: $2}" we need to determine what we are inserting is an object and then that also matches up with an object in the schema. You would then need to check if additionalProperties is true or false in the schema and if the resulting 'hello' and 'goodbye' are in the properties of the object.

When a schema is associated with a yaml file you need to make sure whatever snippet you insert doesn't lead the yaml file to have an error
