### PR TITLE
Fix error on completion 'null' value

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -899,6 +899,9 @@ export class YAMLCompletion extends JSONCompletion {
   }
 
   private getLabelForValue(value: string): string {
+    if (value === null) {
+      return 'null'; // return string with 'null' value if schema contains null as possible value
+    }
     return value;
   }
 

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -616,6 +616,9 @@ export class YAMLCompletion extends JSONCompletion {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private getInsertTextForValue(value: any, separatorAfter: string, type: string | string[]): string {
+    if (value === null) {
+      value = 'null'; // replace type null with string 'null'
+    }
     switch (typeof value) {
       case 'object': {
         const indent = this.indentation;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1524,5 +1524,26 @@ suite('Auto Completion Tests', () => {
         createExpectedCompletion('a2', 'a2', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
       );
     });
+
+    it('should provide completion for "null" enum value', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          kind: {
+            enum: ['project', null],
+          },
+        },
+      });
+
+      const content = 'kind: \n';
+      const completion = await parseSetup(content, 6);
+      expect(completion.items).lengthOf(2);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('project', 'project', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+      expect(completion.items[1]).eql(
+        createExpectedCompletion('null', '\n', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+    });
   });
 });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1542,7 +1542,7 @@ suite('Auto Completion Tests', () => {
         createExpectedCompletion('project', 'project', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
       );
       expect(completion.items[1]).eql(
-        createExpectedCompletion('null', '\n', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        createExpectedCompletion('null', 'null', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
       );
     });
   });


### PR DESCRIPTION
### What does this PR do?
Fix error during completion when schema contains `null` value in enum, example:
```json
{
   "type": "object",
   "properties": {
      "kind": {
        "enum": [
          "project",
          null
       ],
     }
   }
}
```
With this PR error is gone, but I have doubt about behaviour. 
We generate completion item with label `null` but insert only new line`\n`.
According to yaml spec
```yaml
kind:
```
and 
```yaml
kind: null
```
are equal, but maybe it would be better if we will insert `null\n` instead of just `\n`?
### What issues does this PR fix or reference?
Found during https://github.com/redhat-developer/yaml-language-server/issues/344 investigation.

### Is it tested? How?
Use example schema and yaml content:
```yaml
kind: 
```
call completion after `kind: `, you should see completion list with two items `project` and `null`.