### PR TITLE
Made default snippets yaml-like and added tests

### DIFF
--- a/src/languageservice/utils/json.ts
+++ b/src/languageservice/utils/json.ts
@@ -4,41 +4,31 @@
 *--------------------------------------------------------------------------------------------*/
 
 // tslint:disable-next-line: no-any
-export function stringifyObject(obj: any, indent: string, stringifyLiteral: (val: any) => string): string {
-    if (obj !== null && typeof obj === 'object') {
-        const newIndent = indent + '\t';
-        if (Array.isArray(obj)) {
-            if (obj.length === 0) {
-                return '[]';
-            }
-            let result = '[\n';
-            for (let i = 0; i < obj.length; i++) {
-                result += newIndent + stringifyObject(obj[i], newIndent, stringifyLiteral);
-                if (i < obj.length - 1) {
-                    result += ',';
-                }
-                result += '\n';
-            }
-            result += indent + ']';
-            return result;
-        } else {
-            const keys = Object.keys(obj);
-            if (keys.length === 0) {
-                return '{}';
-            }
-            let result = '{\n';
-            for (let i = 0; i < keys.length; i++) {
-                const key = keys[i];
+export interface StringifySettings {
+    newLineFirst: boolean;
+    indentFirstObject: boolean;
+    shouldIndentWithTab: boolean;
+}
 
-                result += newIndent + JSON.stringify(key) + ': ' + stringifyObject(obj[key], newIndent, stringifyLiteral);
-                if (i < keys.length - 1) {
-                    result += ',';
-                }
-                result += '\n';
-            }
-            result += indent + '}';
-            return result;
+export function stringifyObject(obj: any, indent: string, stringifyLiteral: (val: any) => string, settings: StringifySettings): string {
+    if (obj !== null && typeof obj === 'object') {
+        const newIndent = settings.shouldIndentWithTab ? (indent + '\t') : indent;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) {
+            return '';
         }
+        let result = settings.newLineFirst ? '\n' : '';
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            if (i === 0 && !settings.indentFirstObject) {
+                result += indent + key + ': ' + stringifyObject(obj[key], newIndent, stringifyLiteral, settings);
+            } else {
+                result += newIndent + key + ': ' + stringifyObject(obj[key], newIndent, stringifyLiteral, settings);
+            }
+            result += '\n';
+        }
+        result += indent;
+        return result;
     }
     return stringifyLiteral(obj);
 }

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -1,0 +1,126 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { TextDocument } from 'vscode-languageserver';
+import { getLanguageService } from '../src/languageservice/yamlLanguageService';
+import { toFsPath, schemaRequestService, workspaceContext }  from './utils/testHelper';
+import assert = require('assert');
+import path = require('path');
+
+const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
+
+const languageSettings = {
+    schemas: [],
+    completion: true
+};
+
+const uri = toFsPath(path.join(__dirname, './fixtures/defaultSnippets.json'));
+const fileMatch = ['*.yml', '*.yaml'];
+languageSettings.schemas.push({ uri, fileMatch: fileMatch });
+languageService.configure(languageSettings);
+
+suite('Default Snippet Tests', () => {
+
+        describe('Snippet Tests', function () {
+
+            function setup(content: string) {
+                return TextDocument.create('file://~/Desktop/vscode-k8s/test.yaml', 'yaml', 0, content);
+            }
+
+            function parseSetup(content: string, position: number) {
+                const testTextDocument = setup(content);
+                return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), false);
+            }
+
+            it('Snippet in array schema should autocomplete with -', done => {
+                const content = 'array:\n  - ';
+                const completion = parseSetup(content, 11);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 1);
+                    assert.equal(result.items[0].insertText, 'item1: $1\n\titem2: $2\n');
+                    assert.equal(result.items[0].label, 'My array item');
+                }).then(done, done);
+            });
+
+            it('Snippet in array schema should autocomplete on next line with depth', done => {
+                const content = 'array:\n  - item1:\n    - ';
+                const completion = parseSetup(content, 24);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 1);
+                    assert.equal(result.items[0].insertText, 'item1: $1\n\titem2: $2\n');
+                    assert.equal(result.items[0].label, 'My array item');
+                }).then(done, done);
+            });
+
+            it('Snippet in array schema should autocomplete correctly after ', done => {
+                const content = 'array:\n  - item1: asd\n  - item2: asd\n    ';
+                const completion = parseSetup(content, 40);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 1);
+                    assert.equal(result.items[0].insertText, 'item1: $1\nitem2: $2\n');
+                    assert.equal(result.items[0].label, 'My array item');
+                }).then(done, done);
+            });
+
+            it('Snippet in array schema should autocomplete on same line as array', done => {
+                const content = 'array:  ';
+                const completion = parseSetup(content, 7);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 1);
+                }).then(done, done);
+            });
+
+            it('Snippet in object schema should autocomplete on next line ', done => {
+                const content = 'object:\n  ';
+                const completion = parseSetup(content, 11);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 2);
+                    assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2\n');
+                    assert.equal(result.items[0].label, 'Object item');
+                    assert.equal(result.items[1].insertText, 'key:\n\t$1');
+                    assert.equal(result.items[1].label, 'key');
+                }).then(done, done);
+            });
+
+            it('Snippet in object schema should autocomplete on next line with depth', done => {
+                const content = 'object:\n  key:\n    ';
+                const completion = parseSetup(content, 20);
+                completion.then(function (result) {
+                    assert.notEqual(result.items.length, 0);
+                    assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2\n');
+                    assert.equal(result.items[0].label, 'Object item');
+                    assert.equal(result.items[1].insertText, 'key:\n\t$1');
+                    assert.equal(result.items[1].label, 'key');
+                }).then(done, done);
+            });
+
+            it('Snippet in object schema should autocomplete on same line', done => {
+                const content = 'object:  ';
+                const completion = parseSetup(content, 8);
+                completion.then(function (result) {
+                    assert.equal(result.items.length, 1);
+                }).then(done, done);
+            });
+
+            it('Snippet in string schema should autocomplete on same line', done => {
+                const content = 'string:  ';
+                const completion = parseSetup(content, 8);
+                completion.then(function (result) {
+                    assert.notEqual(result.items.length, 0);
+                    assert.equal(result.items[0].insertText, 'test $1');
+                    assert.equal(result.items[0].label, 'My string item');
+                }).then(done, done);
+            });
+
+            it('Snippet in boolean schema should autocomplete on same line', done => {
+                const content = 'boolean:  ';
+                const completion = parseSetup(content, 9);
+                completion.then(function (result) {
+                    assert.notEqual(result.items.length, 0);
+                    assert.equal(result.items[0].label, 'My boolean item');
+                    assert.equal(result.items[0].insertText, 'false');
+                }).then(done, done);
+            });
+        });
+    });

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -1,0 +1,55 @@
+{
+    "type": "object",
+    "properties": {
+        "object": {
+            "type": "object",
+            "defaultSnippets": [
+                {
+                    "label": "Object item",
+                    "description": "Binds a key to a command for a given state",
+                    "body": { "key1": "$1", "key2": "$2" }
+                }
+            ],
+            "properties": {
+                "key": {
+                    "$ref": "#/properties/object"
+                }
+            }
+        },
+        "array": {
+            "type": "array",
+            "defaultSnippets": [
+                {
+                    "label": "My array item",
+                    "body": { "item1": "$1", "item2": "$2" }
+                }
+            ],
+            "items": {
+                "item1": {
+                    "$ref": "#/properties/array"
+                },
+                "item2": {
+                    "$ref": "#/properties/array"
+                }
+            }
+        },
+        "string": {
+            "type": "string",
+            "defaultSnippets": [
+                {
+                    "label": "My string item",
+                    "bodyText": "test $1"
+                }
+            ]
+        },
+        "boolean": {
+            "type": "boolean",
+            "defaultSnippets": [
+                {
+                    "label": "My boolean item",
+                    "bodyText": "false"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR makes default snippets behave more yaml-like (rather than json-like) and inserts the correct spaces depending on the context you are auto completing in.
