### PR TITLE
Register a non-standard LSP content request for resolving schemas on the client side

### DIFF
--- a/src/languageservice/services/schemaRequestHandler.ts
+++ b/src/languageservice/services/schemaRequestHandler.ts
@@ -53,7 +53,7 @@ export const schemaRequestHandler = (
 
   // HTTP(S) requests are sent and the response result is either the schema content or an error
   if (scheme === 'http' || scheme === 'https') {
-    // If we running inside of VSCode we need to make a content request. This content request
+    // If we are running inside of VSCode we need to make a content request. This content request
     // will make it so that schemas behind VPN's will resolve correctly
     if (useVSCodeContentRequest) {
       return connection.sendRequest(VSCodeContentRequest.type, uri).then(

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -17,6 +17,10 @@ export namespace DynamicCustomSchemaRequestRegistration {
   export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
+export namespace VSCodeContentRequestRegistration {
+  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerContentRequest');
+}
+
 export namespace VSCodeContentRequest {
   export const type: RequestType<{}, {}, {}, {}> = new RequestType('vscode/content');
 }

--- a/test/schemaRequestHandler.test.ts
+++ b/test/schemaRequestHandler.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon';
 import * as fs from 'fs';
 import { IConnection } from 'vscode-languageserver';
 import * as assert from 'assert';
+import { URI } from 'vscode-uri';
 
 suite('Schema Request Handler Tests', () => {
   suite('schemaRequestHandler', () => {
@@ -23,7 +24,7 @@ suite('Schema Request Handler Tests', () => {
     });
     test('Should care Win URI', async () => {
       const connection = <IConnection>{};
-      const resultPromise = schemaRequestHandler(connection, 'c:\\some\\window\\path\\scheme.json');
+      const resultPromise = schemaRequestHandler(connection, 'c:\\some\\window\\path\\scheme.json', [], URI.parse(''), false);
       assert.ok(readFileStub.calledOnceWith('c:\\some\\window\\path\\scheme.json'));
       readFileStub.callArgWith(2, undefined, '{some: "json"}');
       const result = await resultPromise;
@@ -32,7 +33,7 @@ suite('Schema Request Handler Tests', () => {
 
     test('UNIX URI should works', async () => {
       const connection = <IConnection>{};
-      const resultPromise = schemaRequestHandler(connection, '/some/unix/path/');
+      const resultPromise = schemaRequestHandler(connection, '/some/unix/path/', [], URI.parse(''), false);
       readFileStub.callArgWith(2, undefined, '{some: "json"}');
       const result = await resultPromise;
       assert.equal(result, '{some: "json"}');


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR registers a non-standard LSP request used specifically for VSCode. This LSP request gets triggered when an HTTP/HTTPS request to a schema is being made. Instead of the server resolving the schema the language server will send the URI to the client-side to be resolved. This has to be done in order to circumvent signed certificate errors that happen when you are trying to fetch the schemas outside of VSCode. From my understanding, VSCode is using Electron which uses Chromium which has certs already installed so this is why we have to do it this way and can't just fetch the schemas normally. I assume this is also why vscode-json-languageservice does the same thing

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/107

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
The only way I know how to test this is on the Red Hat VPN.

You'll need the client-side changes: https://github.com/redhat-developer/vscode-yaml/pull/395

Once you connect to the VPN these schemas should resolve correctly
```
"yaml.schemas": {
    "https://gitlab.cee.redhat.com/cpaas/service/-/raw/development/resources/schemas/release-root.json": "release.yml",
    "https://gitlab.cee.redhat.com/cpaas/service/-/raw/development/resources/schemas/product-root.json": "product.yml"
  }
```