### PR TITLE
Fix issue with duplicate key error on merge keys

### DIFF
--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -191,9 +191,8 @@ function createJSONDocument(yamlDoc: Yaml.YAMLNode, startPositions: number[], te
 
     //Patch ontop of yaml-ast-parser to disable duplicate key message on merge key
     const isDuplicateAndNotMergeKey = function (error: Yaml.YAMLException, yamlText: string) {
-        const errorConverted = convertError(error);
-        const errorStart = errorConverted.range.start.character;
-        const errorEnd = errorConverted.range.end.character;
+        const errorStart = error.mark.position;
+        const errorEnd = error.mark.position + error.mark.column;
         if (error.reason === duplicateKeyReason && yamlText.substring(errorStart, errorEnd).startsWith('<<')) {
             return false;
         }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -51,6 +51,9 @@ export class YAMLValidation {
             if (syd.errors.length > 0) {
                 validationResult.push(...syd.errors);
             }
+            if (syd.warnings.length > 0) {
+                validationResult.push(...syd.warnings);
+            }
 
             validationResult.push(...validation);
             index++;

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -333,6 +333,27 @@ suite('Validation Tests', () => {
 
         });
 
+        describe('Test with no schemas', () => {
+            function parseSetup(content: string) {
+                const testTextDocument = setupTextDocument(content);
+                return languageService.doValidation(testTextDocument, true);
+            }
+
+            it('Duplicate properties are reported', done => {
+                languageService.configure({
+                    validate: true,
+                    isKubernetes: true
+                });
+                const content = 'kind: a\ncwd: b\nkind: c';
+                const validator = parseSetup(content);
+                validator.then(function (result) {
+                    assert.equal(result.length, 2);
+                    assert.equal(result[1].message, 'duplicate key');
+                }).then(done, done);
+
+            });
+        });
+
         describe('Test with custom schemas', function () {
             function parseSetup(content: string) {
                 const testTextDocument = setupTextDocument(content);


### PR DESCRIPTION
This fixes the case when there are multiple merge keys present and there is a duplicate key error thrown. 

Now, when multiple merge keys are present a duplicate key error should NOT be thrown.