### PR TITLE
Changed oneOf to anyOf for multiple custom schema providers

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -251,7 +251,7 @@ export class YAMLSchemaService extends JSONSchemaService {
                                     ({
                                         'errors': [],
                                         'schema': {
-                                            'oneOf': schemas.map(schemaObj => schemaObj.schema)
+                                            'anyOf': schemas.map(schemaObj => schemaObj.schema)
                                         }
                                     })
                                 , err => resolveSchema());


### PR DESCRIPTION
Changed oneOf to anyOf when multiple custom providers are matched to the same file so that you will on longer get the `Matches multiple schemas when only one must validate` error.

Fixes: https://github.com/redhat-developer/vscode-yaml/issues/273