### PR TITLE
Update kubernetes schema to latest available version 1.17.0

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -29,7 +29,7 @@ nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
 /****************
  * Constants
  ****************/
-const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
+const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.17.0-standalone-strict/all.json';
 const JSON_SCHEMASTORE_URL = 'http://schemastore.org/api/json/catalog.json';
 
 /**************************


### PR DESCRIPTION
The current schema version for kubernetes is still at 1.14.0 which is very outdated. @instrumenta repo's latest available version is 1.17.0 