### PR TITLE
Fix Partial Configuration Bug

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -404,10 +404,18 @@ connection.onDidChangeConfiguration(change => {
 
     specificValidatorPaths = [];
     if (settings.yaml) {
-        yamlConfigurationSettings = settings.yaml.schemas || yamlConfigurationSettings;
-        yamlShouldValidate = settings.yaml.validate || yamlShouldValidate;
-        yamlShouldHover = settings.yaml.hover || yamlShouldHover;
-        yamlShouldCompletion = settings.yaml.completion || yamlShouldCompletion;
+        if (settings.yaml.hasOwnProperty('schemas')) {
+            yamlConfigurationSettings = settings.yaml.schemas;
+        }
+        if (settings.yaml.hasOwnProperty('validate')) {
+            yamlShouldValidate = settings.yaml.validate;
+        }
+        if (settings.yaml.hasOwnProperty('hover')) {
+            yamlShouldHover = settings.yaml.hover;
+        }
+        if (settings.yaml.hasOwnProperty('completion')) {
+            yamlShouldCompletion = settings.yaml.completion;
+        }
         customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
         if (settings.yaml.schemaStore) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -404,10 +404,10 @@ connection.onDidChangeConfiguration(change => {
 
     specificValidatorPaths = [];
     if (settings.yaml) {
-        yamlConfigurationSettings = settings.yaml.schemas;
-        yamlShouldValidate = settings.yaml.validate;
-        yamlShouldHover = settings.yaml.hover;
-        yamlShouldCompletion = settings.yaml.completion;
+        yamlConfigurationSettings = settings.yaml.schemas || yamlConfigurationSettings;
+        yamlShouldValidate = settings.yaml.validate || yamlShouldValidate;
+        yamlShouldHover = settings.yaml.hover || yamlShouldHover;
+        yamlShouldCompletion = settings.yaml.completion || yamlShouldCompletion;
         customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
         if (settings.yaml.schemaStore) {


### PR DESCRIPTION
Small patch to fix [#256](https://github.com/redhat-developer/yaml-language-server/issues/256).

When submitting partial settings objects to the language server using the `onDidChangeConfiguration` listener, the server was overwriting its default values with null values for every unspecified parameter.