### PR TITLE
move to https endpoints for schemastore.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following settings are supported:
 * `yaml.hover`: Enable/disable hover
 * `yaml.completion`: Enable/disable autocompletion
 * `yaml.schemas`: Helps you associate schemas with files in a glob pattern
-* `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](http://schemastore.org/json/)
+* `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org/json/)
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
 
 ##### Adding custom tags
@@ -80,7 +80,7 @@ you can do
 
 ```
 yaml.schemas: {
-    "http://json.schemastore.org/composer": "/myYamlFile.yaml"
+    "https://json.schemastore.org/composer": "/myYamlFile.yaml"
 }
 ```
 
@@ -99,7 +99,7 @@ yaml.schemas: {
 e.g.
 ```
 yaml.schemas: {
-    "http://json.schemastore.org/composer": "/*"
+    "https://json.schemastore.org/composer": "/*"
 }
 ```
 
@@ -113,7 +113,7 @@ yaml.schemas: {
 e.g.
 ```
 yaml.schemas: {
-    "http://json.schemastore.org/composer": "/*",
+    "https://json.schemastore.org/composer": "/*",
     "kubernetes": "/myYamlFile.yaml"
 }
 ```

--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -1,2 +1,2 @@
 export const KUBERNETES_SCHEMA_URL = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.17.0-standalone-strict/all.json';
-export const JSON_SCHEMASTORE_URL = 'http://schemastore.org/api/json/catalog.json';
+export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';

--- a/test/autoCompletion2.test.ts
+++ b/test/autoCompletion2.test.ts
@@ -12,7 +12,7 @@ import assert = require('assert');
 
 const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
 
-const uri = 'http://json.schemastore.org/composer';
+const uri = 'https://json.schemastore.org/composer';
 const languageSettings = {
     schemas: [],
     completion: true

--- a/test/autoCompletion3.test.ts
+++ b/test/autoCompletion3.test.ts
@@ -10,7 +10,7 @@ import assert = require('assert');
 
 const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
 
-const uri = 'http://json.schemastore.org/asmdef';
+const uri = 'https://json.schemastore.org/asmdef';
 const languageSettings = {
     schemas: [],
     completion: true

--- a/test/fixtures/customMultipleSchemaSequences.json
+++ b/test/fixtures/customMultipleSchemaSequences.json
@@ -17,7 +17,7 @@
 			"required": ["name","age"]
 		},
 		{
-			"$ref": "http://json.schemastore.org/bowerrc"
+			"$ref": "https://json.schemastore.org/bowerrc"
 		}
 	]
 

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -10,8 +10,8 @@ import assert = require('assert');
 /**
  * Setup the schema we are going to use with the language settings
  */
-const bowerURI = 'http://json.schemastore.org/bowerrc';
-const composerURI = 'http://json.schemastore.org/composer';
+const bowerURI = 'https://json.schemastore.org/bowerrc';
+const composerURI = 'https://json.schemastore.org/composer';
 const fileMatch = ['*.yml', '*.yaml'];
 const languageSettingsSetup = new ServiceSetup()
     .withHover()

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -8,7 +8,7 @@ import { ServiceSetup } from './utils/serviceSetup';
 import { StringTypeError, BooleanTypeError, ArrayTypeError, ObjectTypeError, IncludeWithoutValueError, ColonMissingError, BlockMappingEntryError } from './utils/errorMessages';
 import assert = require('assert');
 
-const uri = 'http://json.schemastore.org/bowerrc';
+const uri = 'https://json.schemastore.org/bowerrc';
 const fileMatch = ['*.yml', '*.yaml'];
 const languageSettingsSetup = new ServiceSetup()
     .withValidate()
@@ -350,7 +350,7 @@ suite('Validation Tests', () => {
             it('Test that anchors do not report Property << is not allowed', done => {
                 languageService.configure({
                     schemas: [{
-                        uri: 'http://json.schemastore.org/gitlab-ci',
+                        uri: 'https://json.schemastore.org/gitlab-ci',
                         fileMatch: ['*.yaml', '*.yml']
                     }],
                     validate: true


### PR DESCRIPTION
https://github.com/SchemaStore/schemastore/commit/47574508df006fd2cf4fcb27ea755fc2a480517b moved to using SSL to serve resources from schemastore.org, with https://github.com/SchemaStore/schemastore/commit/10967162c0c1f0ab8aa07ae544067705f8328847 enforcing the `www` subdomain for the main site (with json schemas served from the `json` subdomain still).