### PR TITLE
Update kubernetes schema to 1.17.0... again

### DIFF
--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -1,2 +1,2 @@
-export const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
+export const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.17.0-standalone-strict/all.json';
 export const JSON_SCHEMASTORE_URL = 'http://schemastore.org/api/json/catalog.json';

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,7 +9,7 @@ import { MarkedString } from '../src';
 
 const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
 
-const uri = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0-standalone-strict/all.json';
+const uri = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.17.0-standalone-strict/all.json';
 const languageSettings: LanguageSettings = {
     schemas: [],
     validate: true,

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -425,7 +425,7 @@ suite('JSON Schema', () => {
 
         await service.addContent({
             action: MODIFICATION_ACTIONS.add,
-            path: 'oneOf/0/properties/kind',
+            path: 'oneOf/1/properties/kind',
             key: 'enum',
             content: [
                 'v2',
@@ -435,7 +435,7 @@ suite('JSON Schema', () => {
         });
 
         const fs = await service.getResolvedSchema(KUBERNETES_SCHEMA_URL);
-        assert.deepEqual(fs.schema.oneOf[0].properties['kind']['enum'], ['v2', 'v3']);
+        assert.deepEqual(fs.schema.oneOf[1].properties['kind']['enum'], ['v2', 'v3']);
     });
 
     test('Deleting schema works with Kubernetes resolution', async () => {
@@ -444,13 +444,13 @@ suite('JSON Schema', () => {
 
         await service.deleteContent({
             action: MODIFICATION_ACTIONS.delete,
-            path: 'oneOf/0/properties/kind',
+            path: 'oneOf/1/properties/kind',
             key: 'enum',
             schema: KUBERNETES_SCHEMA_URL
         });
 
         const fs = await service.getResolvedSchema(KUBERNETES_SCHEMA_URL);
-        assert.equal(fs.schema.oneOf[0].properties['kind']['enum'], undefined);
+        assert.equal(fs.schema.oneOf[1].properties['kind']['enum'], undefined);
     });
 
     test('Adding a brand new schema', async () => {


### PR DESCRIPTION
Kubernetes schema was upgraded to latest available 1.17.0 last month with #214. However, that was reverted, probably by error, in refactoring from commit 5530e9711a1e (in #157, merged a few days later).

This commit updates once more Kubernetes schema to 1.17.0.

NB: tests were updated because with schema 1.17.0, `oneOf/0/properties` does not have property `kind`.