### PR TITLE
Set true for documentFormattingProvider

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -411,7 +411,7 @@ connection.onInitialize(
         completionProvider: { resolveProvider: true },
         hoverProvider: true,
         documentSymbolProvider: true,
-        documentFormattingProvider: false,
+        documentFormattingProvider: true,
         documentRangeFormattingProvider: false,
         definitionProvider: true,
         workspace: {


### PR DESCRIPTION
I'm not sure why yaml-language-server return documentFormattingProvider: false, but I make sure formatting is working with my small modification.