### PR TITLE
yaml completion: add a space between ':' and value

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -673,7 +673,7 @@ export class YAMLCompletion extends JSONCompletion {
                 if (propertySchema.defaultSnippets.length === 1) {
                     const body = propertySchema.defaultSnippets[0].body;
                     if (isDefined(body)) {
-                        value = ' ' + this.getInsertTextForSnippetValue(body, '', {
+                        value = this.getInsertTextForSnippetValue(body, '', {
                             newLineFirst: true,
                             indentFirstObject: false,
                             shouldIndentWithTab: false

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -673,7 +673,7 @@ export class YAMLCompletion extends JSONCompletion {
                 if (propertySchema.defaultSnippets.length === 1) {
                     const body = propertySchema.defaultSnippets[0].body;
                     if (isDefined(body)) {
-                        value = this.getInsertTextForSnippetValue(body, '', {
+                        value = ' ' + this.getInsertTextForSnippetValue(body, '', {
                             newLineFirst: true,
                             indentFirstObject: false,
                             shouldIndentWithTab: false
@@ -684,19 +684,19 @@ export class YAMLCompletion extends JSONCompletion {
             }
             if (propertySchema.enum) {
                 if (!value && propertySchema.enum.length === 1) {
-                    value = this.getInsertTextForGuessedValue(propertySchema.enum[0], '');
+                    value = ' ' + this.getInsertTextForGuessedValue(propertySchema.enum[0], '');
                 }
                 nValueProposals += propertySchema.enum.length;
             }
             if (isDefined(propertySchema.default)) {
                 if (!value) {
-                    value = this.getInsertTextForGuessedValue(propertySchema.default, '');
+                    value = ' ' + this.getInsertTextForGuessedValue(propertySchema.default, '');
                 }
                 nValueProposals++;
             }
             if (Array.isArray(propertySchema.examples) && propertySchema.examples.length) {
                 if (!value) {
-                    value = this.getInsertTextForGuessedValue(propertySchema.examples[0], '');
+                    value = ' ' + this.getInsertTextForGuessedValue(propertySchema.examples[0], '');
                 }
                 nValueProposals += propertySchema.examples.length;
             }
@@ -740,7 +740,7 @@ export class YAMLCompletion extends JSONCompletion {
             }
         }
         if (!value || nValueProposals > 1) {
-            value = '$1';
+            value = ' $1';
         }
         return resultText + value + separatorAfter;
     }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -53,7 +53,7 @@ suite('Auto Completion Tests', () => {
                 const content = 'directory';
                 const completion = parseSetup(content, 10);
                 completion.then(function (result) {
-                    assert.equal(result.items[0].insertText, 'directory: bower_components');
+                    assert.equal(result.items[2].insertText, 'directory: ${1:bower_components}');
                 }).then(done, done);
             });
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -49,6 +49,14 @@ suite('Auto Completion Tests', () => {
                 }).then(done, done);
             });
 
+            it('Autocomplete on default value (without :)', done => {
+                const content = 'directory';
+                const completion = parseSetup(content, 10);
+                completion.then(function (result) {
+                    assert.equal(result.items[0].insertText, 'directory: bower_components');
+                }).then(done, done);
+            });
+
             it('Autocomplete on default value (without value content)', done => {
                 const content = 'directory: ';
                 const completion = parseSetup(content, 12);


### PR DESCRIPTION
Fix the missing space between ':' and value in YAML completion, especially for default values, but not only.
Fix issue https://github.com/redhat-developer/vscode-yaml/issues/281
