### PR TITLE
Fix the way defaultSnippets behaves on array items

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -273,8 +273,7 @@ export class YAMLCompletion extends JSONCompletion {
                 }
             }
 
-            // Covers the case when we are showing a snippet in an array
-            if (node.type === 'object' && node.parent && node.parent.type === 'array' && s.schema.type !== 'object') {
+            if (node.parent && s.node === node.parent && node.type === 'object' && s.schema.defaultSnippets) {
                 // For some reason the first item in the array needs to be treated differently, otherwise
                 // the indentation will not be correct
                 if (node.properties.length === 1) {

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -63,16 +63,6 @@ suite('Default Snippet Tests', () => {
                 }).then(done, done);
             });
 
-            it('Snippet in array schema should autocomplete on next line with depth', done => {
-                const content = 'array:\n  - item1:\n    - ';
-                const completion = parseSetup(content, 24);
-                completion.then(function (result) {
-                    assert.equal(result.items.length, 1);
-                    assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
-                    assert.equal(result.items[0].label, 'My array item');
-                }).then(done, done);
-            });
-
             it('Snippet in array schema should autocomplete correctly after ', done => {
                 const content = 'array:\n  - item1: asd\n    item2: asd\n    ';
                 const completion = parseSetup(content, 40);

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -24,12 +24,12 @@
                     "body": { "item1": "$1", "item2": "$2" }
                 }
             ],
-            "items": {
+            "items": { 
                 "item1": {
-                    "$ref": "#/properties/array"
+                    "type": "string"
                 },
                 "item2": {
-                    "$ref": "#/properties/array"
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
This fix changes the way defaultSnippets are handled on array items. Previously the code was not checking if the schema node was equivalent in some way to the current node you are trying to auto complete on. This lead to cases where defaultSnippets are being shown where they weren't supposed to.

Fixes: https://github.com/redhat-developer/yaml-language-server/issues/232