### PR TITLE
fix issue with `@` symbol in relative path

### DIFF
--- a/src/languageservice/utils/paths.ts
+++ b/src/languageservice/utils/paths.ts
@@ -3,7 +3,7 @@ import { join, normalize } from 'path';
 import { URI } from 'vscode-uri';
 
 export const isRelativePath = (path: string): boolean => {
-    const relativePathRegex = /^(((\.\.?)|([\w-\. ]+))(\/|\\\\?))*[\w-\. ]*\.[\w-]+$/i;
+    const relativePathRegex = /^(((\.\.?)|([\w-@\. ]+))(\/|\\\\?))*[\w-\. ]*\.[\w-]+$/i;
     return relativePathRegex.test(path);
 };
 

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -132,6 +132,11 @@ suite('File path tests', () => {
                       'file:///usr/testuser/relative/path/file.json',
                       'file:///c%3A/Users/testuser/relative/path/file.json');
 
+        checkGoodPath(join('..', '..', 'relative', '@path', 'file.json'),
+                      'file:///relative/%40path/file.json',
+                      'file:///usr/testuser/relative/%40path/file.json',
+                      'file:///c%3A/Users/testuser/relative/%40path/file.json');
+
         describe('Relative path = a workspace folder', () => {
             const path1 = join('aFolder', 'file.json');
             const path2 = join('folder-2', 'file.json');


### PR DESCRIPTION
when trying to add a schema from a scoped package: `./node_modules/@amenity/schemas/myschema.json`, `isRelativePath` returns false and the server issues the following error: `Unable to load schema from '/./node_modules/...`

the fix: add `@` to regex pattern