### PR TITLE
Add isKubernetes option to doHover

### DIFF
--- a/src/languageservice/parser/isKubernetes.ts
+++ b/src/languageservice/parser/isKubernetes.ts
@@ -1,0 +1,7 @@
+import * as Parser from './jsonParser07';
+
+export function setKubernetesParserOption(jsonDocuments: Parser.JSONDocument[], option: boolean): void {
+  for (const jsonDoc of jsonDocuments) {
+    jsonDoc.isKubernetes = option;
+  }
+}

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -30,6 +30,7 @@ import { ClientCapabilities } from 'vscode-languageserver-protocol';
 import { stringifyObject, StringifySettings } from '../utils/json';
 import { guessIndentation } from '../utils/indentationGuesser';
 import { TextBuffer } from '../utils/textBuffer';
+import { setKubernetesParserOption } from '../parser/isKubernetes';
 const localize = nls.loadMessageBundle();
 
 export class YAMLCompletion extends JSONCompletion {
@@ -94,7 +95,7 @@ export class YAMLCompletion extends JSONCompletion {
     } else {
       this.indentation = this.configuredIndentation;
     }
-    this.setKubernetesParserOption(doc.documents, isKubernetes);
+    setKubernetesParserOption(doc.documents, isKubernetes);
 
     const offset = document.offsetAt(position);
     if (document.getText()[offset] === ':') {
@@ -1005,13 +1006,6 @@ export class YAMLCompletion extends JSONCompletion {
 
   private is_EOL(c: number): boolean {
     return c === 0x0a /* LF */ || c === 0x0d /* CR */;
-  }
-
-  // Called by onCompletion
-  private setKubernetesParserOption(jsonDocuments: Parser.JSONDocument[], option: boolean): void {
-    for (const jsonDoc in jsonDocuments) {
-      jsonDocuments[jsonDoc].isKubernetes = option;
-    }
   }
 }
 

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -12,6 +12,7 @@ import { LanguageSettings } from '../yamlLanguageService';
 import { parse as parseYAML } from '../parser/yamlParser07';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { JSONHover } from 'vscode-json-languageservice/lib/umd/services/jsonHover';
+import { setKubernetesParserOption } from '../parser/isKubernetes';
 
 export class YAMLHover {
   private promise: PromiseConstructor;
@@ -30,7 +31,7 @@ export class YAMLHover {
     }
   }
 
-  public doHover(document: TextDocument, position: Position): Thenable<Hover> {
+  public doHover(document: TextDocument, position: Position, isKubernetes = false): Thenable<Hover> {
     if (!this.shouldHover || !document) {
       return this.promise.resolve(undefined);
     }
@@ -41,6 +42,7 @@ export class YAMLHover {
       return this.promise.resolve(undefined);
     }
 
+    setKubernetesParserOption(doc.documents, isKubernetes);
     const currentDocIndex = doc.documents.indexOf(currentDoc);
     currentDoc.currentDocIndex = currentDocIndex;
     return this.jsonHover.doHover(document, position, currentDoc);


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR adds isKubernetes option to doHover. Basically what isKubernetes does is allows you to use a [special comparator](https://github.com/redhat-developer/yaml-language-server/blob/master/src/languageservice/parser/jsonParser07.ts#L585)  when evaluating oneOf/anyOf. This is needed because the [generic comparator](https://github.com/redhat-developer/yaml-language-server/blob/master/src/languageservice/parser/jsonParser07.ts#L1243) provided works well in the general case but breaks down when you have a ton of anyOf/oneOf like in the kubernetes schema: 

### What issues does this PR fix or reference?
Part of https://bugzilla.redhat.com/show_bug.cgi?id=1888874

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
You'll need to set isKubernetes=true in yamlHover.ts before building then set:
```
"yaml.schemas": {
 "https://gist.githubusercontent.com/JPinkney/fbbb95f3708e8b33f81267b243981ff6/raw/09af433aff3972f5d72cfe5c69951e94c1497875/kubernetes-console.json": "test.yaml"
}
```
and use:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
```
as the yaml. Then hover over replicas, selector, etc and see that the hover is working as expected

I can write a test but the json schema for kubernetes is 70000 lines long so I could either have the test pull from the URL specified above or bring the schema into the project though checkout times would increase. 