### PR TITLE
Return folding rage provider

### DIFF
--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -2,6 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { FoldingRange } from 'vscode-json-languageservice';
 import {
   CompletionList,
   DidChangeWatchedFilesParams,
@@ -9,6 +10,7 @@ import {
   DocumentLink,
   DocumentLinkParams,
   DocumentSymbolParams,
+  FoldingRangeParams,
   IConnection,
   TextDocumentPositionParams,
 } from 'vscode-languageserver';
@@ -41,6 +43,7 @@ export class LanguageHandlers {
     this.connection.onHover((textDocumentPositionParams) => this.hoverHandler(textDocumentPositionParams));
     this.connection.onCompletion((textDocumentPosition) => this.completionHandler(textDocumentPosition));
     this.connection.onDidChangeWatchedFiles((change) => this.watchedFilesHandler(change));
+    this.connection.onFoldingRanges((params) => this.foldingRangeHandler(params));
   }
 
   documentLinkHandler(params: DocumentLinkParams): Promise<DocumentLink[]> {
@@ -141,5 +144,14 @@ export class LanguageHandlers {
     if (hasChanges) {
       this.yamlSettings.documents.all().forEach((document) => this.validationHandler.validate(document));
     }
+  }
+
+  foldingRangeHandler(params: FoldingRangeParams): Promise<FoldingRange[] | undefined> | FoldingRange[] | undefined {
+    const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
+    if (!textDocument) {
+      return;
+    }
+
+    return this.languageService.getFoldingRanges(textDocument, this.yamlSettings.capabilities.textDocument.foldingRange);
   }
 }

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -69,6 +69,7 @@ export class YAMLServerInit {
             documentFormattingProvider: false,
             documentRangeFormattingProvider: false,
             documentLinkProvider: {},
+            foldingRangeProvider: true,
             workspace: {
               workspaceFolders: {
                 changeNotifications: true,


### PR DESCRIPTION
### What does this PR do?
It seems that during refactoring https://github.com/redhat-developer/yaml-language-server/pull/381 we lost registration for folding range provider, this PR just return back that.

### What issues does this PR fix or reference?
none

### Is it tested? How?
Folding ranges should works as before refactoring