### PR TITLE
fix: codeCompletion-with-defaultSnippet-and-makdown

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -38,6 +38,7 @@ export class YAMLCompletion extends JSONCompletion {
   private completion: boolean;
   private indentation: string;
   private configuredIndentation: string | undefined;
+  private supportsMarkdown = true;
 
   constructor(schemaService: YAMLSchemaService) {
     super(schemaService, [], Promise);

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -30,6 +30,7 @@ import { stringifyObject, StringifySettings } from '../utils/json';
 import { guessIndentation } from '../utils/indentationGuesser';
 import { TextBuffer } from '../utils/textBuffer';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
+import { ClientCapabilities } from 'vscode-languageserver';
 const localize = nls.loadMessageBundle();
 
 export class YAMLCompletion extends JSONCompletion {
@@ -38,10 +39,9 @@ export class YAMLCompletion extends JSONCompletion {
   private completion: boolean;
   private indentation: string;
   private configuredIndentation: string | undefined;
-  private supportsMarkdown = true;
 
-  constructor(schemaService: YAMLSchemaService) {
-    super(schemaService, [], Promise);
+  constructor(schemaService: YAMLSchemaService, clientCapabilities: ClientCapabilities = {}) {
+    super(schemaService, [], Promise, clientCapabilities);
     this.schemaService = schemaService;
     this.customTags = [];
     this.completion = true;

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -23,7 +23,7 @@ import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
 import { JSONDocument, DefinitionLink } from 'vscode-json-languageservice';
 import { findLinks } from './services/yamlLinks';
-import { TextDocument, FoldingRange } from 'vscode-languageserver';
+import { TextDocument, FoldingRange, ClientCapabilities } from 'vscode-languageserver';
 import { getFoldingRanges } from './services/yamlFolding';
 import { FoldingRangesContext } from './yamlTypes';
 
@@ -112,10 +112,11 @@ export interface LanguageService {
 
 export function getLanguageService(
   schemaRequestService: SchemaRequestService,
-  workspaceContext: WorkspaceContextService
+  workspaceContext: WorkspaceContextService,
+  clientCapabilities?: ClientCapabilities
 ): LanguageService {
   const schemaService = new YAMLSchemaService(schemaRequestService, workspaceContext);
-  const completer = new YAMLCompletion(schemaService);
+  const completer = new YAMLCompletion(schemaService, clientCapabilities);
   const hover = new YAMLHover(schemaService);
   const yamlDocumentSymbols = new YAMLDocumentSymbols(schemaService);
   const yamlValidation = new YAMLValidation(schemaService);

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,6 @@ import {
   WorkspaceContextService,
   SchemaConfiguration,
   SchemaPriority,
-  LanguageService,
 } from './languageservice/yamlLanguageService';
 import * as nls from 'vscode-nls';
 import {

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import {
   WorkspaceContextService,
   SchemaConfiguration,
   SchemaPriority,
+  LanguageService,
 } from './languageservice/yamlLanguageService';
 import * as nls from 'vscode-nls';
 import {
@@ -394,7 +395,7 @@ const schemaRequestHandlerWrapper = (connection: IConnection, uri: string): Prom
 
 const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
 
-export const customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext);
+let customLanguageService: LanguageService;
 
 /***********************
  * Connection listeners
@@ -407,6 +408,8 @@ export const customLanguageService = getCustomLanguageService(schemaRequestServi
 connection.onInitialize(
   (params: InitializeParams): InitializeResult => {
     capabilities = params.capabilities;
+
+    customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, capabilities);
 
     // Only try to parse the workspace root if its not null. Otherwise initialize will fail
     if (params.rootUri) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -395,7 +395,7 @@ const schemaRequestHandlerWrapper = (connection: IConnection, uri: string): Prom
 
 const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
 
-let customLanguageService: LanguageService;
+let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, ClientCapabilities.LATEST);
 
 /***********************
  * Connection listeners

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,6 +54,7 @@ import { isRelativePath, relativeToAbsolutePath, workspaceFoldersChanged } from 
 import { URI } from 'vscode-uri';
 import { KUBERNETES_SCHEMA_URL, JSON_SCHEMASTORE_URL } from './languageservice/utils/schemaUrls';
 import { schemaRequestHandler } from './languageservice/services/schemaRequestHandler';
+import { ClientCapabilities as ClientJsonCapabilities } from 'vscode-json-languageservice';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
@@ -395,7 +396,7 @@ const schemaRequestHandlerWrapper = (connection: IConnection, uri: string): Prom
 
 const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
 
-let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, ClientCapabilities.LATEST);
+let customLanguageService = getCustomLanguageService(schemaRequestService, workspaceContext, ClientJsonCapabilities.LATEST);
 
 /***********************
  * Connection listeners

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -9,7 +9,7 @@ import assert = require('assert');
 import path = require('path');
 import { createExpectedCompletion } from './utils/verifyError';
 import { ServiceSetup } from './utils/serviceSetup';
-import { CompletionList, InsertTextFormat } from 'vscode-languageserver';
+import { CompletionList, InsertTextFormat, MarkupContent } from 'vscode-languageserver';
 import { expect } from 'chai';
 
 const languageSettingsSetup = new ServiceSetup().withCompletion();
@@ -398,6 +398,34 @@ suite('Auto Completion Tests', () => {
         completion
           .then(function (result) {
             assert.equal(result.items.length, 0);
+          })
+          .then(done, done);
+      });
+
+      it('Autocomplete with defaultSnippet markdown', (done) => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            scripts: {
+              type: 'object',
+              properties: {},
+              defaultSnippets: [
+                {
+                  label: 'myOtherSample snippet',
+                  body: { myOtherSample: {} },
+                  markdownDescription: 'snippet\n```yaml\nmyOtherSample:\n```\n',
+                },
+              ],
+            },
+          },
+        });
+        const content = 'scripts: ';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 1);
+            assert.equal(result.items[0].insertText, '\n  myOtherSample: ');
+            assert.equal((result.items[0].documentation as MarkupContent).value, 'snippet\n```yaml\nmyOtherSample:\n```\n');
           })
           .then(done, done);
       });

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -16,6 +16,7 @@ import { getLanguageService, LanguageSettings, LanguageService } from '../../src
 import Strings = require('../../src/languageservice/utils/strings');
 import { URI } from 'vscode-uri';
 import {
+  ClientCapabilities,
   getLanguageService as getJSONLanguageService,
   LanguageService as JSONLanguageService,
 } from 'vscode-json-languageservice';
@@ -86,8 +87,11 @@ export function toFsPath(str: unknown): string {
   return encodeURI(`file://${pathName}`).replace(/[?#]/g, encodeURIComponent);
 }
 
-export function configureLanguageService(languageSettings: LanguageSettings): LanguageService {
-  const languageService = getLanguageService(schemaRequestService, workspaceContext);
+export function configureLanguageService(
+  languageSettings: LanguageSettings,
+  clientCapabilities = ClientCapabilities.LATEST
+): LanguageService {
+  const languageService = getLanguageService(schemaRequestService, workspaceContext, clientCapabilities);
 
   languageService.configure(languageSettings);
   return languageService;


### PR DESCRIPTION
### What does this PR do?
enable defaultSnippet markdown description in schemas for code completion service

### What issues does this PR fix or reference?
when schema has defaultSnippet and markdown description parameter set, jsonCompletion will ignores this markdown description because of undefined parameter `supportsMarkdown`

### Is it tested? How?
added unit-test