### PR TITLE
Keep space before word after inserting completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -63,6 +63,7 @@ export class YAMLCompletion extends JSONCompletion {
     if (!this.completion) {
       return Promise.resolve(result);
     }
+    const originalPosition = Position.create(position.line, position.character);
     const completionFix = this.completionHelper(document, position);
     const newText = completionFix.newText;
     const doc = parseYAML(newText);
@@ -101,11 +102,11 @@ export class YAMLCompletion extends JSONCompletion {
     } else if (node && (node.type === 'string' || node.type === 'number' || node.type === 'boolean')) {
       overwriteRange = Range.create(document.positionAt(node.offset), document.positionAt(node.offset + node.length));
     } else {
-      let overwriteStart = offset - currentWord.length;
+      let overwriteStart = document.offsetAt(originalPosition) - currentWord.length;
       if (overwriteStart > 0 && document.getText()[overwriteStart - 1] === '"') {
         overwriteStart--;
       }
-      overwriteRange = Range.create(document.positionAt(overwriteStart), position);
+      overwriteRange = Range.create(document.positionAt(overwriteStart), originalPosition);
     }
 
     const proposed: { [key: string]: CompletionItem } = {};

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -227,5 +227,31 @@ suite('Default Snippet Tests', () => {
         })
         .then(done, done);
     });
+
+    it('should preserve space after ":" with prefix', async () => {
+      const content = 'boolean: tr\n';
+      const result = await parseSetup(content, 9);
+
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].label, 'My boolean item');
+      assert.equal(result.items[0].textEdit.newText, 'false');
+      assert.equal(result.items[0].textEdit.range.start.line, 0);
+      assert.equal(result.items[0].textEdit.range.start.character, 9);
+      assert.equal(result.items[0].textEdit.range.end.line, 0);
+      assert.equal(result.items[0].textEdit.range.end.character, 9);
+    });
+
+    it('should preserve space after ":"', async () => {
+      const content = 'boolean: ';
+      const result = await parseSetup(content, 9);
+
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].label, 'My boolean item');
+      assert.equal(result.items[0].textEdit.newText, 'false');
+      assert.equal(result.items[0].textEdit.range.start.line, 0);
+      assert.equal(result.items[0].textEdit.range.start.character, 9);
+      assert.equal(result.items[0].textEdit.range.end.line, 0);
+      assert.equal(result.items[0].textEdit.range.end.character, 9);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
When completion invoked on field which has value:
`name: <cursor>aName` and file has scheme which contains `defaultSnippets` for `name`: 
```json
"properties": {
      "name": {
          "type": "string",
          "defaultSnippets": [
              {
                  "label": "some",
                  "body": "some"
              }
          ]
      },
}
```
it contains one option `some`, but inserting of that item will break yaml, as it 'eats' space after `:`:
`name:someaName`, this PR fix that, and now it no break yaml, so editor should contain `name: someaName`.

### What issues does this PR fix or reference?
Found during work on https://github.com/redhat-developer/vscode-tekton/issues/429

### Is it tested? How?
You may use schema example from this description, or try complete any yaml mapping value. Completion shouldn't breck  yaml syntax.
