### PR TITLE
Use space for completion text instead of tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Make yaml-language-server available as ESM and UMD modules in the `/lib` directory [#305](https://github.com/redhat-developer/yaml-language-server/pull/305)
 - Fix: `yaml.schemas` configuration doesn't work on windows with full path [#347](https://github.com/redhat-developer/vscode-yaml/issues/347)
+- Completion text use space instead of tab for indentation [#283](https://github.com/redhat-developer/yaml-language-server/issues/283)
 
 #### 0.10.1
 

--- a/src/languageservice/utils/charCode.ts
+++ b/src/languageservice/utils/charCode.ts
@@ -1,0 +1,436 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// copied from https://github.com/Microsoft/vscode/blob/015c3afe96966df50c15a7d66be2ab0ef1dc5f49/src/vs/base/common/charCode.ts
+
+// Names from https://blog.codinghorror.com/ascii-pronunciation-rules-for-programmers/
+
+/**
+ * An inlined enum containing useful character codes (to be used with String.charCodeAt).
+ * Please leave the const keyword such that it gets inlined when compiled to JavaScript!
+ */
+export const enum CharCode {
+  Null = 0,
+  /**
+   * The `\b` character.
+   */
+  Backspace = 8,
+  /**
+   * The `\t` character.
+   */
+  Tab = 9,
+  /**
+   * The `\n` character.
+   */
+  LineFeed = 10,
+  /**
+   * The `\r` character.
+   */
+  CarriageReturn = 13,
+  Space = 32,
+  /**
+   * The `!` character.
+   */
+  ExclamationMark = 33,
+  /**
+   * The `"` character.
+   */
+  DoubleQuote = 34,
+  /**
+   * The `#` character.
+   */
+  Hash = 35,
+  /**
+   * The `$` character.
+   */
+  DollarSign = 36,
+  /**
+   * The `%` character.
+   */
+  PercentSign = 37,
+  /**
+   * The `&` character.
+   */
+  Ampersand = 38,
+  /**
+   * The `'` character.
+   */
+  SingleQuote = 39,
+  /**
+   * The `(` character.
+   */
+  OpenParen = 40,
+  /**
+   * The `)` character.
+   */
+  CloseParen = 41,
+  /**
+   * The `*` character.
+   */
+  Asterisk = 42,
+  /**
+   * The `+` character.
+   */
+  Plus = 43,
+  /**
+   * The `,` character.
+   */
+  Comma = 44,
+  /**
+   * The `-` character.
+   */
+  Dash = 45,
+  /**
+   * The `.` character.
+   */
+  Period = 46,
+  /**
+   * The `/` character.
+   */
+  Slash = 47,
+
+  Digit0 = 48,
+  Digit1 = 49,
+  Digit2 = 50,
+  Digit3 = 51,
+  Digit4 = 52,
+  Digit5 = 53,
+  Digit6 = 54,
+  Digit7 = 55,
+  Digit8 = 56,
+  Digit9 = 57,
+
+  /**
+   * The `:` character.
+   */
+  Colon = 58,
+  /**
+   * The `;` character.
+   */
+  Semicolon = 59,
+  /**
+   * The `<` character.
+   */
+  LessThan = 60,
+  /**
+   * The `=` character.
+   */
+  Equals = 61,
+  /**
+   * The `>` character.
+   */
+  GreaterThan = 62,
+  /**
+   * The `?` character.
+   */
+  QuestionMark = 63,
+  /**
+   * The `@` character.
+   */
+  AtSign = 64,
+
+  A = 65,
+  B = 66,
+  C = 67,
+  D = 68,
+  E = 69,
+  F = 70,
+  G = 71,
+  H = 72,
+  I = 73,
+  J = 74,
+  K = 75,
+  L = 76,
+  M = 77,
+  N = 78,
+  O = 79,
+  P = 80,
+  Q = 81,
+  R = 82,
+  S = 83,
+  T = 84,
+  U = 85,
+  V = 86,
+  W = 87,
+  X = 88,
+  Y = 89,
+  Z = 90,
+
+  /**
+   * The `[` character.
+   */
+  OpenSquareBracket = 91,
+  /**
+   * The `\` character.
+   */
+  Backslash = 92,
+  /**
+   * The `]` character.
+   */
+  CloseSquareBracket = 93,
+  /**
+   * The `^` character.
+   */
+  Caret = 94,
+  /**
+   * The `_` character.
+   */
+  Underline = 95,
+  /**
+   * The ``(`)`` character.
+   */
+  BackTick = 96,
+
+  a = 97,
+  b = 98,
+  c = 99,
+  d = 100,
+  e = 101,
+  f = 102,
+  g = 103,
+  h = 104,
+  i = 105,
+  j = 106,
+  k = 107,
+  l = 108,
+  m = 109,
+  n = 110,
+  o = 111,
+  p = 112,
+  q = 113,
+  r = 114,
+  s = 115,
+  t = 116,
+  u = 117,
+  v = 118,
+  w = 119,
+  x = 120,
+  y = 121,
+  z = 122,
+
+  /**
+   * The `{` character.
+   */
+  OpenCurlyBrace = 123,
+  /**
+   * The `|` character.
+   */
+  Pipe = 124,
+  /**
+   * The `}` character.
+   */
+  CloseCurlyBrace = 125,
+  /**
+   * The `~` character.
+   */
+  Tilde = 126,
+
+  U_Combining_Grave_Accent = 0x0300, //	U+0300	Combining Grave Accent
+  U_Combining_Acute_Accent = 0x0301, //	U+0301	Combining Acute Accent
+  U_Combining_Circumflex_Accent = 0x0302, //	U+0302	Combining Circumflex Accent
+  U_Combining_Tilde = 0x0303, //	U+0303	Combining Tilde
+  U_Combining_Macron = 0x0304, //	U+0304	Combining Macron
+  U_Combining_Overline = 0x0305, //	U+0305	Combining Overline
+  U_Combining_Breve = 0x0306, //	U+0306	Combining Breve
+  U_Combining_Dot_Above = 0x0307, //	U+0307	Combining Dot Above
+  U_Combining_Diaeresis = 0x0308, //	U+0308	Combining Diaeresis
+  U_Combining_Hook_Above = 0x0309, //	U+0309	Combining Hook Above
+  U_Combining_Ring_Above = 0x030a, //	U+030A	Combining Ring Above
+  U_Combining_Double_Acute_Accent = 0x030b, //	U+030B	Combining Double Acute Accent
+  U_Combining_Caron = 0x030c, //	U+030C	Combining Caron
+  U_Combining_Vertical_Line_Above = 0x030d, //	U+030D	Combining Vertical Line Above
+  U_Combining_Double_Vertical_Line_Above = 0x030e, //	U+030E	Combining Double Vertical Line Above
+  U_Combining_Double_Grave_Accent = 0x030f, //	U+030F	Combining Double Grave Accent
+  U_Combining_Candrabindu = 0x0310, //	U+0310	Combining Candrabindu
+  U_Combining_Inverted_Breve = 0x0311, //	U+0311	Combining Inverted Breve
+  U_Combining_Turned_Comma_Above = 0x0312, //	U+0312	Combining Turned Comma Above
+  U_Combining_Comma_Above = 0x0313, //	U+0313	Combining Comma Above
+  U_Combining_Reversed_Comma_Above = 0x0314, //	U+0314	Combining Reversed Comma Above
+  U_Combining_Comma_Above_Right = 0x0315, //	U+0315	Combining Comma Above Right
+  U_Combining_Grave_Accent_Below = 0x0316, //	U+0316	Combining Grave Accent Below
+  U_Combining_Acute_Accent_Below = 0x0317, //	U+0317	Combining Acute Accent Below
+  U_Combining_Left_Tack_Below = 0x0318, //	U+0318	Combining Left Tack Below
+  U_Combining_Right_Tack_Below = 0x0319, //	U+0319	Combining Right Tack Below
+  U_Combining_Left_Angle_Above = 0x031a, //	U+031A	Combining Left Angle Above
+  U_Combining_Horn = 0x031b, //	U+031B	Combining Horn
+  U_Combining_Left_Half_Ring_Below = 0x031c, //	U+031C	Combining Left Half Ring Below
+  U_Combining_Up_Tack_Below = 0x031d, //	U+031D	Combining Up Tack Below
+  U_Combining_Down_Tack_Below = 0x031e, //	U+031E	Combining Down Tack Below
+  U_Combining_Plus_Sign_Below = 0x031f, //	U+031F	Combining Plus Sign Below
+  U_Combining_Minus_Sign_Below = 0x0320, //	U+0320	Combining Minus Sign Below
+  U_Combining_Palatalized_Hook_Below = 0x0321, //	U+0321	Combining Palatalized Hook Below
+  U_Combining_Retroflex_Hook_Below = 0x0322, //	U+0322	Combining Retroflex Hook Below
+  U_Combining_Dot_Below = 0x0323, //	U+0323	Combining Dot Below
+  U_Combining_Diaeresis_Below = 0x0324, //	U+0324	Combining Diaeresis Below
+  U_Combining_Ring_Below = 0x0325, //	U+0325	Combining Ring Below
+  U_Combining_Comma_Below = 0x0326, //	U+0326	Combining Comma Below
+  U_Combining_Cedilla = 0x0327, //	U+0327	Combining Cedilla
+  U_Combining_Ogonek = 0x0328, //	U+0328	Combining Ogonek
+  U_Combining_Vertical_Line_Below = 0x0329, //	U+0329	Combining Vertical Line Below
+  U_Combining_Bridge_Below = 0x032a, //	U+032A	Combining Bridge Below
+  U_Combining_Inverted_Double_Arch_Below = 0x032b, //	U+032B	Combining Inverted Double Arch Below
+  U_Combining_Caron_Below = 0x032c, //	U+032C	Combining Caron Below
+  U_Combining_Circumflex_Accent_Below = 0x032d, //	U+032D	Combining Circumflex Accent Below
+  U_Combining_Breve_Below = 0x032e, //	U+032E	Combining Breve Below
+  U_Combining_Inverted_Breve_Below = 0x032f, //	U+032F	Combining Inverted Breve Below
+  U_Combining_Tilde_Below = 0x0330, //	U+0330	Combining Tilde Below
+  U_Combining_Macron_Below = 0x0331, //	U+0331	Combining Macron Below
+  U_Combining_Low_Line = 0x0332, //	U+0332	Combining Low Line
+  U_Combining_Double_Low_Line = 0x0333, //	U+0333	Combining Double Low Line
+  U_Combining_Tilde_Overlay = 0x0334, //	U+0334	Combining Tilde Overlay
+  U_Combining_Short_Stroke_Overlay = 0x0335, //	U+0335	Combining Short Stroke Overlay
+  U_Combining_Long_Stroke_Overlay = 0x0336, //	U+0336	Combining Long Stroke Overlay
+  U_Combining_Short_Solidus_Overlay = 0x0337, //	U+0337	Combining Short Solidus Overlay
+  U_Combining_Long_Solidus_Overlay = 0x0338, //	U+0338	Combining Long Solidus Overlay
+  U_Combining_Right_Half_Ring_Below = 0x0339, //	U+0339	Combining Right Half Ring Below
+  U_Combining_Inverted_Bridge_Below = 0x033a, //	U+033A	Combining Inverted Bridge Below
+  U_Combining_Square_Below = 0x033b, //	U+033B	Combining Square Below
+  U_Combining_Seagull_Below = 0x033c, //	U+033C	Combining Seagull Below
+  U_Combining_X_Above = 0x033d, //	U+033D	Combining X Above
+  U_Combining_Vertical_Tilde = 0x033e, //	U+033E	Combining Vertical Tilde
+  U_Combining_Double_Overline = 0x033f, //	U+033F	Combining Double Overline
+  U_Combining_Grave_Tone_Mark = 0x0340, //	U+0340	Combining Grave Tone Mark
+  U_Combining_Acute_Tone_Mark = 0x0341, //	U+0341	Combining Acute Tone Mark
+  U_Combining_Greek_Perispomeni = 0x0342, //	U+0342	Combining Greek Perispomeni
+  U_Combining_Greek_Koronis = 0x0343, //	U+0343	Combining Greek Koronis
+  U_Combining_Greek_Dialytika_Tonos = 0x0344, //	U+0344	Combining Greek Dialytika Tonos
+  U_Combining_Greek_Ypogegrammeni = 0x0345, //	U+0345	Combining Greek Ypogegrammeni
+  U_Combining_Bridge_Above = 0x0346, //	U+0346	Combining Bridge Above
+  U_Combining_Equals_Sign_Below = 0x0347, //	U+0347	Combining Equals Sign Below
+  U_Combining_Double_Vertical_Line_Below = 0x0348, //	U+0348	Combining Double Vertical Line Below
+  U_Combining_Left_Angle_Below = 0x0349, //	U+0349	Combining Left Angle Below
+  U_Combining_Not_Tilde_Above = 0x034a, //	U+034A	Combining Not Tilde Above
+  U_Combining_Homothetic_Above = 0x034b, //	U+034B	Combining Homothetic Above
+  U_Combining_Almost_Equal_To_Above = 0x034c, //	U+034C	Combining Almost Equal To Above
+  U_Combining_Left_Right_Arrow_Below = 0x034d, //	U+034D	Combining Left Right Arrow Below
+  U_Combining_Upwards_Arrow_Below = 0x034e, //	U+034E	Combining Upwards Arrow Below
+  U_Combining_Grapheme_Joiner = 0x034f, //	U+034F	Combining Grapheme Joiner
+  U_Combining_Right_Arrowhead_Above = 0x0350, //	U+0350	Combining Right Arrowhead Above
+  U_Combining_Left_Half_Ring_Above = 0x0351, //	U+0351	Combining Left Half Ring Above
+  U_Combining_Fermata = 0x0352, //	U+0352	Combining Fermata
+  U_Combining_X_Below = 0x0353, //	U+0353	Combining X Below
+  U_Combining_Left_Arrowhead_Below = 0x0354, //	U+0354	Combining Left Arrowhead Below
+  U_Combining_Right_Arrowhead_Below = 0x0355, //	U+0355	Combining Right Arrowhead Below
+  U_Combining_Right_Arrowhead_And_Up_Arrowhead_Below = 0x0356, //	U+0356	Combining Right Arrowhead And Up Arrowhead Below
+  U_Combining_Right_Half_Ring_Above = 0x0357, //	U+0357	Combining Right Half Ring Above
+  U_Combining_Dot_Above_Right = 0x0358, //	U+0358	Combining Dot Above Right
+  U_Combining_Asterisk_Below = 0x0359, //	U+0359	Combining Asterisk Below
+  U_Combining_Double_Ring_Below = 0x035a, //	U+035A	Combining Double Ring Below
+  U_Combining_Zigzag_Above = 0x035b, //	U+035B	Combining Zigzag Above
+  U_Combining_Double_Breve_Below = 0x035c, //	U+035C	Combining Double Breve Below
+  U_Combining_Double_Breve = 0x035d, //	U+035D	Combining Double Breve
+  U_Combining_Double_Macron = 0x035e, //	U+035E	Combining Double Macron
+  U_Combining_Double_Macron_Below = 0x035f, //	U+035F	Combining Double Macron Below
+  U_Combining_Double_Tilde = 0x0360, //	U+0360	Combining Double Tilde
+  U_Combining_Double_Inverted_Breve = 0x0361, //	U+0361	Combining Double Inverted Breve
+  U_Combining_Double_Rightwards_Arrow_Below = 0x0362, //	U+0362	Combining Double Rightwards Arrow Below
+  U_Combining_Latin_Small_Letter_A = 0x0363, //	U+0363	Combining Latin Small Letter A
+  U_Combining_Latin_Small_Letter_E = 0x0364, //	U+0364	Combining Latin Small Letter E
+  U_Combining_Latin_Small_Letter_I = 0x0365, //	U+0365	Combining Latin Small Letter I
+  U_Combining_Latin_Small_Letter_O = 0x0366, //	U+0366	Combining Latin Small Letter O
+  U_Combining_Latin_Small_Letter_U = 0x0367, //	U+0367	Combining Latin Small Letter U
+  U_Combining_Latin_Small_Letter_C = 0x0368, //	U+0368	Combining Latin Small Letter C
+  U_Combining_Latin_Small_Letter_D = 0x0369, //	U+0369	Combining Latin Small Letter D
+  U_Combining_Latin_Small_Letter_H = 0x036a, //	U+036A	Combining Latin Small Letter H
+  U_Combining_Latin_Small_Letter_M = 0x036b, //	U+036B	Combining Latin Small Letter M
+  U_Combining_Latin_Small_Letter_R = 0x036c, //	U+036C	Combining Latin Small Letter R
+  U_Combining_Latin_Small_Letter_T = 0x036d, //	U+036D	Combining Latin Small Letter T
+  U_Combining_Latin_Small_Letter_V = 0x036e, //	U+036E	Combining Latin Small Letter V
+  U_Combining_Latin_Small_Letter_X = 0x036f, //	U+036F	Combining Latin Small Letter X
+
+  /**
+   * Unicode Character 'LINE SEPARATOR' (U+2028)
+   * http://www.fileformat.info/info/unicode/char/2028/index.htm
+   */
+  LINE_SEPARATOR = 0x2028,
+  /**
+   * Unicode Character 'PARAGRAPH SEPARATOR' (U+2029)
+   * http://www.fileformat.info/info/unicode/char/2029/index.htm
+   */
+  PARAGRAPH_SEPARATOR = 0x2029,
+  /**
+   * Unicode Character 'NEXT LINE' (U+0085)
+   * http://www.fileformat.info/info/unicode/char/0085/index.htm
+   */
+  NEXT_LINE = 0x0085,
+
+  // http://www.fileformat.info/info/unicode/category/Sk/list.htm
+  U_CIRCUMFLEX = 0x005e, // U+005E	CIRCUMFLEX
+  U_GRAVE_ACCENT = 0x0060, // U+0060	GRAVE ACCENT
+  U_DIAERESIS = 0x00a8, // U+00A8	DIAERESIS
+  U_MACRON = 0x00af, // U+00AF	MACRON
+  U_ACUTE_ACCENT = 0x00b4, // U+00B4	ACUTE ACCENT
+  U_CEDILLA = 0x00b8, // U+00B8	CEDILLA
+  U_MODIFIER_LETTER_LEFT_ARROWHEAD = 0x02c2, // U+02C2	MODIFIER LETTER LEFT ARROWHEAD
+  U_MODIFIER_LETTER_RIGHT_ARROWHEAD = 0x02c3, // U+02C3	MODIFIER LETTER RIGHT ARROWHEAD
+  U_MODIFIER_LETTER_UP_ARROWHEAD = 0x02c4, // U+02C4	MODIFIER LETTER UP ARROWHEAD
+  U_MODIFIER_LETTER_DOWN_ARROWHEAD = 0x02c5, // U+02C5	MODIFIER LETTER DOWN ARROWHEAD
+  U_MODIFIER_LETTER_CENTRED_RIGHT_HALF_RING = 0x02d2, // U+02D2	MODIFIER LETTER CENTRED RIGHT HALF RING
+  U_MODIFIER_LETTER_CENTRED_LEFT_HALF_RING = 0x02d3, // U+02D3	MODIFIER LETTER CENTRED LEFT HALF RING
+  U_MODIFIER_LETTER_UP_TACK = 0x02d4, // U+02D4	MODIFIER LETTER UP TACK
+  U_MODIFIER_LETTER_DOWN_TACK = 0x02d5, // U+02D5	MODIFIER LETTER DOWN TACK
+  U_MODIFIER_LETTER_PLUS_SIGN = 0x02d6, // U+02D6	MODIFIER LETTER PLUS SIGN
+  U_MODIFIER_LETTER_MINUS_SIGN = 0x02d7, // U+02D7	MODIFIER LETTER MINUS SIGN
+  U_BREVE = 0x02d8, // U+02D8	BREVE
+  U_DOT_ABOVE = 0x02d9, // U+02D9	DOT ABOVE
+  U_RING_ABOVE = 0x02da, // U+02DA	RING ABOVE
+  U_OGONEK = 0x02db, // U+02DB	OGONEK
+  U_SMALL_TILDE = 0x02dc, // U+02DC	SMALL TILDE
+  U_DOUBLE_ACUTE_ACCENT = 0x02dd, // U+02DD	DOUBLE ACUTE ACCENT
+  U_MODIFIER_LETTER_RHOTIC_HOOK = 0x02de, // U+02DE	MODIFIER LETTER RHOTIC HOOK
+  U_MODIFIER_LETTER_CROSS_ACCENT = 0x02df, // U+02DF	MODIFIER LETTER CROSS ACCENT
+  U_MODIFIER_LETTER_EXTRA_HIGH_TONE_BAR = 0x02e5, // U+02E5	MODIFIER LETTER EXTRA-HIGH TONE BAR
+  U_MODIFIER_LETTER_HIGH_TONE_BAR = 0x02e6, // U+02E6	MODIFIER LETTER HIGH TONE BAR
+  U_MODIFIER_LETTER_MID_TONE_BAR = 0x02e7, // U+02E7	MODIFIER LETTER MID TONE BAR
+  U_MODIFIER_LETTER_LOW_TONE_BAR = 0x02e8, // U+02E8	MODIFIER LETTER LOW TONE BAR
+  U_MODIFIER_LETTER_EXTRA_LOW_TONE_BAR = 0x02e9, // U+02E9	MODIFIER LETTER EXTRA-LOW TONE BAR
+  U_MODIFIER_LETTER_YIN_DEPARTING_TONE_MARK = 0x02ea, // U+02EA	MODIFIER LETTER YIN DEPARTING TONE MARK
+  U_MODIFIER_LETTER_YANG_DEPARTING_TONE_MARK = 0x02eb, // U+02EB	MODIFIER LETTER YANG DEPARTING TONE MARK
+  U_MODIFIER_LETTER_UNASPIRATED = 0x02ed, // U+02ED	MODIFIER LETTER UNASPIRATED
+  U_MODIFIER_LETTER_LOW_DOWN_ARROWHEAD = 0x02ef, // U+02EF	MODIFIER LETTER LOW DOWN ARROWHEAD
+  U_MODIFIER_LETTER_LOW_UP_ARROWHEAD = 0x02f0, // U+02F0	MODIFIER LETTER LOW UP ARROWHEAD
+  U_MODIFIER_LETTER_LOW_LEFT_ARROWHEAD = 0x02f1, // U+02F1	MODIFIER LETTER LOW LEFT ARROWHEAD
+  U_MODIFIER_LETTER_LOW_RIGHT_ARROWHEAD = 0x02f2, // U+02F2	MODIFIER LETTER LOW RIGHT ARROWHEAD
+  U_MODIFIER_LETTER_LOW_RING = 0x02f3, // U+02F3	MODIFIER LETTER LOW RING
+  U_MODIFIER_LETTER_MIDDLE_GRAVE_ACCENT = 0x02f4, // U+02F4	MODIFIER LETTER MIDDLE GRAVE ACCENT
+  U_MODIFIER_LETTER_MIDDLE_DOUBLE_GRAVE_ACCENT = 0x02f5, // U+02F5	MODIFIER LETTER MIDDLE DOUBLE GRAVE ACCENT
+  U_MODIFIER_LETTER_MIDDLE_DOUBLE_ACUTE_ACCENT = 0x02f6, // U+02F6	MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT
+  U_MODIFIER_LETTER_LOW_TILDE = 0x02f7, // U+02F7	MODIFIER LETTER LOW TILDE
+  U_MODIFIER_LETTER_RAISED_COLON = 0x02f8, // U+02F8	MODIFIER LETTER RAISED COLON
+  U_MODIFIER_LETTER_BEGIN_HIGH_TONE = 0x02f9, // U+02F9	MODIFIER LETTER BEGIN HIGH TONE
+  U_MODIFIER_LETTER_END_HIGH_TONE = 0x02fa, // U+02FA	MODIFIER LETTER END HIGH TONE
+  U_MODIFIER_LETTER_BEGIN_LOW_TONE = 0x02fb, // U+02FB	MODIFIER LETTER BEGIN LOW TONE
+  U_MODIFIER_LETTER_END_LOW_TONE = 0x02fc, // U+02FC	MODIFIER LETTER END LOW TONE
+  U_MODIFIER_LETTER_SHELF = 0x02fd, // U+02FD	MODIFIER LETTER SHELF
+  U_MODIFIER_LETTER_OPEN_SHELF = 0x02fe, // U+02FE	MODIFIER LETTER OPEN SHELF
+  U_MODIFIER_LETTER_LOW_LEFT_ARROW = 0x02ff, // U+02FF	MODIFIER LETTER LOW LEFT ARROW
+  U_GREEK_LOWER_NUMERAL_SIGN = 0x0375, // U+0375	GREEK LOWER NUMERAL SIGN
+  U_GREEK_TONOS = 0x0384, // U+0384	GREEK TONOS
+  U_GREEK_DIALYTIKA_TONOS = 0x0385, // U+0385	GREEK DIALYTIKA TONOS
+  U_GREEK_KORONIS = 0x1fbd, // U+1FBD	GREEK KORONIS
+  U_GREEK_PSILI = 0x1fbf, // U+1FBF	GREEK PSILI
+  U_GREEK_PERISPOMENI = 0x1fc0, // U+1FC0	GREEK PERISPOMENI
+  U_GREEK_DIALYTIKA_AND_PERISPOMENI = 0x1fc1, // U+1FC1	GREEK DIALYTIKA AND PERISPOMENI
+  U_GREEK_PSILI_AND_VARIA = 0x1fcd, // U+1FCD	GREEK PSILI AND VARIA
+  U_GREEK_PSILI_AND_OXIA = 0x1fce, // U+1FCE	GREEK PSILI AND OXIA
+  U_GREEK_PSILI_AND_PERISPOMENI = 0x1fcf, // U+1FCF	GREEK PSILI AND PERISPOMENI
+  U_GREEK_DASIA_AND_VARIA = 0x1fdd, // U+1FDD	GREEK DASIA AND VARIA
+  U_GREEK_DASIA_AND_OXIA = 0x1fde, // U+1FDE	GREEK DASIA AND OXIA
+  U_GREEK_DASIA_AND_PERISPOMENI = 0x1fdf, // U+1FDF	GREEK DASIA AND PERISPOMENI
+  U_GREEK_DIALYTIKA_AND_VARIA = 0x1fed, // U+1FED	GREEK DIALYTIKA AND VARIA
+  U_GREEK_DIALYTIKA_AND_OXIA = 0x1fee, // U+1FEE	GREEK DIALYTIKA AND OXIA
+  U_GREEK_VARIA = 0x1fef, // U+1FEF	GREEK VARIA
+  U_GREEK_OXIA = 0x1ffd, // U+1FFD	GREEK OXIA
+  U_GREEK_DASIA = 0x1ffe, // U+1FFE	GREEK DASIA
+
+  U_OVERLINE = 0x203e, // Unicode Character 'OVERLINE'
+
+  /**
+   * UTF-8 BOM
+   * Unicode Character 'ZERO WIDTH NO-BREAK SPACE' (U+FEFF)
+   * http://www.fileformat.info/info/unicode/char/feff/index.htm
+   */
+  UTF8_BOM = 65279,
+}

--- a/src/languageservice/utils/indentationGuesser.ts
+++ b/src/languageservice/utils/indentationGuesser.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+//copied from https://github.com/Microsoft/vscode/blob/015c3afe96966df50c15a7d66be2ab0ef1dc5f49/src/vs/editor/common/model/indentationGuesser.ts
+
 import { CharCode } from './charCode';
 import { TextBuffer } from './textBuffer';
 

--- a/src/languageservice/utils/indentationGuesser.ts
+++ b/src/languageservice/utils/indentationGuesser.ts
@@ -1,0 +1,224 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CharCode } from './charCode';
+import { TextBuffer } from './textBuffer';
+
+class SpacesDiffResult {
+  public spacesDiff = 0;
+  public looksLikeAlignment = false;
+}
+
+/**
+ * Compute the diff in spaces between two line's indentation.
+ */
+function spacesDiff(a: string, aLength: number, b: string, bLength: number, result: SpacesDiffResult): void {
+  result.spacesDiff = 0;
+  result.looksLikeAlignment = false;
+
+  // This can go both ways (e.g.):
+  //  - a: "\t"
+  //  - b: "\t    "
+  //  => This should count 1 tab and 4 spaces
+
+  let i: number;
+
+  for (i = 0; i < aLength && i < bLength; i++) {
+    const aCharCode = a.charCodeAt(i);
+    const bCharCode = b.charCodeAt(i);
+
+    if (aCharCode !== bCharCode) {
+      break;
+    }
+  }
+
+  let aSpacesCnt = 0,
+    aTabsCount = 0;
+  for (let j = i; j < aLength; j++) {
+    const aCharCode = a.charCodeAt(j);
+    if (aCharCode === CharCode.Space) {
+      aSpacesCnt++;
+    } else {
+      aTabsCount++;
+    }
+  }
+
+  let bSpacesCnt = 0,
+    bTabsCount = 0;
+  for (let j = i; j < bLength; j++) {
+    const bCharCode = b.charCodeAt(j);
+    if (bCharCode === CharCode.Space) {
+      bSpacesCnt++;
+    } else {
+      bTabsCount++;
+    }
+  }
+
+  if (aSpacesCnt > 0 && aTabsCount > 0) {
+    return;
+  }
+  if (bSpacesCnt > 0 && bTabsCount > 0) {
+    return;
+  }
+
+  const tabsDiff = Math.abs(aTabsCount - bTabsCount);
+  const spacesDiff = Math.abs(aSpacesCnt - bSpacesCnt);
+
+  if (tabsDiff === 0) {
+    // check if the indentation difference might be caused by alignment reasons
+    // sometime folks like to align their code, but this should not be used as a hint
+    result.spacesDiff = spacesDiff;
+
+    if (spacesDiff > 0 && 0 <= bSpacesCnt - 1 && bSpacesCnt - 1 < a.length && bSpacesCnt < b.length) {
+      if (b.charCodeAt(bSpacesCnt) !== CharCode.Space && a.charCodeAt(bSpacesCnt - 1) === CharCode.Space) {
+        if (a.charCodeAt(a.length - 1) === CharCode.Comma) {
+          // This looks like an alignment desire: e.g.
+          // const a = b + c,
+          //       d = b - c;
+          result.looksLikeAlignment = true;
+        }
+      }
+    }
+    return;
+  }
+  if (spacesDiff % tabsDiff === 0) {
+    result.spacesDiff = spacesDiff / tabsDiff;
+    return;
+  }
+}
+
+/**
+ * Result for a guessIndentation
+ */
+export interface IGuessedIndentation {
+  /**
+   * If indentation is based on spaces (`insertSpaces` = true), then what is the number of spaces that make an indent?
+   */
+  tabSize: number;
+  /**
+   * Is indentation based on spaces?
+   */
+  insertSpaces: boolean;
+}
+
+export function guessIndentation(source: TextBuffer, defaultTabSize: number, defaultInsertSpaces: boolean): IGuessedIndentation {
+  // Look at most at the first 10k lines
+  const linesCount = Math.min(source.getLineCount(), 10000);
+
+  let linesIndentedWithTabsCount = 0; // number of lines that contain at least one tab in indentation
+  let linesIndentedWithSpacesCount = 0; // number of lines that contain only spaces in indentation
+
+  let previousLineText = ''; // content of latest line that contained non-whitespace chars
+  let previousLineIndentation = 0; // index at which latest line contained the first non-whitespace char
+
+  const ALLOWED_TAB_SIZE_GUESSES = [2, 4, 6, 8, 3, 5, 7]; // prefer even guesses for `tabSize`, limit to [2, 8].
+  const MAX_ALLOWED_TAB_SIZE_GUESS = 8; // max(ALLOWED_TAB_SIZE_GUESSES) = 8
+
+  const spacesDiffCount = [0, 0, 0, 0, 0, 0, 0, 0, 0]; // `tabSize` scores
+  const tmp = new SpacesDiffResult();
+
+  for (let lineNumber = 1; lineNumber <= linesCount; lineNumber++) {
+    const currentLineLength = source.getLineLength(lineNumber);
+    const currentLineText = source.getLineContent(lineNumber);
+
+    // if the text buffer is chunk based, so long lines are cons-string, v8 will flattern the string when we check charCode.
+    // checking charCode on chunks directly is cheaper.
+    const useCurrentLineText = currentLineLength <= 65536;
+
+    let currentLineHasContent = false; // does `currentLineText` contain non-whitespace chars
+    let currentLineIndentation = 0; // index at which `currentLineText` contains the first non-whitespace char
+    let currentLineSpacesCount = 0; // count of spaces found in `currentLineText` indentation
+    let currentLineTabsCount = 0; // count of tabs found in `currentLineText` indentation
+    for (let j = 0, lenJ = currentLineLength; j < lenJ; j++) {
+      const charCode = useCurrentLineText ? currentLineText.charCodeAt(j) : source.getLineCharCode(lineNumber, j);
+
+      if (charCode === CharCode.Tab) {
+        currentLineTabsCount++;
+      } else if (charCode === CharCode.Space) {
+        currentLineSpacesCount++;
+      } else {
+        // Hit non whitespace character on this line
+        currentLineHasContent = true;
+        currentLineIndentation = j;
+        break;
+      }
+    }
+
+    // Ignore empty or only whitespace lines
+    if (!currentLineHasContent) {
+      continue;
+    }
+
+    if (currentLineTabsCount > 0) {
+      linesIndentedWithTabsCount++;
+    } else if (currentLineSpacesCount > 1) {
+      linesIndentedWithSpacesCount++;
+    }
+
+    spacesDiff(previousLineText, previousLineIndentation, currentLineText, currentLineIndentation, tmp);
+
+    if (tmp.looksLikeAlignment) {
+      // if defaultInsertSpaces === true && the spaces count == tabSize, we may want to count it as valid indentation
+      //
+      // - item1
+      //   - item2
+      //
+      // otherwise skip this line entirely
+      //
+      // const a = 1,
+      //       b = 2;
+
+      if (!(defaultInsertSpaces && defaultTabSize === tmp.spacesDiff)) {
+        continue;
+      }
+    }
+
+    const currentSpacesDiff = tmp.spacesDiff;
+    if (currentSpacesDiff <= MAX_ALLOWED_TAB_SIZE_GUESS) {
+      spacesDiffCount[currentSpacesDiff]++;
+    }
+
+    previousLineText = currentLineText;
+    previousLineIndentation = currentLineIndentation;
+  }
+
+  let insertSpaces = defaultInsertSpaces;
+  if (linesIndentedWithTabsCount !== linesIndentedWithSpacesCount) {
+    insertSpaces = linesIndentedWithTabsCount < linesIndentedWithSpacesCount;
+  }
+
+  let tabSize = defaultTabSize;
+
+  // Guess tabSize only if inserting spaces...
+  if (insertSpaces) {
+    let tabSizeScore = insertSpaces ? 0 : 0.1 * linesCount;
+
+    // console.log("score threshold: " + tabSizeScore);
+
+    ALLOWED_TAB_SIZE_GUESSES.forEach((possibleTabSize) => {
+      const possibleTabSizeScore = spacesDiffCount[possibleTabSize];
+      if (possibleTabSizeScore > tabSizeScore) {
+        tabSizeScore = possibleTabSizeScore;
+        tabSize = possibleTabSize;
+      }
+    });
+
+    // Let a tabSize of 2 win even if it is not the maximum
+    // (only in case 4 was guessed)
+    if (tabSize === 4 && spacesDiffCount[4] > 0 && spacesDiffCount[2] > 0 && spacesDiffCount[2] >= spacesDiffCount[4] / 2) {
+      tabSize = 2;
+    }
+  }
+
+  // console.log('--------------------------');
+  // console.log('linesIndentedWithTabsCount: ' + linesIndentedWithTabsCount + ', linesIndentedWithSpacesCount: ' + linesIndentedWithSpacesCount);
+  // console.log('spacesDiffCount: ' + spacesDiffCount);
+  // console.log('tabSize: ' + tabSize + ', tabSizeScore: ' + tabSizeScore);
+
+  return {
+    insertSpaces: insertSpaces,
+    tabSize: tabSize,
+  };
+}

--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -6,6 +6,10 @@
 import { TextDocument } from 'vscode-languageserver';
 import { Range } from 'vscode-languageserver-types';
 
+interface FullTextDocument {
+  getLineOffsets(): number[];
+}
+
 export class TextBuffer {
   constructor(private doc: TextDocument) {}
 
@@ -14,8 +18,7 @@ export class TextBuffer {
   }
 
   getLineLength(lineNumber: number): number {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const lineOffsets: number[] = (this.doc as any).getLineOffsets();
+    const lineOffsets = ((this.doc as unknown) as FullTextDocument).getLineOffsets();
     if (lineNumber >= lineOffsets.length) {
       return this.doc.getText().length;
     } else if (lineNumber < 0) {
@@ -27,8 +30,7 @@ export class TextBuffer {
   }
 
   getLineContent(lineNumber: number): string {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const lineOffsets: number[] = (this.doc as any).getLineOffsets();
+    const lineOffsets = ((this.doc as unknown) as FullTextDocument).getLineOffsets();
     if (lineNumber >= lineOffsets.length) {
       return this.doc.getText();
     } else if (lineNumber < 0) {

--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -1,0 +1,45 @@
+import { SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION } from 'constants';
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocument } from 'vscode-languageserver';
+import { Range } from 'vscode-languageserver-types';
+
+export class TextBuffer {
+  constructor(private doc: TextDocument) {}
+
+  getLineCount(): number {
+    return this.doc.lineCount;
+  }
+
+  getLineLength(lineNumber: number): number {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lineOffsets: number[] = (this.doc as any).getLineOffsets();
+    if (lineNumber >= lineOffsets.length) {
+      return this.doc.getText().length;
+    } else if (lineNumber < 0) {
+      return 0;
+    }
+
+    const nextLineOffset = lineNumber + 1 < lineOffsets.length ? lineOffsets[lineNumber + 1] : this.doc.getText().length;
+    return nextLineOffset - lineOffsets[lineNumber];
+  }
+
+  getLineContent(lineNumber: number): string {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lineOffsets: number[] = (this.doc as any).getLineOffsets();
+    if (lineNumber >= lineOffsets.length) {
+      return this.doc.getText();
+    } else if (lineNumber < 0) {
+      return '';
+    }
+    const nextLineOffset = lineNumber + 1 < lineOffsets.length ? lineOffsets[lineNumber + 1] : this.doc.getText().length;
+    return this.doc.getText().substring(lineOffsets[lineNumber], nextLineOffset);
+  }
+
+  getLineCharCode(lineNumber: number, index: number): number {
+    return this.doc.getText(Range.create(lineNumber - 1, index - 1, lineNumber - 1, index)).charCodeAt(0);
+  }
+}

--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -1,4 +1,3 @@
-import { SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION } from 'constants';
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -36,6 +36,10 @@ export interface LanguageSettings {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   schemas?: any[]; //List of schemas,
   customTags?: Array<string>; //Array of Custom Tags
+  /**
+   * Default indentation size
+   */
+  indentation?: string;
 }
 
 export interface PromiseConstructor {

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,7 +88,7 @@ interface Settings {
     proxyStrictSSL: boolean;
   };
   editor: {
-    tabSize: string;
+    tabSize: number;
   };
 }
 
@@ -511,8 +511,8 @@ connection.onDidChangeConfiguration((change) => {
 
   schemaConfigurationSettings = [];
 
-  if (settings.editor.tabSize) {
-    indentation = settings.editor.tabSize;
+  if (settings.editor?.tabSize) {
+    indentation = ' '.repeat(settings.editor.tabSize);
   }
 
   for (const uri in yamlConfigurationSettings) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,9 @@ interface Settings {
     proxy: string;
     proxyStrictSSL: boolean;
   };
+  editor: {
+    tabSize: string;
+  };
 }
 
 interface JSONSchemaSettings {
@@ -118,6 +121,7 @@ let yamlShouldCompletion = true;
 let schemaStoreSettings = [];
 let customTags = [];
 let schemaStoreEnabled = true;
+let indentation: string | undefined = undefined;
 
 // File validation helpers
 const pendingValidationRequests: { [uri: string]: NodeJS.Timer } = {};
@@ -219,6 +223,7 @@ function updateConfiguration(): void {
     schemas: [],
     customTags: customTags,
     format: yamlFormatterSettings.enable,
+    indentation: indentation,
   };
 
   if (schemaAssociations) {
@@ -505,6 +510,10 @@ connection.onDidChangeConfiguration((change) => {
   }
 
   schemaConfigurationSettings = [];
+
+  if (settings.editor.tabSize) {
+    indentation = settings.editor.tabSize;
+  }
 
   for (const uri in yamlConfigurationSettings) {
     const globPattern = yamlConfigurationSettings[uri];

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -79,7 +79,7 @@ suite('Default Snippet Tests', () => {
           assert.equal(result.items.length, 2);
           assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
           assert.equal(result.items[0].label, 'Object item');
-          assert.equal(result.items[1].insertText, 'key:\n\t$1');
+          assert.equal(result.items[1].insertText, 'key:\n  $1');
           assert.equal(result.items[1].label, 'key');
         })
         .then(done, done);
@@ -93,7 +93,7 @@ suite('Default Snippet Tests', () => {
           assert.notEqual(result.items.length, 0);
           assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
           assert.equal(result.items[0].label, 'Object item');
-          assert.equal(result.items[1].insertText, 'key:\n\t$1');
+          assert.equal(result.items[1].insertText, 'key:\n  $1');
           assert.equal(result.items[1].label, 'key');
         })
         .then(done, done);

--- a/test/textBuffer.test.ts
+++ b/test/textBuffer.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextBuffer } from '../src/languageservice/utils/textBuffer';
+import { TextDocument } from 'vscode-languageserver';
+import * as assert from 'assert';
+
+suite('TextBuffer', () => {
+  test('getLineLength should return actual line length', () => {
+    const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\nbar'));
+    const length = buffer.getLineLength(0);
+    assert.strictEqual(length, 4);
+    const length2 = buffer.getLineLength(1);
+    assert.strictEqual(length2, 3);
+  });
+
+  test('getLineLength should return actual line length, win style', () => {
+    const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\r\nbar'));
+    const length = buffer.getLineLength(0);
+    assert.strictEqual(length, 5);
+    const length2 = buffer.getLineLength(1);
+    assert.strictEqual(length2, 3);
+  });
+
+  test('getLineContent should return actual line content', () => {
+    const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\nbar\nfooBar\nsome'));
+    const line = buffer.getLineContent(1);
+    assert.strictEqual(line, 'bar\n');
+  });
+
+  test('getLineContent should return last line', () => {
+    const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\nbar\nfooBar\nsome'));
+    const line = buffer.getLineContent(3);
+    assert.strictEqual(line, 'some');
+  });
+
+  test('getLineCharCode should return charCode', () => {
+    const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\nbar\nfooBar\nsome'));
+    const charCode = buffer.getLineCharCode(3, 4);
+    assert.strictEqual(charCode, 'B'.charCodeAt(0));
+  });
+});

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -17,6 +17,7 @@ export class ServiceSetup {
     isKubernetes: false,
     schemas: [],
     customTags: [],
+    indentation: undefined,
   };
 
   withValidate(): ServiceSetup {
@@ -51,6 +52,11 @@ export class ServiceSetup {
 
   withCustomTags(customTags: string[]): ServiceSetup {
     this.languageSettings.customTags = customTags;
+    return this;
+  }
+
+  withIndentation(indentation: string): ServiceSetup {
+    this.languageSettings.indentation = indentation;
     return this;
   }
 }


### PR DESCRIPTION
This PR replace hardcoded `\t` character in completion snippets.
It try to take space preference, if it not defined, it try to detect indentation by file content, if it is not possible it use double space for completion text indentation.

Fix: #283