### PR TITLE
fix remaining schemastore links to https

### DIFF
--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -9,7 +9,7 @@ import assert = require('assert');
 
 const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
 
-const uri = 'http://json.schemastore.org/bowerrc';
+const uri = 'https://json.schemastore.org/bowerrc';
 const languageSettings = {
     schemas: [],
     completion: true

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -88,8 +88,8 @@ suite('JSON Schema', () => {
         const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
         service.setSchemaContributions({
             schemas: {
-                'http://json.schemastore.org/swagger-2.0': {
-                    id: 'http://json.schemastore.org/swagger-2.0',
+                'https://json.schemastore.org/swagger-2.0': {
+                    id: 'https://json.schemastore.org/swagger-2.0',
                     type: 'object',
                     properties: {
                         'responseValue': {
@@ -111,7 +111,7 @@ suite('JSON Schema', () => {
             }
         });
 
-        service.getResolvedSchema('http://json.schemastore.org/swagger-2.0').then(fs => {
+        service.getResolvedSchema('https://json.schemastore.org/swagger-2.0').then(fs => {
             assert.deepEqual(fs.schema.properties['responseValue'], {
                 type: 'object',
                 required: ['$ref'],


### PR DESCRIPTION
When editing files for #264, missed a handful of them in the commit as I did not realize I had not saved the files in my editor like a dummy.