### PR TITLE
Fix for redhat-developer/vscode-yaml#353, error when editing yaml wit…

### DIFF
--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -17,7 +17,6 @@ import { getLineStartPositions } from '../utils/documentPositionCalculator';
 import { ASTNode } from '../jsonASTTypes';
 import { ErrorCode } from 'vscode-json-languageservice';
 
-const YAML_DIRECTIVE_PREFIX = '%';
 const YAML_COMMENT_PREFIX = '#';
 const YAML_DATA_INSTANCE_SEPARATOR = '---';
 
@@ -118,14 +117,14 @@ export function parse(text: string, customTags = []): YAMLDocument {
 function parseLineComments(text: string, yamlDocs: SingleYAMLDocument[]): void {
   const lines = text.split(/[\r\n]+/g);
   let yamlDocCount = 0;
+  let firstSeparatorFound = false;
   lines.forEach((line) => {
-    if (line.startsWith(YAML_DIRECTIVE_PREFIX) && yamlDocCount === 0) {
-      yamlDocCount--;
-    }
-    if (line === YAML_DATA_INSTANCE_SEPARATOR) {
+    if (line === YAML_DATA_INSTANCE_SEPARATOR && firstSeparatorFound) {
       yamlDocCount++;
+    } else if (line === YAML_DATA_INSTANCE_SEPARATOR) {
+      firstSeparatorFound = true;
     }
-    if (line.startsWith(YAML_COMMENT_PREFIX)) {
+    if (line.startsWith(YAML_COMMENT_PREFIX) && yamlDocCount < yamlDocs.length) {
       yamlDocs[yamlDocCount].lineComments.push(line);
     }
   });

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -777,4 +777,42 @@ suite('Validation Tests', () => {
         .then(done, done);
     });
   });
+
+  describe('Multi Document schema validation tests', () => {
+    it('Document does not error when --- is present with schema', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          cwd: {
+            type: 'string',
+          },
+        },
+      });
+      const content = '---\n# this is a test\ncwd: this';
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          assert.equal(result.length, 0);
+        })
+        .then(done, done);
+    });
+
+    it('Multi Document does not error when --- is present with schema', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          cwd: {
+            type: 'string',
+          },
+        },
+      });
+      const content = '---\n# this is a test\ncwd: this...\n---\n# second comment\ncwd: hello\n...';
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          assert.equal(result.length, 0);
+        })
+        .then(done, done);
+    });
+  });
 });

--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -17,6 +17,62 @@ suite('YAML parser', () => {
       assert(parsedDocument.documents.length === 1, 'No document has been created when there is a comment');
     });
 
+    it('parse single document with --- at the start of the file', () => {
+      const parsedDocument = parse('---\n# a comment\ntest: test');
+      assert(
+        parsedDocument.documents.length === 1,
+        `A single document should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+    });
+
+    it('parse multi document with --- at the start of the file', () => {
+      const parsedDocument = parse('---\n# a comment\ntest: test\n...\n---\n# second document\ntest2: test2');
+      assert(
+        parsedDocument.documents.length === 2,
+        `two documents should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+
+      assert(parsedDocument.documents[1].lineComments.length === 1);
+      assert(parsedDocument.documents[1].lineComments[0] === '# second document');
+    });
+
+    it('parse single document with directives and line comments', () => {
+      const parsedDocument = parse('%TAG !yaml! tag:yaml.org,2002:\n---\n# a comment\ntest');
+      assert(
+        parsedDocument.documents.length === 1,
+        `A single document should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(
+        parsedDocument.documents[0].root.children.length === 0,
+        `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`
+      );
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+    });
+
+    it('parse 2 documents with directives and line comments', () => {
+      const parsedDocument = parse('%TAG !yaml! tag:yaml.org,2002:\n# a comment\ntest\n...\n---\ntest2');
+      assert(
+        parsedDocument.documents.length === 2,
+        `2 documents should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(
+        parsedDocument.documents[0].root.children.length === 0,
+        `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`
+      );
+      assert(
+        parsedDocument.documents[1].root.children.length === 0,
+        `There should no children available but there are ${parsedDocument.documents[1].root.children.length}`
+      );
+      assert(parsedDocument.documents[1].root.value === 'test2');
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+    });
+
     it('parse single document', () => {
       const parsedDocument = parse('test');
       assert(
@@ -30,7 +86,7 @@ suite('YAML parser', () => {
     });
 
     it('parse single document with directives', () => {
-      const parsedDocument = parse('%TAG demo\n---\ntest');
+      const parsedDocument = parse('%TAG !yaml! tag:yaml.org,2002:\n---\ntest');
       assert(
         parsedDocument.documents.length === 1,
         `A single document should be available but there are ${parsedDocument.documents.length}`
@@ -97,7 +153,28 @@ suite('YAML parser', () => {
     });
 
     it('parse 2 documents with comment', () => {
-      const parsedDocument = parse('# a comment\ntest\n---\n# a second comment\ntest2');
+      const parsedDocument = parse('---\n# a comment\ntest: test\n---\n# a second comment\ntest2');
+      assert(
+        parsedDocument.documents.length === 2,
+        `2 documents should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(
+        parsedDocument.documents[0].root.children.length === 1,
+        `There should one children available but there are ${parsedDocument.documents[0].root.children.length}`
+      );
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+
+      assert(
+        parsedDocument.documents[1].root.children.length === 0,
+        `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`
+      );
+      assert(parsedDocument.documents[1].lineComments.length === 1);
+      assert(parsedDocument.documents[1].lineComments[0] === '# a second comment');
+    });
+
+    it('parse 2 documents with comment and a directive', () => {
+      const parsedDocument = parse('%TAG !yaml! tag:yaml.org,2002:\n---\n# a comment\ntest\n---\n# a second comment\ntest2');
       assert(
         parsedDocument.documents.length === 2,
         `2 documents should be available but there are ${parsedDocument.documents.length}`
@@ -117,25 +194,34 @@ suite('YAML parser', () => {
       assert(parsedDocument.documents[1].lineComments[0] === '# a second comment');
     });
 
-    it('parse 2 documents with comment and a directive', () => {
-      const parsedDocument = parse('%TAG demo\n---\n# a comment\ntest\n---\n# a second comment\ntest2');
+    it('parse document with comment first', () => {
+      const parsedDocument = parse('# a comment\n---\ntest:test');
       assert(
-        parsedDocument.documents.length === 2,
-        `2 documents should be available but there are ${parsedDocument.documents.length}`
-      );
-      assert(
-        parsedDocument.documents[0].root.children.length === 0,
-        `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`
+        parsedDocument.documents.length === 1,
+        `1 document should be available but there are ${parsedDocument.documents.length}`
       );
       assert(parsedDocument.documents[0].lineComments.length === 1);
       assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+    });
 
+    it('parse document with comment first and directive', () => {
+      const parsedDocument = parse('# a comment\n%TAG !yaml! tag:yaml.org,2002:\ntest: test');
       assert(
-        parsedDocument.documents[1].root.children.length === 0,
-        `There should no children available but there are ${parsedDocument.documents[0].root.children.length}`
+        parsedDocument.documents.length === 1,
+        `1 document should be available but there are ${parsedDocument.documents.length}`
       );
-      assert(parsedDocument.documents[1].lineComments.length === 1);
-      assert(parsedDocument.documents[1].lineComments[0] === '# a second comment');
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
+    });
+
+    it('parse document with comment first, directive, and seperator', () => {
+      const parsedDocument = parse('# a comment\n%TAG !yaml! tag:yaml.org,2002:\n---test: test');
+      assert(
+        parsedDocument.documents.length === 1,
+        `1 document should be available but there are ${parsedDocument.documents.length}`
+      );
+      assert(parsedDocument.documents[0].lineComments.length === 1);
+      assert(parsedDocument.documents[0].lineComments[0] === '# a comment');
     });
   });
 });


### PR DESCRIPTION
…h comments

This PR should fix https://github.com/redhat-developer/vscode-yaml/issues/353.

This is occurring because https://github.com/redhat-developer/yaml-language-server/blob/master/src/languageservice/parser/yamlParser07.ts#L125 is incrementing yamlDocCount by 1 when `---` is the first thing present in the YAML file. Then when https://github.com/redhat-developer/yaml-language-server/blob/master/src/languageservice/parser/yamlParser07.ts#L129 is hit yamlDocs[1] will be undefined when there is only a single YAML document, thus creating the error.

The solution is to only increment yamlDocCount when you see `---` and it's not the first line of the file. That way these two instances (with and without `---` at the start get parsed correctly)
```
# some comment
test: test
...
```
and
```
---
# some comment
test: test
...
```

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>