### PR TITLE
Fix completion indentation for object in array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -149,7 +149,7 @@ export class YAMLCompletion extends JSONCompletion {
           suggestion.label = label;
           proposed[label] = suggestion;
           result.items.push(suggestion);
-        } else if (!existing.documentation) {
+        } else if (!existing.documentation && suggestion.documentation) {
           existing.documentation = suggestion.documentation;
         }
       },
@@ -260,7 +260,7 @@ export class YAMLCompletion extends JSONCompletion {
     addValue: boolean,
     separatorAfter: string,
     collector: CompletionsCollector,
-    document
+    document: TextDocument
   ): void {
     const matchingSchemas = doc.getMatchingSchemas(schema.schema);
     matchingSchemas.forEach((s) => {
@@ -723,12 +723,7 @@ export class YAMLCompletion extends JSONCompletion {
             break;
           case 'array':
             {
-              const arrayInsertResult = this.getInsertTextForArray(
-                propertySchema.items,
-                separatorAfter,
-                `${indent}${this.indentation}`,
-                insertIndex++
-              );
+              const arrayInsertResult = this.getInsertTextForArray(propertySchema.items, separatorAfter, insertIndex++);
               insertIndex = arrayInsertResult.insertIndex;
               insertText += `${indent}${key}:\n${indent}${this.indentation}- ${arrayInsertResult.insertText}\n`;
             }
@@ -769,7 +764,7 @@ export class YAMLCompletion extends JSONCompletion {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getInsertTextForArray(schema: any, separatorAfter: string, indent = this.indentation, insertIndex = 1): InsertText {
+  private getInsertTextForArray(schema: any, separatorAfter: string, insertIndex = 1): InsertText {
     let insertText = '';
     if (!schema) {
       insertText = `$${insertIndex++}`;
@@ -797,12 +792,7 @@ export class YAMLCompletion extends JSONCompletion {
         break;
       case 'object':
         {
-          const objectInsertResult = this.getInsertTextForObject(
-            schema,
-            separatorAfter,
-            `${indent}${this.indentation}`,
-            insertIndex++
-          );
+          const objectInsertResult = this.getInsertTextForObject(schema, separatorAfter, `${this.indentation}  `, insertIndex++);
           insertText = objectInsertResult.insertText.trimLeft();
           insertIndex = objectInsertResult.insertIndex;
         }
@@ -864,7 +854,7 @@ export class YAMLCompletion extends JSONCompletion {
         return `${resultText}\n${this.getInsertTextForObject(propertySchema, separatorAfter, ident).insertText}`;
       } else if (propertySchema.items) {
         return `${resultText}\n${this.indentation}- ${
-          this.getInsertTextForArray(propertySchema.items, separatorAfter, ident).insertText
+          this.getInsertTextForArray(propertySchema.items, separatorAfter).insertText
         }`;
       }
       if (nValueProposals === 0) {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -149,7 +149,7 @@ export class YAMLCompletion extends JSONCompletion {
           suggestion.label = label;
           proposed[label] = suggestion;
           result.items.push(suggestion);
-        } else if (!existing.documentation && suggestion.documentation) {
+        } else if (!existing.documentation) {
           existing.documentation = suggestion.documentation;
         }
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -511,7 +511,9 @@ connection.onDidChangeConfiguration((change) => {
 
   schemaConfigurationSettings = [];
 
-  if (settings.editor?.tabSize) {
+  if (settings['[yaml]'] && settings['[yaml]']['editor.tabSize']) {
+    indentation = ' '.repeat(settings['[yaml]']['editor.tabSize']);
+  } else if (settings.editor?.tabSize) {
     indentation = ' '.repeat(settings.editor.tabSize);
   }
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1008,6 +1008,162 @@ suite('Auto Completion Tests', () => {
           })
           .then(done, done);
       });
+
+      it('Array of objects autocomplete with 4 space indentation check', async () => {
+        const languageSettingsSetup = new ServiceSetup().withCompletion().withIndentation('    ');
+        languageService.configure(languageSettingsSetup.languageSettings);
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            metadata: {
+              type: 'object',
+              properties: {
+                ownerReferences: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      apiVersion: {
+                        type: 'string',
+                      },
+                      kind: {
+                        type: 'string',
+                      },
+                      name: {
+                        type: 'string',
+                      },
+                      uid: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['apiVersion', 'kind', 'name', 'uid'],
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const content = 'metadata:\n    ownerReferences';
+        const completion = await parseSetup(content, 29);
+        expect(completion.items[0]).deep.eq(
+          createExpectedCompletion(
+            'ownerReferences',
+            'ownerReferences:\n    - apiVersion: $1\n      kind: $2\n      name: $3\n      uid: $4',
+            1,
+            4,
+            1,
+            19,
+            10,
+            2,
+            { documentation: '' }
+          )
+        );
+      });
+    });
+
+    it('Array of objects autocomplete with 2 space indentation check', async () => {
+      const languageSettingsSetup = new ServiceSetup().withCompletion().withIndentation('  ');
+      languageService.configure(languageSettingsSetup.languageSettings);
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          metadata: {
+            type: 'object',
+            properties: {
+              ownerReferences: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    apiVersion: {
+                      type: 'string',
+                    },
+                    kind: {
+                      type: 'string',
+                    },
+                    name: {
+                      type: 'string',
+                    },
+                    uid: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['apiVersion', 'kind', 'name', 'uid'],
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const content = 'metadata:\n  ownerReferences';
+      const completion = await parseSetup(content, 27);
+      expect(completion.items[0]).deep.eq(
+        createExpectedCompletion(
+          'ownerReferences',
+          'ownerReferences:\n  - apiVersion: $1\n    kind: $2\n    name: $3\n    uid: $4',
+          1,
+          2,
+          1,
+          17,
+          10,
+          2,
+          { documentation: '' }
+        )
+      );
+
+      it('Array of objects autocomplete with 3 space indentation check', async () => {
+        const languageSettingsSetup = new ServiceSetup().withCompletion().withIndentation('   ');
+        languageService.configure(languageSettingsSetup.languageSettings);
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            metadata: {
+              type: 'object',
+              properties: {
+                ownerReferences: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      apiVersion: {
+                        type: 'string',
+                      },
+                      kind: {
+                        type: 'string',
+                      },
+                      name: {
+                        type: 'string',
+                      },
+                      uid: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['apiVersion', 'kind', 'name', 'uid'],
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const content = 'metadata:\n   ownerReferences';
+        const completion = await parseSetup(content, 27);
+        expect(completion.items[0]).deep.eq(
+          createExpectedCompletion(
+            'ownerReferences',
+            'ownerReferences:\n   - apiVersion: $1\n     kind: $2\n     name: $3\n     uid: $4',
+            1,
+            2,
+            1,
+            17,
+            10,
+            2,
+            { documentation: '' }
+          )
+        );
+      });
     });
 
     describe('JSON Schema 7 Specific Tests', function () {


### PR DESCRIPTION
This is firs PR, fix completion snippet generation for object in array. We also have problem with settings synchronisation, in case if `editor.tabSize` set up in language scope `[yaml]` we not take in account it. This PR fix that, but it also requires fix in `vscode-yaml` which I'm going to provide.

For #329