### PR TITLE
Add vim-lsp for Vim client

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This repository only contains the server implementation. Here are some known cli
 * [coc-yaml](https://github.com/neoclide/coc-yaml) for [coc.nvim](https://github.com/neoclide/coc.nvim)
 * [Eclipse Wild Web Developer](https://marketplace.eclipse.org/content/eclipse-wild-web-developer-web-development-eclipse-ide) for Eclipse IDE
 * [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs
+* [vim-lsp](https://github.com/prabirshrestha/vim-lsp) for Vim
 
 ## Developer Support
 


### PR DESCRIPTION
`vim-lsp` now supports `yaml-language-server` so added it to the client list.

- Ref: [vim-lsp wiki](https://github.com/prabirshrestha/vim-lsp/wiki/Servers-YAML)
- Ref: [vim-lsp-settings supported-languages](https://github.com/mattn/vim-lsp-settings#supported-languages)