### PR TITLE
Fix if/then/else shema conditions

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -648,7 +648,7 @@ function validate(
 
     const ifSchema = asSchema(schema.if);
     if (ifSchema) {
-      testCondition(ifSchema, asSchema(schema.then), asSchema(schema.else));
+      testCondition(ifSchema, schema, asSchema(schema.then), asSchema(schema.else));
     }
 
     if (Array.isArray(schema.enum)) {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -917,4 +917,41 @@ suite('Validation Tests', () => {
       );
     });
   });
+
+  describe('Conditional Schema', () => {
+    it('validator use "then" block if "if" valid', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        default: [],
+        properties: {
+          name: {
+            type: 'string',
+          },
+          var: {
+            type: 'string',
+          },
+        },
+        if: {
+          properties: {
+            var: {
+              type: 'string',
+            },
+          },
+        },
+        then: {
+          required: ['pineapple'],
+        },
+        else: {
+          required: ['tomato'],
+        },
+        additionalProperties: true,
+      });
+      const content = `
+      name: aName
+      var: something
+      inputs:`;
+      const result = await parseSetup(content);
+      expect(result[0].message).to.eq('Missing property "pineapple".');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Fix bug when only `else` section of `if/then/else` was applied during file validation

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/393

### Is it tested? How?
Take schema and yaml definition from issue description, now validation works correctly:
<img width="585" alt="Screenshot 2020-11-19 at 10 46 00" src="https://user-images.githubusercontent.com/929743/99643452-5dd8ad00-2a55-11eb-840b-808379d6fa8e.png">

