### PR TITLE
Hover doesn't work when there is now symbol after property

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -405,7 +405,7 @@ export function getNodePath(node: ASTNode): JSONPath {
 
 export function contains(node: ASTNode, offset: number, includeRightBound = false): boolean {
   return (
-    (offset >= node.offset && offset < node.offset + node.length) || (includeRightBound && offset === node.offset + node.length)
+    (offset >= node.offset && offset <= node.offset + node.length) || (includeRightBound && offset === node.offset + node.length)
   );
 }
 

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -303,5 +303,25 @@ suite('Hover Tests', () => {
         })
         .then(done, done);
     });
+
+    it('Hover on null property', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          childObject: {
+            type: 'object',
+            description: 'should return this description',
+          },
+        },
+      });
+      const content = 'childObject: \n';
+      const hover = parseSetup(content, 1);
+      hover
+        .then(function (result) {
+          assert.equal((result.contents as MarkedString[]).length, 1);
+          assert.equal(result.contents[0], 'should return this description');
+        })
+        .then(done, done);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix jsonParser when objects is null and doesn't continue with any symbol in yaml file.

### What issues does this PR fix or reference?
no issue reference
problem:

![nullPropHover](https://user-images.githubusercontent.com/38421337/102894796-ef2bac80-4463-11eb-9195-edbe1c613a09.gif)

Hover doesn't work when there is now symbol after property.
On this example no hover will be displayed on `objProperty`
```
obj:
  objProperty:
```


### Is it tested? How?
`hover.test.ts: 'Hover on null property'`