### PR TITLE
fix: completion with default snippet when node is array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -371,6 +371,11 @@ export class YAMLCompletion extends JSONCompletion {
       const matchingSchemas = doc.getMatchingSchemas(schema.schema);
       matchingSchemas.forEach((s) => {
         if (s.node === node && !s.inverted && s.schema) {
+          this.collectDefaultSnippets(s.schema, separatorAfter, collector, {
+            newLineFirst: false,
+            indentFirstObject: false,
+            shouldIndentWithTab: false,
+          });
           if (s.schema.items) {
             if (Array.isArray(s.schema.items)) {
               const index = super.findItemAtOffset(node, document, offset);

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -60,9 +60,20 @@ suite('Default Snippet Tests', () => {
         .then(done, done);
     });
 
-    it('Snippet in array schema should autocomplete correctly after ', (done) => {
+    it('Snippet in array schema should autocomplete correctly on array level ', (done) => {
+      const content = 'array:\n  - item1: asd\n    item2: asd\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
+          assert.equal(result.items[0].label, 'My array item');
+        })
+        .then(done, done);
+    });
+    it('Snippet in array schema should autocomplete correctly inside array item ', (done) => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n    ';
-      const completion = parseSetup(content, 40);
+      const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);


### PR DESCRIPTION
Completion with defaultSnippet doesn't work in this scenario:
```yaml
array:
  #invoke here without "-"
```

### What does this PR do?
fix Completion with defaultSnippet when node is array

### What issues does this PR fix or reference?
https://github.com/p-spacek/yaml-language-server/issues/4

### Is it tested? How?
added unit test