### PR TITLE
Fix required attributes insertion with first array item

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -250,7 +250,7 @@ export class YAMLCompletion extends JSONCompletion {
                                     // indent
                                     const sourceText = document.getText();
                                     const indexOfSlash = sourceText.lastIndexOf('-', node.offset - 1);
-                                    if (indexOfSlash > 0) {
+                                    if (indexOfSlash >= 0) {
                                         // add one space to compensate the '-'
                                         identCompensation = ' ' + sourceText.slice(indexOfSlash + 1, node.offset);
                                     }

--- a/test/autoCompletion.requiredproperties.test.ts
+++ b/test/autoCompletion.requiredproperties.test.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { TextDocument } from 'vscode-languageserver';
+import { getLanguageService } from '../src/languageservice/yamlLanguageService';
+import { toFsPath, schemaRequestService, workspaceContext }  from './utils/testHelper';
+import assert = require('assert');
+import path = require('path');
+
+const languageService = getLanguageService(schemaRequestService, workspaceContext, [], null);
+
+const languageSettings = {
+    schemas: [],
+    completion: true
+};
+
+const uri = toFsPath(path.join(__dirname, './fixtures/testRequiredProperties.json'));
+const fileMatch = ['*.yml', '*.yaml'];
+languageSettings.schemas.push({ uri, fileMatch: fileMatch });
+languageService.configure(languageSettings);
+
+suite('Auto Completion Tests for required properties', () => {
+
+    describe('yamlCompletion with required properties', function () {
+
+        describe('doComplete', function () {
+
+            function setup(content: string) {
+                return TextDocument.create('file://~/Desktop/vscode-k8s/test.yaml', 'yaml', 0, content);
+            }
+
+            function parseSetup(content: string, position) {
+                const testTextDocument = setup(content);
+                return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), false);
+            }
+
+            it('Insert required attributes at correct level', done => {
+                const content = '- top:\n    prop1: demo\n- ';
+                const completion = parseSetup(content, content.length);
+                completion.then(function (result) {
+                    const insertText = result.items[0].insertText;
+                    assert.equal(insertText, 'top:\n  \tprop1: $1');
+                }).then(done, done);
+            });
+           
+            it('Insert required attributes at correct level even on first element', done => {
+                const content = '- ';
+                const completion = parseSetup(content, content.length);
+                completion.then(function (result) {
+                    const insertText = result.items[0].insertText;
+                    assert.equal(insertText, 'top:\n  \tprop1: $1');
+                }).then(done, done);
+            });
+
+        });
+    });
+});

--- a/test/fixtures/testRequiredProperties.json
+++ b/test/fixtures/testRequiredProperties.json
@@ -1,0 +1,21 @@
+{
+    "$id": "https://example.com/arrays.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "items": {
+        "properties": {
+            "top": {
+                "type": "object",
+                "properties": {
+                    "prop1": {
+                        "type": "string"
+                    },
+                    "prop2": {
+                       "type": "string"
+                  }
+                },
+                "required": ["prop1"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
it seems that a `\t` is used instead of 4 spaces. I thought that tabs shouldn't be used in yaml files. To investigate more. @JPinkney does it ring a bell to you?

```
  1) yamlCompletion with required properties
       doComplete
         Insert required attributes at correct level:

      AssertionError [ERR_ASSERTION]: 'top:\n\tprop1: $1' == 'top\n    prop1: $1'
      + expected - actual

      -top:
      -	prop1: $1
      +top
      +    prop1: $1
```