### PR TITLE
204 support schema associations in file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.10.0
+
+- Allows to declare a schema inside the yaml file through modeline `# yaml-language-server: $schema=<urlOfTheSchema>`
+
 #### 0.9.0
 - Improve Diagnostic positions [#260](https://github.com/redhat-developer/yaml-language-server/issues/260)
 - Support `maxProperties` when providing completion [#269](https://github.com/redhat-developer/yaml-language-server/issues/269)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ and that will associate the composer schema with myYamlFile.yaml.
 
 ## More examples of schema association:
 
+### Using yaml.schemas settings
+
+#### Single root schema association:
+
 When associating a schema it should follow the format below
 ```
 yaml.schemas: {
@@ -118,7 +122,7 @@ yaml.schemas: {
 }
 ```
 
-## Multi root schema association:
+#### Multi root schema association:
 You can also use relative paths when working with multi root workspaces.
 
 Suppose you have a multi root workspace that is laid out like:
@@ -140,6 +144,14 @@ yaml.schemas: {
 ```
 
 `yaml.schemas` allows you to specify json schemas that you want to validate against the yaml that you write. Kubernetes is an optional field. It does not require a url as the language server will provide that. You just need the keyword kubernetes and a glob pattern.
+
+### Using inlined schema
+
+It is possible to specify a yaml schema using a modeline.
+
+```
+# yaml-language-server: $schema=<urlToTheSchema>
+```
 
 ## Clients
 This repository only contains the server implementation. Here are some known clients consuming this server:

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -17,7 +17,8 @@ import { convertSimple2RegExpPattern } from '../utils/strings';
 import { TextDocument } from 'vscode-languageserver';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { stringifyObject } from '../utils/json';
-import { getNodeValue } from '../parser/jsonParser07';
+import { getNodeValue, JSONDocument } from '../parser/jsonParser07';
+import { Parser } from 'prettier';
 const localize = nls.loadMessageBundle();
 
 export declare type CustomSchemaProvider = (uri: string) => Thenable<string | string[]>;
@@ -218,7 +219,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     }
     //tslint:enable
 
-    public getSchemaForResource (resource: string, doc = undefined): Thenable<ResolvedSchema> {
+    public getSchemaForResource (resource: string, doc : JSONDocument): Thenable<ResolvedSchema> {
         const resolveSchema = () => {
             const seen: { [schemaId: string]: boolean } = Object.create(null);
             const schemas: string[] = [];
@@ -253,8 +254,8 @@ export class YAMLSchemaService extends JSONSchemaService {
 
             if (schemas.length > 0) {
                 return super.createCombinedSchema(resource, schemas).getResolvedSchema().then(schema => {
-                    if (schema.schema && schema.schema.schemaSequence && schema.schema.schemaSequence[doc.currentDocIndex]) {
-                        return new ResolvedSchema(schema.schema.schemaSequence[doc.currentDocIndex]);
+                    if (schema.schema && schema.schema.schemaSequence && schema.schema.schemaSequence[(<SingleYAMLDocument>doc).currentDocIndex]) {
+                        return new ResolvedSchema(schema.schema.schemaSequence[(<SingleYAMLDocument>doc).currentDocIndex]);
                     }
                     return schema;
                 });

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -305,7 +305,7 @@ export class YAMLSchemaService extends JSONSchemaService {
             if (yamlLanguageServerModeline != undefined) {
                 const schemaKey = '$schema=';
                 const indexOfJsonSchemaParameter = yamlLanguageServerModeline.indexOf(schemaKey);
-                if (yamlLanguageServerModeline.indexOf(schemaKey) != -1) {
+                if (indexOfJsonSchemaParameter !== -1) {
                     const startIndex = indexOfJsonSchemaParameter + schemaKey.length;
                     const indexOfNextSpace = yamlLanguageServerModeline.indexOf(' ', startIndex);
                     const endIndex = indexOfNextSpace !== -1 ? indexOfNextSpace : yamlLanguageServerModeline.length;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -951,20 +951,11 @@ suite('Auto Completion Tests', () => {
                 const completionDoc1 = parseSetup(content, documentContent1.length);
                 completionDoc1.then(function (result) {
                     assert.equal(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
-                    assert.deepEqual(result.items[0], createExpectedCompletion('prop1', 'prop1: $1', 0, 2, 0, 2, 10, 2, {
-                        documentation: ''
-                    }));
-                    assert.deepEqual(result.items[1], createExpectedCompletion('prop2', 'prop2: $1', 0, 2, 0, 2, 10, 2, {
-                        documentation: ''
-                    }));
-                    assert.deepEqual(result.items[2], createExpectedCompletion('prop3', 'prop3: $1', 0, 2, 0, 2, 10, 2, {
-                        documentation: ''
-                    }));
                     const completionDoc2 = parseSetup(content, content.length);
                     completionDoc2.then(function (resultDoc2) {
                         assert.equal(resultDoc2.items.length, 0, `Expecting no items in completion but found ${resultDoc2.items.length}`);
                     }).then(done, done);
-                });
+                }, done);
                 
             });
         });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert = require('assert');
+import {parse} from './../src/languageservice/parser/yamlParser07';
+
+suite('Test parser', () => {
+
+    describe('test parser', function () {
+
+            it('parse emtpy text', () => {
+                const parsedDocument = parse('');
+                assert(parsedDocument.documents.length === 0, 'A document has been created for an empty text');
+            });
+            
+            it('parse single document', () => {
+                const parsedDocument = parse('test');
+                assert(parsedDocument.documents.length === 1, `A single document should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+            });
+            
+            it('parse single document with directives', () => {
+                const parsedDocument = parse('%TAG demo\n---\ntest');
+                assert(parsedDocument.documents.length === 1, `A single document should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+            });
+            
+            it('parse 2 documents', () => {
+                const parsedDocument = parse('test\n---\ntest2');
+                assert(parsedDocument.documents.length === 2, `2 documents should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[0].root.value === 'test');
+                assert(parsedDocument.documents[1].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[1].root.children.length}`);
+                assert(parsedDocument.documents[1].root.value === 'test2');
+            });
+            
+            it('parse 3 documents', () => {
+                const parsedDocument = parse('test\n---\ntest2\n---\ntest3');
+                assert(parsedDocument.documents.length === 3, `3 documents should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[0].root.value === 'test');
+                assert(parsedDocument.documents[1].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[1].root.children.length}`);
+                assert(parsedDocument.documents[1].root.value === 'test2');
+                assert(parsedDocument.documents[2].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[2].root.children.length}`);
+                assert(parsedDocument.documents[2].root.value === 'test3');
+            });
+            
+            it('parse single document with comment', () => {
+                const parsedDocument = parse('# a comment\ntest');
+                assert(parsedDocument.documents.length === 1, `A single document should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[0].lineComments.length === 1);
+                assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+            });
+            
+            it('parse 2 documents with comment', () => {
+                const parsedDocument = parse('# a comment\ntest\n---\n# a second comment\ntest2');
+                assert(parsedDocument.documents.length === 2, `2 documents should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[0].lineComments.length === 1);
+                assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+                
+                assert(parsedDocument.documents[1].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[1].lineComments.length === 1);
+                assert(parsedDocument.documents[1].lineComments[0] === '# a second comment');
+            });
+            
+            it('parse 2 documents with comment and a directive', () => {
+                const parsedDocument = parse('%TAG demo\n---\n# a comment\ntest\n---\n# a second comment\ntest2');
+                assert(parsedDocument.documents.length === 2, `2 documents should be available but there are ${parsedDocument.documents.length}`);
+                assert(parsedDocument.documents[0].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[0].lineComments.length === 1);
+                assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+                
+                assert(parsedDocument.documents[1].root.children.length === 0, `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`);
+                assert(parsedDocument.documents[1].lineComments.length === 1);
+                assert(parsedDocument.documents[1].lineComments[0] === '# a second comment');
+            });
+    });
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -14,6 +14,11 @@ suite('Test parser', () => {
                 assert(parsedDocument.documents.length === 0, 'A document has been created for an empty text');
             });
             
+            it('parse only comment', () => {
+                const parsedDocument = parse('# a comment');
+                assert(parsedDocument.documents.length === 1, 'No document has been created when there is a comment');
+            });
+            
             it('parse single document', () => {
                 const parsedDocument = parse('test');
                 assert(parsedDocument.documents.length === 1, `A single document should be available but there are ${parsedDocument.documents.length}`);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -272,7 +272,7 @@ suite('JSON Schema', () => {
 
         service.registerExternalSchema(id, ['*.json'], schema);
 
-        service.getSchemaForResource('test.json').then(schema => {
+        service.getSchemaForResource('test.json', undefined).then(schema => {
             const section = schema.getSection(['child', 'grandchild']);
             assert.equal(section.description, 'Meaning of Life');
         }).then(() => {
@@ -285,7 +285,7 @@ suite('JSON Schema', () => {
     test('Null Schema', function (testDone) {
         const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
-        service.getSchemaForResource('test.json').then(schema => {
+        service.getSchemaForResource('test.json', undefined).then(schema => {
             assert.equal(schema, null);
         }).then(() => {
             return testDone();


### PR DESCRIPTION
Choose to use modeline with pattern `# yaml-language-server: $schema=<urlToTheSchema>`

Why?
- needs to make a choice :-)
- using directive likes using `#SCHEMA` for instance is creating an invalid file with current specifications state, so need to move to a comment-like `#`
- use `$schema` because it is what is used by VS Code for JSON schema

![completionUsingInlinedSchemaDeclaration](https://user-images.githubusercontent.com/1105127/88053922-db9ab380-cb5c-11ea-8082-4fa5cd0cc122.gif)


big advantages of allowing defining the schema in the file is that the filename can be whatever is needed. It avoids the requirement of specific file name pattern. It ensures users can use a schema in all IDEs, no need for a specific IDE integration (apart from relying on Yaml Language Server of course).

For instance in OpenShift dev console, there is no way for user to choose the filename. it would allow to add have completion/validation there.
