### PR TITLE
fix codeCompletion with defaultSnippet and makdown

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -371,12 +371,12 @@ export class YAMLCompletion extends JSONCompletion {
       const matchingSchemas = doc.getMatchingSchemas(schema.schema);
       matchingSchemas.forEach((s) => {
         if (s.node === node && !s.inverted && s.schema) {
-          this.collectDefaultSnippets(s.schema, separatorAfter, collector, {
-            newLineFirst: false,
-            indentFirstObject: false,
-            shouldIndentWithTab: false,
-          });
           if (s.schema.items) {
+            this.collectDefaultSnippets(s.schema, separatorAfter, collector, {
+              newLineFirst: false,
+              indentFirstObject: false,
+              shouldIndentWithTab: false,
+            });
             if (Array.isArray(s.schema.items)) {
               const index = super.findItemAtOffset(node, document, offset);
               if (index < s.schema.items.length) {

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -135,6 +135,16 @@ suite('Default Snippet Tests', () => {
         .then(done, done);
     });
 
+    it('Snippet in object schema should not autocomplete on children', (done) => {
+      const content = 'object_any:\n someProp: ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 0);
+        })
+        .then(done, done);
+    });
+
     it('Snippet in string schema should autocomplete on same line', (done) => {
       const content = 'string:  ';
       const completion = parseSetup(content, 8);
@@ -180,7 +190,7 @@ suite('Default Snippet Tests', () => {
       const completion = parseSetup(content, 3);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 9); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 10); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[4].label, 'longSnippet');
           // eslint-disable-next-line
           assert.equal(
@@ -196,7 +206,7 @@ suite('Default Snippet Tests', () => {
       const completion = parseSetup(content, 11);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 9); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 10); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[5].label, 'arrayArraySnippet');
           assert.equal(
             result.items[5].insertText,

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -126,10 +126,22 @@
     "name": {
       "type": "string",
       "defaultSnippets": [
-          {
-              "label": "some",
-              "body": "some"
+        {
+          "label": "some",
+          "body": "some"
+        }
+      ]
+    },
+    "object_any": {
+      "type": "object",
+      "defaultSnippets": [
+        {
+          "label": "Object empty",
+          "description": "Binds a root",
+          "body": {
+            "root": {}
           }
+        }
       ]
     }
   }


### PR DESCRIPTION
### What does this PR do?
fix previous PR https://github.com/redhat-developer/yaml-language-server/pull/385 'enable defaultSnippet markdown description in schemas for code completion service'
the problem is there
```yaml
object:
  propertyFromSnipper:  #completion here suggest 'propertyFromSnipper' again
``` 

### What issues does this PR fix or reference?
fix previous PR
move `collectDefaultSnippets` into 'array' condition

### Is it tested? How?
added unite test