### PR TITLE
add support for textDocument/definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "^3.13.1",
     "jsonc-parser": "^2.2.1",
     "request-light": "^0.2.4",
-    "vscode-json-languageservice": "^3.5.2",
+    "vscode-json-languageservice": "^3.6.0",
     "vscode-languageserver": "^5.2.1",
     "vscode-languageserver-types": "^3.15.1",
     "vscode-nls": "^4.1.2",

--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -1,0 +1,18 @@
+import { JSONSchemaRef, JSONSchema } from '../jsonSchema';
+import { TextDocument, Position, DefinitionLink } from 'vscode-languageserver-types';
+import { parse as parseYAML } from '../parser/yamlParser07';
+import { matchOffsetToDocument } from '../utils/arrUtils';
+import { findDefinition as JSONFindDefinition } from 'vscode-json-languageservice/lib/umd/services/jsonDefinition';
+
+export function findDefinition(document: TextDocument, position: Position): Thenable<DefinitionLink[]> {
+    const doc = parseYAML(document.getText());
+    const offset = document.offsetAt(position);
+    const currentDoc = matchOffsetToDocument(offset, doc);
+    if (currentDoc === null) {
+        return Promise.resolve([]);
+    }
+
+    const currentDocIndex = doc.documents.indexOf(currentDoc);
+    currentDoc.currentDocIndex = currentDocIndex;
+    return JSONFindDefinition(document, position, currentDoc);
+}

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { YAMLSchemaService, CustomSchemaProvider, SchemaAdditions, SchemaDeletions } from './services/yamlSchemaService';
-import { TextDocument, Position, CompletionList, Diagnostic, Hover, SymbolInformation, DocumentSymbol, CompletionItem, TextEdit } from 'vscode-languageserver-types';
+import { TextDocument, Position, CompletionList, Diagnostic, Hover, SymbolInformation, DocumentSymbol, CompletionItem, TextEdit, DefinitionLink } from 'vscode-languageserver-types';
 import { JSONSchema } from './jsonSchema';
 import { YAMLDocumentSymbols } from './services/documentSymbols';
 import { YAMLCompletion } from './services/yamlCompletion';
@@ -13,6 +13,7 @@ import { YAMLHover } from './services/yamlHover';
 import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
 import { getLanguageService as getJSONLanguageService, JSONWorkerContribution } from 'vscode-json-languageservice';
+import { findDefinition } from './services/yamlDefinition';
 
 export interface LanguageSettings {
   validate?: boolean; //Setting for whether we want to validate the schema
@@ -116,6 +117,7 @@ export interface LanguageService {
   findDocumentSymbols(document: TextDocument): SymbolInformation[];
   findDocumentSymbols2(document: TextDocument): DocumentSymbol[];
   doResolve(completionItem): Thenable<CompletionItem>;
+  findDefinition(document: TextDocument, position: Position): Thenable<DefinitionLink[]>;
   resetSchema(uri: string): boolean;
   doFormat(document: TextDocument, options: CustomFormatterOptions): TextEdit[];
   addSchema(schemaID: string, schema: JSONSchema): void;
@@ -154,6 +156,7 @@ export function getLanguageService(schemaRequestService: SchemaRequestService,
       registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => {
         schemaService.registerCustomSchemaProvider(schemaProvider);
       },
+      findDefinition,
       doComplete: completer.doComplete.bind(completer),
       doResolve: completer.doResolve.bind(completer),
       doValidation: yamlValidation.doValidation.bind(yamlValidation),

--- a/test/findDefintion.test.ts
+++ b/test/findDefintion.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { getLanguageService } from '../src/languageservice/yamlLanguageService';
+import { schemaRequestService, setupTextDocument, workspaceContext } from './utils/testHelper';
+import assert = require('assert');
+
+const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
+
+suite('FindDefintion Tests', () => {
+
+    describe('Jump to defintion', function () {
+
+        function findDefinitions(content: string, position: number) {
+            const testTextDocument = setupTextDocument(content);
+            return languageService.findDefinition(testTextDocument, testTextDocument.positionAt(position));
+        }
+
+        it('Find source defintion', done => {
+            const content = "definitions:\n  link:\n    type: string\ntype: object\nproperties:\n  uri:\n    $ref: '#/definitions/link'\n";
+            const definitions = findDefinitions(content, content.lastIndexOf('/li'));
+            definitions.then(function (results) {
+                assert.equal(results.length, 1);
+                assert.deepEqual(results[0].originSelectionRange, {
+                    start: {
+                        line: 6,
+                        character: 10
+                    },
+                    end: {
+                        line: 6,
+                        character: 30
+                    }
+                });
+                assert.deepEqual(results[0].targetRange, {
+                    start: {
+                        line: 2,
+                        character: 4
+                    },
+                    end: {
+                        line: 2,
+                        character: 16
+                    }
+                });
+            }).then(done, done);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,15 +1490,15 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-json-languageservice@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.5.2.tgz#4b898140a8e581359c10660845a4cae15dcbb4f9"
-  integrity sha512-9cUvBq00O08lpWVVOx6tQ1yLxCHss79nsUdEAVYGomRyMbnPBmc0AkYPcXI9WK1EM6HBo0R9Zo3NjFhcICpy4A==
+vscode-json-languageservice@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.6.0.tgz#133a1e2c3a3dffe38564a1ba948516805c3c1869"
+  integrity sha512-dXzFywypUZ9T0tjr4fREZiknXDz6vAGx1zsxbQY1+9DOpjMfbz0VLP873KmcbuvL4K3nseKTxc4TKHu8kLXRMw==
   dependencies:
     jsonc-parser "^2.2.1"
     vscode-languageserver-textdocument "^1.0.1"
     vscode-languageserver-types "^3.15.1"
-    vscode-nls "^4.1.1"
+    vscode-nls "^4.1.2"
     vscode-uri "^2.1.1"
 
 vscode-jsonrpc@^4.0.0:


### PR DESCRIPTION
This would allow the user to jump from `$ref` to its definition. References https://github.com/microsoft/vscode-json-languageservice/pull/50 https://github.com/vscode-langservers/vscode-json-languageserver/commit/cea01c453e98b9ca5efcb27e098b39418913967d