### PR TITLE
Add call 'addSchemaValueCompletions'

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -332,6 +332,7 @@ export class YAMLCompletion extends JSONCompletion {
                                 insertText: `- ${this.getInsertTextForObject(s.schema.items, separatorAfter).insertText.trimLeft()}`,
                                 insertTextFormat: InsertTextFormat.Snippet,
                             });
+                            this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
                         }
                         else {
                             this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);


### PR DESCRIPTION
We are loosing completion items which we can create from JSON Scheme(including items from `defaultSnippets` property ) in case if array is contains objects.
This PR is fixed that.

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>