### PR TITLE
Fix indentation for object in array completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -250,7 +250,7 @@ export class YAMLCompletion extends JSONCompletion {
               const propertySchema = schemaProperties[key];
               if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema['doNotSuggest']) {
                 let identCompensation = '';
-                if (node.parent && node.parent.type === 'array') {
+                if (node.parent && node.parent.type === 'array' && node.properties.length <= 1) {
                   // because there is a slash '-' to prevent the properties generated to have the correct
                   // indent
                   const sourceText = document.getText();
@@ -703,8 +703,17 @@ export class YAMLCompletion extends JSONCompletion {
           case 'array':
             {
               const arrayInsertResult = this.getInsertTextForArray(propertySchema.items, separatorAfter, insertIndex++);
+              const arrayInsertLines = arrayInsertResult.insertText.split('\n');
+              let arrayTemplate = arrayInsertResult.insertText;
+              if (arrayInsertLines.length > 1) {
+                for (let index = 1; index < arrayInsertLines.length; index++) {
+                  const element = arrayInsertLines[index];
+                  arrayInsertLines[index] = `${indent}${this.indentation}  ${element.trimLeft()}`;
+                }
+                arrayTemplate = arrayInsertLines.join('\n');
+              }
               insertIndex = arrayInsertResult.insertIndex;
-              insertText += `${indent}${key}:\n${indent}${this.indentation}- ${arrayInsertResult.insertText}\n`;
+              insertText += `${indent}${key}:\n${indent}${this.indentation}- ${arrayTemplate}\n`;
             }
             break;
           case 'object':

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1350,6 +1350,60 @@ suite('Auto Completion Tests', () => {
     });
 
     describe('Bug fixes', () => {
+      it('Object in array completion indetetion', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            components: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string',
+                  },
+                  settings: {
+                    type: 'object',
+                    required: ['data'],
+                    properties: {
+                      data: {
+                        type: 'object',
+                        required: ['arrayItems'],
+                        properties: {
+                          arrayItems: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              required: ['id'],
+                              properties: {
+                                show: {
+                                  type: 'boolean',
+                                  default: true,
+                                },
+                                id: {
+                                  type: 'string',
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const content = 'components:\n  - id: jsakdh\n    setti';
+        const completion = await parseSetup(content, 36);
+        expect(completion.items).lengthOf(1);
+        expect(completion.items[0].textEdit.newText).to.equal(
+          'settings:\n  data:\n    arrayItems:\n      - show: ${1:true}\n        id: $2'
+        );
+      });
+
       it('Object completion', (done) => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',


### PR DESCRIPTION
### What does this PR do?
Fixes wrong indentation in case if object has array with object and it belongs to upper array, see schema in https://github.com/redhat-developer/yaml-language-server/issues/376#issuecomment-745850083

### What issues does this PR fix or reference?
#376

### Is it tested? How?
Use schema from https://github.com/redhat-developer/yaml-language-server/issues/376#issuecomment-745850083
and yaml file content: 
```yaml
components:
  - id: ss
    type: dd
    se
```
call code completion after `se`, and insert `settings` completion item.
You should have same result as on:
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/929743/102333127-a8d2db00-3f95-11eb-94ff-7d9fdb24b6af.gif)
