### PR TITLE
Add space before value from default snippets

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -792,7 +792,7 @@ export class YAMLCompletion extends JSONCompletion {
     const propertyText = this.getInsertTextForValue(key, '', 'string');
     const resultText = propertyText + ':';
 
-    let value;
+    let value: string;
     let nValueProposals = 0;
     if (propertySchema) {
       let type = Array.isArray(propertySchema.type) ? propertySchema.type[0] : propertySchema.type;
@@ -817,6 +817,10 @@ export class YAMLCompletion extends JSONCompletion {
               },
               1
             );
+            // add space before default snippet value
+            if (!value.startsWith(' ') && !value.startsWith('\n')) {
+              value = ' ' + value;
+            }
           }
         }
         nValueProposals += propertySchema.defaultSnippets.length;

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -7,6 +7,7 @@ import assert = require('assert');
 import path = require('path');
 import { ServiceSetup } from './utils/serviceSetup';
 import { CompletionList } from 'vscode-languageserver';
+import { expect } from 'chai';
 
 const uri = toFsPath(path.join(__dirname, './fixtures/defaultSnippets.json'));
 const fileMatch = ['*.yml', '*.yaml'];
@@ -154,7 +155,7 @@ suite('Default Snippet Tests', () => {
       const completion = parseSetup(content, 3);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 8); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 9); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[4].label, 'longSnippet');
           // eslint-disable-next-line
           assert.equal(
@@ -170,7 +171,7 @@ suite('Default Snippet Tests', () => {
       const completion = parseSetup(content, 11);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 8); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 9); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[5].label, 'arrayArraySnippet');
           assert.equal(
             result.items[5].insertText,
@@ -252,6 +253,14 @@ suite('Default Snippet Tests', () => {
       assert.equal(result.items[0].textEdit.range.start.character, 9);
       assert.equal(result.items[0].textEdit.range.end.line, 0);
       assert.equal(result.items[0].textEdit.range.end.character, 9);
+    });
+
+    it('should add space before value on root node', async () => {
+      const content = 'name\n';
+      const result = await parseSetup(content, 4);
+      const item = result.items.find((i) => i.label === 'name');
+      expect(item).is.not.undefined;
+      expect(item.textEdit.newText).to.be.equal('name: some');
     });
   });
 });

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -122,6 +122,15 @@
           }
         }
       ]
+    },
+    "name": {
+      "type": "string",
+      "defaultSnippets": [
+          {
+              "label": "some",
+              "body": "some"
+          }
+      ]
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add missing space after value from default snippets

### What issues does this PR fix or reference?
Fix: #364

### Is it tested? How?
Just follow #364 description, with this PR you should see `name: some` instead of `name:some`
