### PR TITLE
Implement folding range provider

### DIFF
--- a/src/languageservice/services/yamlFolding.ts
+++ b/src/languageservice/services/yamlFolding.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { TextDocument, FoldingRange, Range } from 'vscode-languageserver';
+import { FoldingRangesContext } from '../yamlTypes';
+import { parse as parseYAML } from '../parser/yamlParser07';
+
+export function getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | undefined {
+  if (!document) {
+    return;
+  }
+  const result: FoldingRange[] = [];
+  const doc = parseYAML(document.getText());
+  for (const ymlDoc of doc.documents) {
+    ymlDoc.visit((node) => {
+      if (
+        (node.type === 'property' && node.valueNode.type === 'array') ||
+        (node.type === 'object' && node.parent?.type === 'array')
+      ) {
+        const startPos = document.positionAt(node.offset);
+        let endPos = document.positionAt(node.offset + node.length);
+        const textFragment = document.getText(Range.create(startPos, endPos));
+        const newLength = textFragment.length - textFragment.trimRight().length;
+        if (newLength > 0) {
+          endPos = document.positionAt(node.offset + node.length - newLength);
+        }
+
+        result.push(FoldingRange.create(startPos.line, endPos.line, startPos.character, endPos.character));
+      }
+      if (node.type === 'property' && node.valueNode.type === 'object') {
+        const startPos = document.positionAt(node.offset);
+        const endPos = document.positionAt(node.offset + node.length);
+        result.push(FoldingRange.create(startPos.line, endPos.line, startPos.character, endPos.character));
+      }
+
+      return true;
+    });
+  }
+
+  const rangeLimit = context && context.rangeLimit;
+  if (typeof rangeLimit !== 'number' || result.length <= rangeLimit) {
+    return result;
+  }
+
+  return result.slice(0, context.rangeLimit - 1);
+}

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -6,7 +6,6 @@
 
 import { YAMLSchemaService, CustomSchemaProvider, SchemaAdditions, SchemaDeletions } from './services/yamlSchemaService';
 import {
-  TextDocument,
   Position,
   CompletionList,
   Diagnostic,
@@ -22,9 +21,11 @@ import { YAMLCompletion } from './services/yamlCompletion';
 import { YAMLHover } from './services/yamlHover';
 import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { JSONDocument, DefinitionLink } from 'vscode-json-languageservice';
 import { findLinks } from './services/yamlLinks';
+import { TextDocument, FoldingRange } from 'vscode-languageserver';
+import { getFoldingRanges } from './services/yamlFolding';
+import { FoldingRangesContext } from './yamlTypes';
 
 export enum SchemaPriority {
   SchemaStore = 1,
@@ -106,6 +107,7 @@ export interface LanguageService {
   deleteSchema(schemaID: string): void;
   modifySchemaContent(schemaAdditions: SchemaAdditions): void;
   deleteSchemaContent(schemaDeletions: SchemaDeletions): void;
+  getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | null;
 }
 
 export function getLanguageService(
@@ -162,5 +164,6 @@ export function getLanguageService(
     deleteSchemaContent: (schemaDeletions: SchemaDeletions) => {
       return schemaService.deleteContent(schemaDeletions);
     },
+    getFoldingRanges,
   };
 }

--- a/src/languageservice/yamlTypes.ts
+++ b/src/languageservice/yamlTypes.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface FoldingRangesContext {
+  /**
+   * The maximal number of ranges returned.
+   */
+  rangeLimit?: number;
+  /**
+   * If set, the client signals that it only supports folding complete lines. If set, client will
+   * ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+   */
+  lineFoldingOnly?: boolean;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -434,6 +434,7 @@ connection.onInitialize(
         documentFormattingProvider: false,
         documentRangeFormattingProvider: false,
         documentLinkProvider: {},
+        foldingRangeProvider: true,
         workspace: {
           workspaceFolders: {
             changeNotifications: true,
@@ -685,6 +686,14 @@ connection.onRequest(SchemaModificationNotification.type, (modifications: Schema
     customLanguageService.deleteSchemaContent(modifications);
   }
   return Promise.resolve();
+});
+
+connection.onFoldingRanges((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) {
+    return Promise.resolve(undefined);
+  }
+  return customLanguageService.getFoldingRanges(document, capabilities.textDocument?.foldingRange);
 });
 
 // Start listening for any messages from the client

--- a/test/yamlFolding.test.ts
+++ b/test/yamlFolding.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { FoldingRange } from 'vscode-languageserver';
+import { getFoldingRanges } from '../src/languageservice/services/yamlFolding';
+import { FoldingRangesContext } from '../src/languageservice/yamlTypes';
+import { setupTextDocument } from './utils/testHelper';
+
+const context: FoldingRangesContext = { rangeLimit: 10_0000 };
+
+suite('YAML Folding', () => {
+  it('should return undefined if no document provided', () => {
+    const ranges = getFoldingRanges(undefined, context);
+    expect(ranges).to.be.undefined;
+  });
+
+  it('should return empty array for empty document', () => {
+    const doc = setupTextDocument('');
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges).to.be.empty;
+  });
+
+  it('should provide folding ranges for object', () => {
+    const yaml = `
+    foo: bar
+    aaa:
+      bbb: ccc
+    `;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges.length).to.equal(1);
+    expect(ranges[0]).to.be.eql(FoldingRange.create(2, 3, 4, 14));
+  });
+
+  it('should provide folding ranges for array', () => {
+    const yaml = `
+    foo: bar
+    aaa:
+      - bbb
+    ccc: ddd
+    `;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges.length).to.equal(1);
+    expect(ranges[0]).to.be.eql(FoldingRange.create(2, 3, 4, 11));
+  });
+
+  it('should provide folding ranges for mapping in array', () => {
+    const yaml = `
+    foo: bar
+    aaa:
+      - bbb: "bbb"
+        fff: "fff"
+    ccc: ddd
+    `;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges).to.deep.include.members([FoldingRange.create(2, 4, 4, 18), FoldingRange.create(3, 4, 8, 18)]);
+  });
+
+  it('should provide folding ranges for mapping in mapping', () => {
+    const yaml = `
+    foo: bar
+    aaa:
+      bbb:
+        fff: "fff"
+    ccc: ddd
+    `;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges).to.deep.include.members([FoldingRange.create(2, 4, 4, 18), FoldingRange.create(3, 4, 6, 18)]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Add implementation for [foldingRange](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange) request. Most cases it should be exactly the same as vscode default folding for yaml.

### What issues does this PR fix or reference?
Fix: #337

### Is it tested? How?
Open any yaml file and look on "folding" chevrons in editor line number panel:
<img width="210" alt="Screenshot 2020-12-17 at 14 47 40" src="https://user-images.githubusercontent.com/929743/102490010-f410ea80-4076-11eb-8600-d7a7d5eca0df.png">

Try to fold/unfold some regions, and look on folding range if they is what you expect.
 
