### PR TITLE
Fix empty completion list on empty file

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -936,11 +936,7 @@ export class YAMLCompletion extends JSONCompletion {
     if (document.getText().trim().length === 0) {
       return {
         // add empty object to be compatible with JSON
-        newText:
-          document.getText().substring(0, start + textLine.length) +
-          (textLine.trim()[0] === '-' && !textLine.endsWith(' ') ? ' ' : '') +
-          '{}\n' +
-          document.getText().substr(lineOffset[linePos + 1] || document.getText().length),
+        newText: `{${document.getText()}}\n`,
         newPosition: textDocumentPosition,
       };
     }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -932,6 +932,19 @@ export class YAMLCompletion extends JSONCompletion {
 
     const textLine = document.getText().substring(start, end);
 
+    // Check if document contains only white spaces and line delimiters
+    if (document.getText().trim().length === 0) {
+      return {
+        // add empty object to be compatible with JSON
+        newText:
+          document.getText().substring(0, start + textLine.length) +
+          (textLine.trim()[0] === '-' && !textLine.endsWith(' ') ? ' ' : '') +
+          '{}\n' +
+          document.getText().substr(lineOffset[linePos + 1] || document.getText().length),
+        newPosition: textDocumentPosition,
+      };
+    }
+
     // Check if the string we are looking at is a node
     if (textLine.indexOf(':') === -1) {
       // We need to add the ":" to load the nodes

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1573,14 +1573,14 @@ suite('Auto Completion Tests', () => {
           ],
         });
 
-        const content = ' \n';
-        const completion = await parseSetup(content, 1);
+        const content = ' \n\n\n';
+        const completion = await parseSetup(content, 3);
         expect(completion.items).lengthOf(2);
         expect(completion.items[0]).eql(
-          createExpectedCompletion('kind', 'kind: $1', 0, 1, 0, 1, 10, InsertTextFormat.Snippet, { documentation: '' })
+          createExpectedCompletion('kind', 'kind: $1', 2, 0, 2, 0, 10, InsertTextFormat.Snippet, { documentation: '' })
         );
         expect(completion.items[1]).eql(
-          createExpectedCompletion('name', 'name: $1', 0, 1, 0, 1, 10, InsertTextFormat.Snippet, { documentation: '' })
+          createExpectedCompletion('name', 'name: $1', 2, 0, 2, 0, 10, InsertTextFormat.Snippet, { documentation: '' })
         );
       });
     });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1452,98 +1452,137 @@ suite('Auto Completion Tests', () => {
         expect(completion.items[0].label).eq('fooBar');
         expect(completion.items[0].insertText).eq('fooBar:\n    name: $1\n    aaa:\n      - $2');
       });
-    });
 
-    it('should complete string which contains number in default value', async () => {
-      languageService.addSchema(SCHEMA_ID, {
-        type: 'object',
-        properties: {
-          env: {
-            type: 'integer',
-            default: '1',
+      it('should complete string which contains number in default value', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            env: {
+              type: 'integer',
+              default: '1',
+            },
+            enum: {
+              type: 'string',
+              default: '1',
+            },
           },
-          enum: {
-            type: 'string',
-            default: '1',
-          },
-        },
+        });
+
+        const content = 'enum';
+        const completion = await parseSetup(content, 3);
+
+        const enumItem = completion.items.find((i) => i.label === 'enum');
+        expect(enumItem).to.not.undefined;
+        expect(enumItem.textEdit.newText).equal('enum: ${1:"1"}');
+
+        const envItem = completion.items.find((i) => i.label === 'env');
+        expect(envItem).to.not.undefined;
+        expect(envItem.textEdit.newText).equal('env: ${1:1}');
       });
 
-      const content = 'enum';
-      const completion = await parseSetup(content, 3);
-
-      const enumItem = completion.items.find((i) => i.label === 'enum');
-      expect(enumItem).to.not.undefined;
-      expect(enumItem.textEdit.newText).equal('enum: ${1:"1"}');
-
-      const envItem = completion.items.find((i) => i.label === 'env');
-      expect(envItem).to.not.undefined;
-      expect(envItem.textEdit.newText).equal('env: ${1:1}');
-    });
-
-    it('should complete string which contains number in examples values', async () => {
-      languageService.addSchema(SCHEMA_ID, {
-        type: 'object',
-        properties: {
-          fooBar: {
-            type: 'string',
-            examples: ['test', '1', 'true'],
+      it('should complete string which contains number in examples values', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            fooBar: {
+              type: 'string',
+              examples: ['test', '1', 'true'],
+            },
           },
-        },
+        });
+
+        const content = 'fooBar: \n';
+        const completion = await parseSetup(content, 8);
+
+        const testItem = completion.items.find((i) => i.label === 'test');
+        expect(testItem).to.not.undefined;
+        expect(testItem.textEdit.newText).equal('test');
+
+        const oneItem = completion.items.find((i) => i.label === '1');
+        expect(oneItem).to.not.undefined;
+        expect(oneItem.textEdit.newText).equal('"1"');
+
+        const trueItem = completion.items.find((i) => i.label === 'true');
+        expect(trueItem).to.not.undefined;
+        expect(trueItem.textEdit.newText).equal('"true"');
       });
 
-      const content = 'fooBar: \n';
-      const completion = await parseSetup(content, 8);
+      it('should provide completion for flow map', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: { A: { type: 'string', enum: ['a1', 'a2'] }, B: { type: 'string', enum: ['b1', 'b2'] } },
+        });
 
-      const testItem = completion.items.find((i) => i.label === 'test');
-      expect(testItem).to.not.undefined;
-      expect(testItem.textEdit.newText).equal('test');
-
-      const oneItem = completion.items.find((i) => i.label === '1');
-      expect(oneItem).to.not.undefined;
-      expect(oneItem.textEdit.newText).equal('"1"');
-
-      const trueItem = completion.items.find((i) => i.label === 'true');
-      expect(trueItem).to.not.undefined;
-      expect(trueItem.textEdit.newText).equal('"true"');
-    });
-
-    it('should provide completion for flow map', async () => {
-      languageService.addSchema(SCHEMA_ID, {
-        type: 'object',
-        properties: { A: { type: 'string', enum: ['a1', 'a2'] }, B: { type: 'string', enum: ['b1', 'b2'] } },
+        const content = '{A: , B: b1}';
+        const completion = await parseSetup(content, 4);
+        expect(completion.items).lengthOf(2);
+        expect(completion.items[0]).eql(
+          createExpectedCompletion('a1', 'a1', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        );
+        expect(completion.items[1]).eql(
+          createExpectedCompletion('a2', 'a2', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        );
       });
 
-      const content = '{A: , B: b1}';
-      const completion = await parseSetup(content, 4);
-      expect(completion.items).lengthOf(2);
-      expect(completion.items[0]).eql(
-        createExpectedCompletion('a1', 'a1', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
-      );
-      expect(completion.items[1]).eql(
-        createExpectedCompletion('a2', 'a2', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
-      );
-    });
-
-    it('should provide completion for "null" enum value', async () => {
-      languageService.addSchema(SCHEMA_ID, {
-        type: 'object',
-        properties: {
-          kind: {
-            enum: ['project', null],
+      it('should provide completion for "null" enum value', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            kind: {
+              enum: ['project', null],
+            },
           },
-        },
+        });
+
+        const content = 'kind: \n';
+        const completion = await parseSetup(content, 6);
+        expect(completion.items).lengthOf(2);
+        expect(completion.items[0]).eql(
+          createExpectedCompletion('project', 'project', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        );
+        expect(completion.items[1]).eql(
+          createExpectedCompletion('null', 'null', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        );
       });
 
-      const content = 'kind: \n';
-      const completion = await parseSetup(content, 6);
-      expect(completion.items).lengthOf(2);
-      expect(completion.items[0]).eql(
-        createExpectedCompletion('project', 'project', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
-      );
-      expect(completion.items[1]).eql(
-        createExpectedCompletion('null', 'null', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
-      );
+      it('should provide completion for empty file', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          oneOf: [
+            {
+              type: 'object',
+              description: 'dummy schema',
+            },
+            {
+              properties: {
+                kind: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+              additionalProperties: false,
+            },
+            {
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+              additionalProperties: false,
+            },
+          ],
+        });
+
+        const content = ' \n';
+        const completion = await parseSetup(content, 1);
+        expect(completion.items).lengthOf(2);
+        expect(completion.items[0]).eql(
+          createExpectedCompletion('kind', 'kind: $1', 0, 1, 0, 1, 10, InsertTextFormat.Snippet, { documentation: '' })
+        );
+        expect(completion.items[1]).eql(
+          createExpectedCompletion('name', 'name: $1', 0, 1, 0, 1, 10, InsertTextFormat.Snippet, { documentation: '' })
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes empty completion list on empty file. I found that we add `holder: \n` text in to text document, if line on which completion called is empty(contains only white spaces and line delimiter). 
Such behaviour do not to allow to choose proper schema, as some(k8's) schemas has `additionalProperties: false`, 
but AST contains property `holder`.
This PR fix that, so if file is empty we add `{}`(empty object)

### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/349

### Is it tested? How?
Configure vscode-yaml with 
```json
"yaml.schemas": {
    "kubernetes": [
      "kubernetes.yaml"
    ]
}
```
then open `kubernetes.yaml`, file should be empty, and call code completion, you should see :
<img width="894" alt="Screenshot 2020-12-10 at 14 31 13" src="https://user-images.githubusercontent.com/929743/101773398-63299480-3af5-11eb-997b-19384e385a37.png">
