### PR TITLE
Fix document symbols computation if yaml has complex mappings

### DIFF
--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -17,6 +17,17 @@ export class YAMLDocumentSymbols {
 
     constructor (schemaService: YAMLSchemaService) {
         this.jsonDocumentSymbols = new JSONDocumentSymbols(schemaService);
+        const origKeyLabel = this.jsonDocumentSymbols.getKeyLabel;
+
+        // override 'getKeyLabel' to handle complex mapping
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this.jsonDocumentSymbols.getKeyLabel = (property: any) => {
+            if (typeof property.keyNode.value === 'object') {
+                return property.keyNode.value.value;
+            } else {
+                return origKeyLabel.call(this.jsonDocumentSymbols, property);
+            }
+        };
     }
 
     public findDocumentSymbols (document: TextDocument): SymbolInformation[] {

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -299,7 +299,8 @@ suite('Document Symbols Tests', () => {
         });
 
         it('Document Symbols with complex mapping and aliases', () => {
-            const content = `version: 0.0.1
+            const content = `
+            version: 0.0.1
             structure:
               ? &root root
               :
@@ -311,12 +312,30 @@ suite('Document Symbols Tests', () => {
                   height: 41
             `;
 
-            try {
-                const symbols = parseHierarchicalSetup(content);
-                assert.equal(symbols.length, 2);
-            } catch (err) {
-                assert.fail(err);
-            }
+            const symbols = parseHierarchicalSetup(content);
+
+            assert.equal(symbols.length, 3);
+            assert.deepEqual(
+                symbols[0],
+                createExpectedDocumentSymbol('version', SymbolKind.String, 1, 12, 1, 26, 1, 12, 1, 19)
+            );
+
+            const element = createExpectedDocumentSymbol('element', SymbolKind.String, 5, 16, 5, 28, 5, 16, 5, 23, );
+            const root1 = createExpectedDocumentSymbol('root', SymbolKind.Module, 3, 22, 5, 28, 3, 22, 3, 26,[element]);
+
+            const height = createExpectedDocumentSymbol('height', SymbolKind.Number, 10, 18, 10, 28, 10, 18, 10, 24);
+            const style = createExpectedDocumentSymbol('style', SymbolKind.Module, 9, 16, 10, 28, 9, 16, 9, 21, [height]);
+            const root2 = createExpectedDocumentSymbol('root', SymbolKind.Module, 7, 17, 10, 28, 7, 17, 7, 21, [style]);
+
+            assert.deepEqual(
+                symbols[1],
+                createExpectedDocumentSymbol('structure', SymbolKind.Module, 2, 12, 5, 28, 2, 12, 2, 21, [root1])
+            );
+
+            assert.deepEqual(
+                symbols[2],
+                createExpectedDocumentSymbol('conditions', SymbolKind.Module, 6, 12, 10, 28, 6, 12, 6, 22, [root2])
+            );
 
         });
 

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupTextDocument, TEST_URI, configureLanguageService }  from './utils/testHelper';
+import { setupTextDocument, TEST_URI, configureLanguageService } from './utils/testHelper';
 import { createExpectedSymbolInformation, createExpectedDocumentSymbol } from './utils/verifyError';
 import { DocumentSymbol, SymbolKind } from 'vscode-languageserver-types';
 import assert = require('assert');
@@ -16,7 +16,7 @@ suite('Document Symbols Tests', () => {
 
         function parseNonHierarchicalSetup (content: string) {
             const testTextDocument = setupTextDocument(content);
-            return languageService.findDocumentSymbols(testTextDocument );
+            return languageService.findDocumentSymbols(testTextDocument);
         }
 
         it('Document is empty', done => {
@@ -296,6 +296,28 @@ suite('Document Symbols Tests', () => {
                 symbols[1],
                 createExpectedDocumentSymbol('json', SymbolKind.String, 4, 0, 4, 10, 4, 0, 4, 4)
             );
+        });
+
+        it('Document Symbols with complex mapping and aliases', () => {
+            const content = `version: 0.0.1
+            structure:
+              ? &root root
+              :
+                element: div
+            conditions:
+              ? *root
+              :
+                style:
+                  height: 41
+            `;
+
+            try {
+                const symbols = parseHierarchicalSetup(content);
+                assert.equal(symbols.length, 2);
+            } catch (err) {
+                assert.fail(err);
+            }
+
         });
 
     });


### PR DESCRIPTION
Fix: https://github.com/redhat-developer/vscode-yaml/issues/285