### PR TITLE
Fixed merge key error with JSON schema

### DIFF
--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -354,6 +354,23 @@ suite('Validation Tests', () => {
             });
         });
 
+        describe('Test anchors specifically against gitlab schema', function () {
+            it('Test that anchors do not report Property << is not allowed', done => {
+                languageService.configure({
+                    schemas: [{
+                        uri: 'http://json.schemastore.org/gitlab-ci',
+                        fileMatch: ['*.yaml', '*.yml']
+                    }],
+                    validate: true
+                });
+                const content = '.test-cache: &test-cache\n  cache: {}\nnodejs-tests:\n  <<: *test-cache\n  script: test';
+                const validator = parseSetup(content);
+                validator.then(function (result) {
+                    assert.equal(result.length, 0);
+                }).then(done, done);
+            });
+        });
+
         describe('Test with custom schemas', function () {
             function parseSetup(content: string) {
                 const testTextDocument = setupTextDocument(content);
@@ -412,7 +429,6 @@ suite('Validation Tests', () => {
                     assert.equal(result[1].message, `Value is not accepted. Valid values: "ImageStreamImport", "ImageStreamLayers".`);
                 }).then(done, done);
             });
-
         });
     });
 });


### PR DESCRIPTION
This new code is a port from the json schema 4 parser to the new json schema 7 parser. It basically replaces the merge key with the actual values of what the node value points to.

Fixes: https://github.com/redhat-developer/yaml-language-server/issues/180 and https://github.com/redhat-developer/vscode-yaml/issues/233