### PR TITLE
Added setting options like schemaStore in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ The following settings are supported:
 * `yaml.format.singleQuote`: Use single quotes instead of double quotes
 * `yaml.format.bracketSpacing`: Print spaces between brackets in objects
 * `yaml.format.proseWrap`: Always: wrap prose if it exeeds the print width, Never: never wrap the prose, Preserve: wrap prose as-is
+* `yaml.format.printWidth`: Specify the line length that the printer will wrap on
 * `yaml.validate`: Enable/disable validation feature
 * `yaml.hover`: Enable/disable hover
 * `yaml.completion`: Enable/disable autocompletion
 * `yaml.schemas`: Helps you associate schemas with files in a glob pattern
+* `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](http://schemastore.org/json/)
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
 
 ##### Adding custom tags


### PR DESCRIPTION
Added setting options like schemaStore in `README.md`.

Ref: [vscode-yaml settings](https://github.com/redhat-developer/vscode-yaml#language-server-settings)