### PR TITLE
Fix 'yarn pack', remove unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,12 @@
-src/
-test/
+/src
+/test
 .editorconfig
 Jenkinsfile
 tsconfig.json
+.nyc_output/
+coverage/
+.vscode/
+.github/
+.eslintrc.js
+.prettierrc.json
+.travis.yml


### PR DESCRIPTION
With https://github.com/redhat-developer/yaml-language-server/pull/333 we use `yarn` to publish `next` version.
Before and now, we use [`npm`](https://github.com/redhat-developer/yaml-language-server/blob/master/.travis.yml#L16) to publish release version on LS. And there are [some difference](https://github.com/yarnpkg/yarn/issues/754) between `npm` and `yarn` on packaging, that difference cause that `out/server/*` was not included with `yarn` packaging, but it included by `npm`. 
This PR just fix that, and also remove some unnecessary files from npm package.