### PR TITLE
Modify .travis.yml to work with new travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+version: ~> 1.0
 language: node_js
 node_js:
 - '8'
@@ -17,9 +17,9 @@ after_script:
 deploy:
   provider: npm
   email: gorkem.ercan@gmail.com
-  skip_cleanup: true
+  cleanup: false
   on:
     tags: true
     repo: redhat-developer/yaml-language-server
-  api_key:
+  api_token:
     secure: q5zN3WjUGWWTlxC0yViMK9RcXeEEwYRsXuqEwYBEyz+er4XUJzisHdXELu0tf56caCZ1Kp0NCUHsGqyV+fBS5zhaR0SSil59tSPp3fo+av/eLymI+4RXLAo3vCuRITSKPG+AwJnwAZF5cwGRdUCKPjV0yi7lX/WcZzZCPKb4IlKpMET/x9n0vhtSRK0Spxb0xB+pdjzujOHg2hkU9J81i1c62pZ6KlGhipdRrsONB6ujpSgpBakatp6FFPwmg8YwjbrNAWcqBZA1KwgiymaJSUa0asrGqeTRph/+xtVIr1WYRL7ed4yg1EYhLptNThhlO+To4FSZbOQfE5Rqcgo1BcLFLgQuPdp5HQwnQcVrkKWvRDyxvNI61cSW9Pb3hwytcVik0yz5neRGWVmJpVRulK5LVH37+XqVmic5Amc46ovst7HHw52dKayR97FoBq1+CXpxCONdjtvWnHZgahXxjOb4pJkNaGnmOR157MZ7Oo6GrilOSo8WBtdsOv2/CCrL119Eqbr8rJuQR9H2q5Y7at0QNsuO24jrKvFmqf8igE0t6Z70Dk1cxApME5nMAaww/tL7Mgv4zSvSGQRykwxvAZfoIu4v0fRHR+3I5wRy4P0HHvwxGlBPhq8+m4aCzHCbL+AejEOxSWknhnE/AEd9p719mVMx6FbqBrilnuSlOsg=


### PR DESCRIPTION
.travis.yml files are now being validated on travis and I believe its why the current version of yaml language server won't release to npm on travis.

See: https://travis-ci.community/t/npm-deploy-failed-missing-api-key-but-i-have-set-it/6624/2

This PR seeks to fix this issue.