### PR TITLE
Rename all applicable Thenables to Promise

### DIFF
--- a/src/languageservice/services/schemaRequestHandler.ts
+++ b/src/languageservice/services/schemaRequestHandler.ts
@@ -3,14 +3,14 @@ import { IConnection } from 'vscode-languageserver';
 import { xhr, XHRResponse, getErrorStatusDescription } from 'request-light';
 import * as fs from 'fs';
 
-import { VSCodeContentRequest, CustomSchemaContentRequest } from '../../requestTypes';
+import { CustomSchemaContentRequest } from '../../requestTypes';
 import { isRelativePath, relativeToAbsolutePath } from '../utils/paths';
 
 /**
  * Handles schema content requests given the schema URI
  * @param uri can be a local file, vscode request, http(s) request or a custom request
  */
-export const schemaRequestHandler = (connection: IConnection, uri: string): Thenable<string> => {
+export const schemaRequestHandler = (connection: IConnection, uri: string): Promise<string> => {
   if (!uri) {
     return Promise.reject('No schema specified');
   }
@@ -45,20 +45,6 @@ export const schemaRequestHandler = (connection: IConnection, uri: string): Then
     });
   }
 
-  // vscode schema content requests are forwarded to the client through LSP
-  // This is a non-standard LSP extension introduced by the JSON language server
-  // See https://github.com/microsoft/vscode/blob/master/extensions/json-language-features/server/README.md
-  if (scheme === 'vscode') {
-    return connection.sendRequest(VSCodeContentRequest.type, uri).then(
-      (responseText) => {
-        return responseText;
-      },
-      (error) => {
-        return error.message;
-      }
-    );
-  }
-
   // HTTP(S) requests are sent and the response result is either the schema content or an error
   if (scheme === 'http' || scheme === 'https') {
     // Send the HTTP(S) schema content request and return the result
@@ -74,5 +60,5 @@ export const schemaRequestHandler = (connection: IConnection, uri: string): Then
   }
 
   // Neither local file nor vscode, nor HTTP(S) schema request, so send it off as a custom request
-  return connection.sendRequest(CustomSchemaContentRequest.type, uri) as Thenable<string>;
+  return connection.sendRequest(CustomSchemaContentRequest.type, uri) as Promise<string>;
 };

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -10,7 +10,7 @@ import { ASTNode, ObjectASTNode, PropertyASTNode } from '../jsonASTTypes';
 import { parse as parseYAML } from '../parser/yamlParser07';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
-import { Thenable, CompletionsCollector } from 'vscode-json-languageservice';
+import { CompletionsCollector } from 'vscode-json-languageservice';
 import {
   CompletionItem,
   CompletionItemKind,
@@ -54,7 +54,7 @@ export class YAMLCompletion extends JSONCompletion {
     this.configuredIndentation = languageSettings.indentation;
   }
 
-  public doComplete(document: TextDocument, position: Position, isKubernetes = false): Thenable<CompletionList> {
+  public doComplete(document: TextDocument, position: Position, isKubernetes = false): Promise<CompletionList> {
     const result: CompletionList = {
       items: [],
       isIncomplete: false,
@@ -157,7 +157,7 @@ export class YAMLCompletion extends JSONCompletion {
       const newSchema = schema;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const collectionPromises: Thenable<any>[] = [];
+      const collectionPromises: Promise<any>[] = [];
 
       let addValue = true;
 

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -5,7 +5,6 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { Thenable } from 'vscode-json-languageservice';
 import { Hover, TextDocument, Position } from 'vscode-languageserver-types';
 import { matchOffsetToDocument } from '../utils/arrUtils';
 import { LanguageSettings } from '../yamlLanguageService';
@@ -29,7 +28,7 @@ export class YAMLHover {
     }
   }
 
-  public doHover(document: TextDocument, position: Position, isKubernetes = false): Thenable<Hover> {
+  public doHover(document: TextDocument, position: Position, isKubernetes = false): Promise<Hover> {
     if (!this.shouldHover || !document) {
       return Promise.resolve(undefined);
     }

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -7,7 +7,7 @@ import { parse as parseYAML } from '../parser/yamlParser07';
 import { findLinks as JSONFindLinks } from 'vscode-json-languageservice/lib/umd/services/jsonLinks';
 import { DocumentLink } from 'vscode-languageserver';
 
-export function findLinks(document: TextDocument): Thenable<DocumentLink[]> {
+export function findLinks(document: TextDocument): Promise<DocumentLink[]> {
   const doc = parseYAML(document.getText());
   // Find links across all YAML Documents then report them back once finished
   const linkPromises = [];

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { JSONSchema, JSONSchemaMap, JSONSchemaRef } from '../jsonSchema';
-import { SchemaRequestService, WorkspaceContextService, PromiseConstructor, Thenable } from '../yamlLanguageService';
+import { SchemaRequestService, WorkspaceContextService } from '../yamlLanguageService';
 import {
   UnresolvedSchema,
   ResolvedSchema,
@@ -26,7 +26,7 @@ import * as yaml from 'js-yaml';
 
 const localize = nls.loadMessageBundle();
 
-export declare type CustomSchemaProvider = (uri: string) => Thenable<string | string[]>;
+export declare type CustomSchemaProvider = (uri: string) => Promise<string | string[]>;
 
 export enum MODIFICATION_ACTIONS {
   'delete',
@@ -105,7 +105,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     schemaToResolve: UnresolvedSchema,
     schemaURL: string,
     dependencies: SchemaDependencies
-  ): Thenable<ResolvedSchema> {
+  ): Promise<ResolvedSchema> {
     const resolveErrors: string[] = schemaToResolve.errors.slice(0);
     const schema = schemaToResolve.schema;
     const contextService = this.contextService;
@@ -147,7 +147,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       parentSchemaURL: string,
       parentSchemaDependencies: SchemaDependencies
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ): Thenable<any> => {
+    ): Promise<any> => {
       if (contextService && !/^\w+:\/\/.*/.test(uri)) {
         uri = contextService.resolveRelativePath(uri, parentSchemaURL);
       }
@@ -174,7 +174,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       parentSchemaURL: string,
       parentSchemaDependencies: SchemaDependencies
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ): Thenable<any> => {
+    ): Promise<any> => {
       if (!node || typeof node !== 'object') {
         return Promise.resolve(null);
       }
@@ -183,7 +183,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       const seen: JSONSchema[] = [];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const openPromises: Thenable<any>[] = [];
+      const openPromises: Promise<any>[] = [];
 
       const collectEntries = (...entries: JSONSchemaRef[]): void => {
         for (const entry of entries) {
@@ -262,7 +262,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     });
   }
 
-  public getSchemaForResource(resource: string, doc: JSONDocument): Thenable<ResolvedSchema> {
+  public getSchemaForResource(resource: string, doc: JSONDocument): Promise<ResolvedSchema> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const resolveSchema = (): any => {
       const seen: { [schemaId: string]: boolean } = Object.create(null);

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -507,7 +507,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     return super.getOrAddSchemaHandle(id, unresolvedSchemaContent);
   }
 
-  loadSchema(schemaUri: string): Thenable<UnresolvedSchema> {
+  loadSchema(schemaUri: string): Promise<UnresolvedSchema> {
     const requestService = this.requestService;
     return super.loadSchema(schemaUri).then((unresolvedJsonSchema: UnresolvedSchema) => {
       // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
@@ -570,7 +570,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     return super.getRegisteredSchemaIds(filter);
   }
 
-  getResolvedSchema(schemaId: string): Thenable<ResolvedSchema> {
+  getResolvedSchema(schemaId: string): Promise<ResolvedSchema> {
     return super.getResolvedSchema(schemaId);
   }
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -23,7 +23,7 @@ import { YAMLHover } from './services/yamlHover';
 import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { JSONWorkerContribution, JSONDocument, DefinitionLink } from 'vscode-json-languageservice';
+import { JSONDocument, DefinitionLink } from 'vscode-json-languageservice';
 import { findLinks } from './services/yamlLinks';
 
 export interface LanguageSettings {
@@ -41,56 +41,6 @@ export interface LanguageSettings {
   indentation?: string;
 }
 
-export interface PromiseConstructor {
-  /**
-   * Creates a new Promise.
-   * @param executor A callback used to initialize the promise. This callback is passed two arguments:
-   * a resolve callback used resolve the promise with a value or the result of another promise,
-   * and a reject callback used to reject the promise with a provided reason or error.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  new <T>(executor: (resolve: (value?: T | Thenable<T>) => void, reject: (reason?: any) => void) => void): Thenable<T>;
-
-  /**
-   * Creates a Promise that is resolved with an array of results when all of the provided Promises
-   * resolve, or rejected when any Promise is rejected.
-   * @param values An array of Promises.
-   * @returns A new Promise.
-   */
-  all<T>(values: Array<T | Thenable<T>>): Thenable<T[]>;
-  /**
-   * Creates a new rejected promise for the provided reason.
-   * @param reason The reason the promise was rejected.
-   * @returns A new rejected Promise.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  reject<T>(reason: any): Thenable<T>;
-
-  /**
-   * Creates a new resolved promise for the provided value.
-   * @param value A promise.
-   * @returns A promise whose internal state matches the provided promise.
-   */
-  resolve<T>(value: T | Thenable<T>): Thenable<T>;
-}
-
-export interface Thenable<R> {
-  /**
-   * Attaches callbacks for the resolution and/or rejection of the Promise.
-   * @param onfulfilled The callback to execute when the Promise is resolved.
-   * @param onrejected The callback to execute when the Promise is rejected.
-   * @returns A Promise for the completion of which ever callback is executed.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  then<TResult>(
-    onfulfilled?: (value: R) => TResult | Thenable<TResult>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onrejected?: (reason: any) => TResult | Thenable<TResult>
-  ): Thenable<TResult>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  then<TResult>(onfulfilled?: (value: R) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
-}
-
 export interface WorkspaceContextService {
   resolveRelativePath(relativePath: string, resource: string): string;
 }
@@ -99,7 +49,7 @@ export interface WorkspaceContextService {
  * in case of an error, a displayable error string
  */
 export interface SchemaRequestService {
-  (uri: string): Thenable<string>;
+  (uri: string): Promise<string>;
 }
 
 export interface SchemaConfiguration {
@@ -129,13 +79,13 @@ export interface CustomFormatterOptions {
 export interface LanguageService {
   configure(settings: LanguageSettings): void;
   registerCustomSchemaProvider(schemaProvider: CustomSchemaProvider): void;
-  doComplete(document: TextDocument, position: Position, isKubernetes: boolean): Thenable<CompletionList>;
-  doValidation(document: TextDocument, isKubernetes: boolean): Thenable<Diagnostic[]>;
-  doHover(document: TextDocument, position: Position): Thenable<Hover | null>;
+  doComplete(document: TextDocument, position: Position, isKubernetes: boolean): Promise<CompletionList>;
+  doValidation(document: TextDocument, isKubernetes: boolean): Promise<Diagnostic[]>;
+  doHover(document: TextDocument, position: Position): Promise<Hover | null>;
   findDocumentSymbols(document: TextDocument): SymbolInformation[];
   findDocumentSymbols2(document: TextDocument): DocumentSymbol[];
-  findDefinition(document: TextDocument, position: Position, doc: JSONDocument): Thenable<DefinitionLink[]>;
-  findLinks(document: TextDocument): Thenable<DocumentLink[]>;
+  findDefinition(document: TextDocument, position: Position, doc: JSONDocument): Promise<DefinitionLink[]>;
+  findLinks(document: TextDocument): Promise<DocumentLink[]>;
   resetSchema(uri: string): boolean;
   doFormat(document: TextDocument, options: CustomFormatterOptions): TextEdit[];
   addSchema(schemaID: string, schema: JSONSchema): void;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -16,7 +16,7 @@ const languageSettingsSetup = new ServiceSetup().withCompletion();
 const languageService = configureLanguageService(languageSettingsSetup.languageSettings);
 
 suite('Auto Completion Tests', () => {
-  function parseSetup(content: string, position): Thenable<CompletionList> {
+  function parseSetup(content: string, position): Promise<CompletionList> {
     const testTextDocument = setupSchemaIDTextDocument(content);
     return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), false);
   }

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -13,7 +13,7 @@ let languageService = configureLanguageService(languageSettingsSetup.languageSet
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite('Custom Tag tests Tests', () => {
-  function parseSetup(content: string, customTags: string[]): Thenable<Diagnostic[]> {
+  function parseSetup(content: string, customTags: string[]): Promise<Diagnostic[]> {
     const testTextDocument = setupTextDocument(content);
     languageSettingsSetup.languageSettings.customTags = customTags;
     languageService = configureLanguageService(languageSettingsSetup.languageSettings);

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -18,7 +18,7 @@ const languageService = configureLanguageService(languageSettingsSetup.languageS
 
 suite('Default Snippet Tests', () => {
   describe('Snippet Tests', function () {
-    function parseSetup(content: string, position: number): Thenable<CompletionList> {
+    function parseSetup(content: string, position: number): Promise<CompletionList> {
       const testTextDocument = setupTextDocument(content);
       return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), false);
     }

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -11,7 +11,7 @@ const languageService = configureLanguageService(new ServiceSetup().languageSett
 
 suite('FindDefintion Tests', () => {
   describe('Jump to defintion', function () {
-    function findLinks(content: string): Thenable<DocumentLink[]> {
+    function findLinks(content: string): Promise<DocumentLink[]> {
       const testTextDocument = setupTextDocument(content);
       return languageService.findLinks(testTextDocument);
     }

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -17,7 +17,7 @@ suite('Hover Tests', () => {
   });
 
   describe('Hover', function () {
-    function parseSetup(content: string, position): Thenable<Hover> {
+    function parseSetup(content: string, position): Promise<Hover> {
       const testTextDocument = setupSchemaIDTextDocument(content);
       return languageService.doHover(testTextDocument, testTextDocument.positionAt(position));
     }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -25,7 +25,7 @@ languageService.configure(languageSettings);
 suite('Kubernetes Integration Tests', () => {
   // Tests for validator
   describe('Yaml Validation with kubernetes', function () {
-    function parseSetup(content: string): Thenable<Diagnostic[]> {
+    function parseSetup(content: string): Promise<Diagnostic[]> {
       const testTextDocument = setupTextDocument(content);
       return languageService.doValidation(testTextDocument, true);
     }
@@ -193,7 +193,7 @@ suite('Kubernetes Integration Tests', () => {
 
   describe('yamlCompletion with kubernetes', function () {
     describe('doComplete', function () {
-      function parseSetup(content: string, position): Thenable<CompletionList> {
+      function parseSetup(content: string, position): Promise<CompletionList> {
         const testTextDocument = setupTextDocument(content);
         return languageService.doComplete(testTextDocument, testTextDocument.positionAt(position), true);
       }
@@ -283,7 +283,7 @@ suite('Kubernetes Integration Tests', () => {
   });
 
   describe('yamlHover with kubernetes', function () {
-    function parseSetup(content: string, offset: number): Thenable<Hover> {
+    function parseSetup(content: string, offset: number): Promise<Hover> {
       const testTextDocument = setupTextDocument(content);
       return languageService.doHover(testTextDocument, testTextDocument.positionAt(offset));
     }

--- a/test/mulipleDocuments.test.ts
+++ b/test/mulipleDocuments.test.ts
@@ -23,13 +23,13 @@ const languageSettingsSetup = new ServiceSetup()
 suite('Multiple Documents Validation Tests', () => {
   // Tests for validator
   describe('Multiple Documents Validation', function () {
-    function validatorSetup(content: string): Thenable<Diagnostic[]> {
+    function validatorSetup(content: string): Promise<Diagnostic[]> {
       const testTextDocument = setupTextDocument(content);
       const languageService = configureLanguageService(languageSettingsSetup.languageSettings);
       return languageService.doValidation(testTextDocument, false);
     }
 
-    function hoverSetup(content: string, position): Thenable<Hover> {
+    function hoverSetup(content: string, position): Promise<Hover> {
       const testTextDocument = setupTextDocument(content);
       const languageService = configureLanguageService(languageSettingsSetup.languageSettings);
       return languageService.doHover(testTextDocument, testTextDocument.positionAt(position));

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -20,7 +20,7 @@ const workspaceContext = {
   },
 };
 
-const schemaRequestServiceForURL = (uri: string): Thenable<string> => {
+const schemaRequestServiceForURL = (uri: string): Promise<string> => {
   const headers = { 'Accept-Encoding': 'gzip, deflate' };
   return xhr({ url: uri, followRedirects: 5, headers }).then(
     (response) => {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -26,7 +26,7 @@ const languageService = configureLanguageService(languageSettingsSetup.languageS
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite('Validation Tests', () => {
-  function parseSetup(content: string, isKubernetes = false): Thenable<Diagnostic[]> {
+  function parseSetup(content: string, isKubernetes = false): Promise<Diagnostic[]> {
     const testTextDocument = setupSchemaIDTextDocument(content);
     return languageService.doValidation(testTextDocument, isKubernetes);
   }

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -10,7 +10,6 @@ import {
   TextDocumentSyncKind,
   TextDocument,
   InitializeResult,
-  RequestType,
 } from 'vscode-languageserver';
 import { xhr, XHRResponse, getErrorStatusDescription } from 'request-light';
 import { getLanguageService, LanguageSettings, LanguageService } from '../../src/languageservice/yamlLanguageService';
@@ -23,12 +22,6 @@ import {
 import * as URL from 'url';
 import fs = require('fs');
 import path = require('path');
-
-// eslint-disable-next-line @typescript-eslint/no-namespace
-namespace VSCodeContentRequest {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  export const type: RequestType<{}, {}, {}, {}> = new RequestType('vscode/content');
-}
 
 // Create a connection for the server.
 let connection: IConnection = null;
@@ -59,7 +52,7 @@ export const workspaceContext = {
   },
 };
 
-export const schemaRequestService = (uri: string): Thenable<string> => {
+export const schemaRequestService = (uri: string): Promise<string> => {
   if (Strings.startsWith(uri, 'file://')) {
     const fsPath = URI.parse(uri).fsPath;
     return new Promise<string>((c, e) => {
@@ -67,15 +60,6 @@ export const schemaRequestService = (uri: string): Thenable<string> => {
         return err ? e('') : c(result.toString());
       });
     });
-  } else if (Strings.startsWith(uri, 'vscode://')) {
-    return connection.sendRequest(VSCodeContentRequest.type, uri).then(
-      (responseText) => {
-        return responseText;
-      },
-      (error) => {
-        return error.message;
-      }
-    );
   }
   return xhr({ url: uri, followRedirects: 5 }).then(
     (response) => {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR renames all Thenables to Promises and removes a few pieces of code that are never called. There is 1 lingering Thenable that I didn't get rid of in server.ts. The type returned for formatterRegistration is a Thenable (all promises are thenable but not all thenables are promises) so we can't convert it.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/138

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested to see that the yamlValidation contribution, json schema store schemas, setting a schema manually, and the custom contributor api all still work and then ran npm run test
