### PR TITLE
Check if dynamic registration is enabled before executing onDidChangeWorkspaceFolders

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -446,7 +446,7 @@ connection.onInitialize(
 );
 
 connection.onInitialized(() => {
-  if (hasWorkspaceFolderCapability) {
+  if (hasWorkspaceFolderCapability && clientDynamicRegisterSupport) {
     connection.workspace.onDidChangeWorkspaceFolders((changedFolders) => {
       workspaceFolders = workspaceFoldersChanged(workspaceFolders, changedFolders);
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -136,7 +136,7 @@ const documents: TextDocuments = new TextDocuments();
 let capabilities: ClientCapabilities;
 let workspaceRoot: URI = null;
 let workspaceFolders: WorkspaceFolder[] = [];
-let clientDynamicRegisterSupport = false;
+let clientFormatterDynamicRegisterSupport = false;
 let hierarchicalDocumentSymbolSupport = false;
 let hasWorkspaceFolderCapability = false;
 let useVSCodeContentRequest = false;
@@ -419,7 +419,7 @@ connection.onInitialize(
       capabilities.textDocument.documentSymbol &&
       capabilities.textDocument.documentSymbol.hierarchicalDocumentSymbolSupport
     );
-    clientDynamicRegisterSupport = !!(
+    clientFormatterDynamicRegisterSupport = !!(
       capabilities.textDocument &&
       capabilities.textDocument.rangeFormatting &&
       capabilities.textDocument.rangeFormatting.dynamicRegistration
@@ -446,7 +446,7 @@ connection.onInitialize(
 );
 
 connection.onInitialized(() => {
-  if (hasWorkspaceFolderCapability && clientDynamicRegisterSupport) {
+  if (hasWorkspaceFolderCapability && clientFormatterDynamicRegisterSupport) {
     connection.workspace.onDidChangeWorkspaceFolders((changedFolders) => {
       workspaceFolders = workspaceFoldersChanged(workspaceFolders, changedFolders);
     });
@@ -555,7 +555,7 @@ connection.onDidChangeConfiguration((change) => {
   updateConfiguration();
 
   // dynamically enable & disable the formatter
-  if (clientDynamicRegisterSupport) {
+  if (clientFormatterDynamicRegisterSupport) {
     const enableFormatter = settings && settings.yaml && settings.yaml.format && settings.yaml.format.enable;
 
     if (enableFormatter) {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
It seems that [vscode-languageserver](https://github.com/microsoft/vscode-languageserver-node/blob/master/server/src/common/workspaceFolders.ts#L39) automatically sends a `client/registerCapability` to the client if you use `onDidChangeWorkspaceFolders` on the server side. This means that currently the server will then send `client/registerCapability` even if the client doesn't support it. Since workspaceFolders don't have dynamicRegistration in the initialization according to the LSP spec, there's no way to tell if we should be using `onDidChangeWorkspaceFolders` and thus sending the `client/registerCapability` on the server side. This PR makes it so that `onDidChangeWorkspaceFolders` is only registered when the formatter dynamic registration is available

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/370
https://github.com/redhat-developer/yaml-language-server/issues/377

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
