### PR TITLE
Add code action to open json schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ To run the image you can use:
 docker run -it quay.io/redhat-developer/yaml-language-server:latest
 ```
 
+## Language Server Protocol version
+
+`yaml-language-server` use `vscode-languageserver@7.0.0` which implements [LSP 3.16](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md)
+
 ## Clients
 
 This repository only contains the server implementation. Here are some known clients consuming this server:

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vscode-json-languageservice": "^3.10.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.15.1",
+    "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^4.1.2",
     "vscode-uri": "^2.1.1",
     "yaml-language-server-parser": "next"
@@ -49,6 +49,7 @@
     "@types/node": "^12.11.7",
     "@types/prettier": "2.0.2",
     "@types/sinon": "^9.0.5",
+    "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jsonc-parser": "^2.2.1",
     "request-light": "^0.2.4",
     "vscode-json-languageservice": "^3.10.0",
-    "vscode-languageserver": "^5.2.1",
+    "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.15.1",
     "vscode-nls": "^4.1.2",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum YamlCommands {
+  JUMP_TO_SCHEMA = 'jumpToSchema',
+}

--- a/src/languageserver/commandExecutor.ts
+++ b/src/languageserver/commandExecutor.ts
@@ -14,7 +14,7 @@ export class CommandExecutor {
   executeCommand(params: ExecuteCommandParams): void {
     if (this.commands.has(params.command)) {
       const handler = this.commands.get(params.command);
-      return handler(params.arguments);
+      return handler(...params.arguments);
     }
     throw new Error(`Command '${params.command}' not found`);
   }

--- a/src/languageserver/commandExecutor.ts
+++ b/src/languageserver/commandExecutor.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExecuteCommandParams } from 'vscode-languageserver';
+
+export interface CommandHandler {
+  (...args: any[]): void;
+}
+
+export class CommandExecutor {
+  private commands = new Map<string, CommandHandler>();
+  executeCommand(params: ExecuteCommandParams): void {
+    if (this.commands.has(params.command)) {
+      const handler = this.commands.get(params.command);
+      return handler(params.arguments);
+    }
+    throw new Error(`Command '${params.command}' not found`);
+  }
+
+  registerCommand(commandId: string, handler: CommandHandler): void {
+    this.commands.set(commandId, handler);
+  }
+}
+
+export const commandExecutor = new CommandExecutor();

--- a/src/languageserver/commandExecutor.ts
+++ b/src/languageserver/commandExecutor.ts
@@ -6,7 +6,7 @@
 import { ExecuteCommandParams } from 'vscode-languageserver';
 
 export interface CommandHandler {
-  (...args: any[]): void;
+  (...args: unknown[]): void;
 }
 
 export class CommandExecutor {

--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { FoldingRange } from 'vscode-json-languageservice';
 import {
+  CodeAction,
+  CodeActionParams,
   CompletionList,
   DidChangeWatchedFilesParams,
   DocumentFormattingParams,
@@ -11,7 +13,7 @@ import {
   DocumentLinkParams,
   DocumentSymbolParams,
   FoldingRangeParams,
-  IConnection,
+  Connection,
   TextDocumentPositionParams,
 } from 'vscode-languageserver';
 import { DocumentSymbol, Hover, SymbolInformation, TextEdit } from 'vscode-languageserver-types';
@@ -26,7 +28,7 @@ export class LanguageHandlers {
   private validationHandler: ValidationHandler;
 
   constructor(
-    private readonly connection: IConnection,
+    private readonly connection: Connection,
     languageService: LanguageService,
     yamlSettings: SettingsState,
     validationHandler: ValidationHandler
@@ -44,6 +46,7 @@ export class LanguageHandlers {
     this.connection.onCompletion((textDocumentPosition) => this.completionHandler(textDocumentPosition));
     this.connection.onDidChangeWatchedFiles((change) => this.watchedFilesHandler(change));
     this.connection.onFoldingRanges((params) => this.foldingRangeHandler(params));
+    this.connection.onCodeAction((params) => this.codeActionHandler(params));
   }
 
   documentLinkHandler(params: DocumentLinkParams): Promise<DocumentLink[]> {
@@ -153,5 +156,14 @@ export class LanguageHandlers {
     }
 
     return this.languageService.getFoldingRanges(textDocument, this.yamlSettings.capabilities.textDocument.foldingRange);
+  }
+
+  codeActionHandler(params: CodeActionParams): CodeAction[] | undefined {
+    const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
+    if (!textDocument) {
+      return;
+    }
+
+    return this.languageService.getCodeAction(textDocument, params);
   }
 }

--- a/src/languageserver/handlers/notificationHandlers.ts
+++ b/src/languageserver/handlers/notificationHandlers.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { IConnection } from 'vscode-languageserver';
+import { Connection } from 'vscode-languageserver';
 import { CustomSchemaProvider } from '../../languageservice/services/yamlSchemaService';
 import { LanguageService, SchemaConfiguration } from '../../languageservice/yamlLanguageService';
 import {
@@ -20,7 +20,7 @@ export class NotificationHandlers {
   private settingsHandler: SettingsHandler;
 
   constructor(
-    private readonly connection: IConnection,
+    private readonly connection: Connection,
     languageService: LanguageService,
     yamlSettings: SettingsState,
     settingsHandler: SettingsHandler

--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -2,14 +2,14 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { IConnection } from 'vscode-languageserver';
+import { Connection } from 'vscode-languageserver';
 import { MODIFICATION_ACTIONS, SchemaAdditions, SchemaDeletions } from '../../languageservice/services/yamlSchemaService';
 import { LanguageService } from '../../languageservice/yamlLanguageService';
 import { SchemaModificationNotification } from '../../requestTypes';
 
 export class RequestHandlers {
   private languageService: LanguageService;
-  constructor(private readonly connection: IConnection, languageService: LanguageService) {
+  constructor(private readonly connection: Connection, languageService: LanguageService) {
     this.languageService = languageService;
   }
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { xhr, configure as configureHttpRequests } from 'request-light';
-import { DidChangeConfigurationParams, DocumentFormattingRequest, IConnection } from 'vscode-languageserver';
+import { DidChangeConfigurationParams, DocumentFormattingRequest, Connection } from 'vscode-languageserver';
 import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
 import { checkSchemaURI, JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from '../../languageservice/utils/schemaUrls';
 import { LanguageService, LanguageSettings } from '../../languageservice/yamlLanguageService';
@@ -12,7 +12,7 @@ import { ValidationHandler } from './validationHandlers';
 
 export class SettingsHandler {
   constructor(
-    private readonly connection: IConnection,
+    private readonly connection: Connection,
     private readonly languageService: LanguageService,
     private readonly yamlSettings: SettingsState,
     private readonly validationHandler: ValidationHandler

--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { IConnection } from 'vscode-languageserver';
+import { Connection } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic } from 'vscode-languageserver-types';
 import { isKubernetesAssociatedDocument } from '../../languageservice/parser/isKubernetes';
@@ -14,7 +14,7 @@ export class ValidationHandler {
   private languageService: LanguageService;
   private yamlSettings: SettingsState;
 
-  constructor(private readonly connection: IConnection, languageService: LanguageService, yamlSettings: SettingsState) {
+  constructor(private readonly connection: Connection, languageService: LanguageService, yamlSettings: SettingsState) {
     this.languageService = languageService;
     this.yamlSettings = yamlSettings;
 

--- a/src/languageserver/handlers/workspaceHandlers.ts
+++ b/src/languageserver/handlers/workspaceHandlers.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExecuteCommandParams, Connection } from 'vscode-languageserver';
+import { CommandExecutor } from '../commandExecutor';
+
+export class WorkspaceHandlers {
+  constructor(private readonly connection: Connection, private readonly commandExecutor: CommandExecutor) {}
+
+  registerHandlers(): void {
+    this.connection.onExecuteCommand((params) => this.executeCommand(params));
+  }
+
+  private executeCommand(params: ExecuteCommandParams): void {
+    return this.commandExecutor.executeCommand(params);
+  }
+}

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -20,8 +20,9 @@ import {
 import { ErrorCode, JSONPath } from 'vscode-json-languageservice';
 import * as nls from 'vscode-nls';
 import { URI } from 'vscode-uri';
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import { DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic } from 'vscode-languageserver';
 
 const localize = nls.loadMessageBundle();
 
@@ -64,7 +65,7 @@ export interface IProblem {
   schemaUri?: string;
 }
 
-export interface DiagnosticExt extends Diagnostic {
+interface DiagnosticExt extends Diagnostic {
   schemaUri?: string;
 }
 
@@ -460,8 +461,8 @@ export class JSONDocument {
           textDocument.positionAt(p.location.offset),
           textDocument.positionAt(p.location.offset + p.location.length)
         );
-        const diagnostic: DiagnosticExt = Diagnostic.create(range, p.message, p.severity, p.code, p.source);
-        diagnostic.schemaUri = p.schemaUri;
+        const diagnostic: Diagnostic = Diagnostic.create(range, p.message, p.severity, p.code, p.source);
+        diagnostic.data = { schemaUri: p.schemaUri };
         return diagnostic;
       });
     }

--- a/src/languageservice/services/schemaRequestHandler.ts
+++ b/src/languageservice/services/schemaRequestHandler.ts
@@ -1,5 +1,5 @@
 import { URI } from 'vscode-uri';
-import { IConnection, WorkspaceFolder } from 'vscode-languageserver';
+import { Connection, WorkspaceFolder } from 'vscode-languageserver';
 import { xhr, XHRResponse, getErrorStatusDescription } from 'request-light';
 import * as fs from 'fs';
 import * as URL from 'url';
@@ -12,7 +12,7 @@ import { WorkspaceContextService } from '../yamlLanguageService';
  * @param uri can be a local file, vscode request, http(s) request or a custom request
  */
 export const schemaRequestHandler = (
-  connection: IConnection,
+  connection: Connection,
   uri: string,
   workspaceFolders: WorkspaceFolder[],
   workspaceRoot: URI,

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TextDocument } from 'vscode-json-languageservice';
-import { CodeAction, CodeActionParams, Command, Connection, Diagnostic, Range } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CodeAction, CodeActionParams, Command, Connection, Diagnostic } from 'vscode-languageserver';
 import { YamlCommands } from '../../commands';
 import { CommandExecutor } from '../../languageserver/commandExecutor';
+import { isIntersect as isRangesIntersect } from '../utils/ranges';
 import { LATEST_DIAGNOSTIC } from './yamlValidation';
 
 export class YamlCodeActions {
@@ -36,7 +37,7 @@ export class YamlCodeActions {
       if (
         schemaUri &&
         (schemaUri.startsWith('file') || schemaUri.startsWith('https')) &&
-        isIntersect(params.range, diagnostic.range)
+        isRangesIntersect(params.range, diagnostic.range)
       ) {
         if (!schemaUriToDiagnostic.has(schemaUri)) {
           schemaUriToDiagnostic.set(schemaUri, []);
@@ -56,40 +57,4 @@ export class YamlCodeActions {
 
     return result;
   }
-}
-
-/**
- * Check if rangeA and rangeB is intersect
- * @param rangeA
- * @param rangeB
- */
-function isIntersect(rangeA: Range, rangeB: Range): boolean {
-  if (
-    rangeA.start.line >= rangeB.start.line &&
-    rangeA.start.character >= rangeB.start.character &&
-    rangeA.start.line <= rangeB.end.line &&
-    rangeA.start.character <= rangeB.end.character
-  ) {
-    return true;
-  }
-
-  if (
-    rangeA.end.line >= rangeB.start.line &&
-    rangeA.end.character >= rangeB.start.character &&
-    rangeA.end.line <= rangeB.end.line &&
-    rangeA.end.character <= rangeB.end.character
-  ) {
-    return true;
-  }
-
-  if (
-    rangeA.start.line >= rangeB.start.line &&
-    rangeA.start.character >= rangeB.start.character &&
-    rangeA.end.line <= rangeB.end.line &&
-    rangeA.end.character <= rangeB.end.character
-  ) {
-    return true;
-  }
-
-  return false;
 }

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocument } from 'vscode-json-languageservice';
+import { CodeAction, CodeActionParams, Command, Connection, Diagnostic, Range } from 'vscode-languageserver';
+import { YamlCommands } from '../../commands';
+import { CommandExecutor } from '../../languageserver/commandExecutor';
+import { LATEST_DIAGNOSTIC } from './yamlValidation';
+
+export class YamlCodeActions {
+  constructor(commandExecutor: CommandExecutor, connection: Connection) {
+    commandExecutor.registerCommand(YamlCommands.JUMP_TO_SCHEMA, async (param: string) => {
+      let [uri] = param;
+      if (!uri.startsWith('file')) {
+        uri = 'json-schema' + uri.substring(uri.indexOf('://'), uri.length);
+      }
+      console.error(uri);
+      const result = await connection.window.showDocument({ uri: uri, external: false, takeFocus: true });
+      if (!result) {
+        connection.window.showErrorMessage(`Cannot open ${uri}`);
+      }
+    });
+  }
+
+  getCodeAction(document: TextDocument, params: CodeActionParams): CodeAction[] | undefined {
+    const diagnostics = LATEST_DIAGNOSTIC.get(document.uri);
+    if (!diagnostics || diagnostics.length === 0) {
+      return;
+    }
+    const schemaUriToDiagnostic = new Map<string, Diagnostic[]>();
+
+    for (const diagnostic of diagnostics) {
+      const schemaUri = diagnostic.schemaUri;
+      if (
+        schemaUri &&
+        (schemaUri.startsWith('file') || schemaUri.startsWith('https')) &&
+        isIntersect(params.range, diagnostic.range)
+      ) {
+        if (!schemaUriToDiagnostic.has(schemaUri)) {
+          schemaUriToDiagnostic.set(schemaUri, []);
+        }
+        schemaUriToDiagnostic.get(schemaUri).push(diagnostic);
+      }
+    }
+    const result = [];
+    for (const schemaUri of schemaUriToDiagnostic.keys()) {
+      const action = CodeAction.create(
+        'Jump to schema location',
+        Command.create('JumpToSchema', YamlCommands.JUMP_TO_SCHEMA, schemaUri)
+      );
+      action.diagnostics = schemaUriToDiagnostic.get(schemaUri);
+      result.push(action);
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Check if rangeA and rangeB is intersect
+ * @param rangeA
+ * @param rangeB
+ */
+function isIntersect(rangeA: Range, rangeB: Range): boolean {
+  if (
+    rangeA.start.line >= rangeB.start.line &&
+    rangeA.start.character >= rangeB.start.character &&
+    rangeA.start.line <= rangeB.end.line &&
+    rangeA.start.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  if (
+    rangeA.end.line >= rangeB.start.line &&
+    rangeA.end.character >= rangeB.start.character &&
+    rangeA.end.line <= rangeB.end.line &&
+    rangeA.end.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  if (
+    rangeA.start.line >= rangeB.start.line &&
+    rangeA.start.character >= rangeB.start.character &&
+    rangeA.end.line <= rangeB.end.line &&
+    rangeA.end.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocumentOnTypeFormattingParams, Position, Range, TextDocument, TextEdit } from 'vscode-languageserver';
+import { DocumentOnTypeFormattingParams, Position, Range, TextEdit } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { TextBuffer } from '../utils/textBuffer';
 
 export function doDocumentOnTypeFormatting(
@@ -23,10 +24,13 @@ export function doDocumentOnTypeFormatting(
         if (indentationFix === params.options.tabSize && !isInArray) {
           return; // skip if line already has proper formatting
         }
-        return [
-          TextEdit.del(Range.create(position, Position.create(position.line, currentLine.length - 1))),
-          TextEdit.insert(position, ' '.repeat(params.options.tabSize + (isInArray ? 2 - indentationFix : 0))),
-        ];
+        const result = [];
+        if (currentLine.length > 0) {
+          result.push(TextEdit.del(Range.create(position, Position.create(position.line, currentLine.length - 1))));
+        }
+        result.push(TextEdit.insert(position, ' '.repeat(params.options.tabSize + (isInArray ? 2 - indentationFix : 0))));
+
+        return result;
       }
       if (isInArray) {
         return [TextEdit.insert(position, ' '.repeat(params.options.tabSize))];

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -5,15 +5,15 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { Diagnostic } from 'vscode-languageserver-types';
+import { Diagnostic } from 'vscode-languageserver';
 import { LanguageSettings } from '../yamlLanguageService';
 import { parse as parseYAML, YAMLDocument } from '../parser/yamlParser07';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { YAMLDocDiagnostic } from '../utils/parseUtils';
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { JSONValidation } from 'vscode-json-languageservice/lib/umd/services/jsonValidation';
-import { DiagnosticExt, YAML_SOURCE } from '../parser/jsonParser07';
+import { YAML_SOURCE } from '../parser/jsonParser07';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -28,8 +28,6 @@ export const yamlDiagToLSDiag = (yamlDiag: YAMLDocDiagnostic, textDocument: Text
 
   return Diagnostic.create(range, yamlDiag.message, yamlDiag.severity, undefined, YAML_SOURCE);
 };
-
-export const LATEST_DIAGNOSTIC = new Map<string, DiagnosticExt[]>();
 
 export class YAMLValidation {
   private validationEnabled: boolean;
@@ -104,7 +102,7 @@ export class YAMLValidation {
         foundSignatures.add(errSig);
       }
     }
-    LATEST_DIAGNOSTIC.set(textDocument.uri, duplicateMessagesRemoved);
+
     return duplicateMessagesRemoved;
   }
 }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -13,7 +13,7 @@ import { YAMLSchemaService } from './yamlSchemaService';
 import { YAMLDocDiagnostic } from '../utils/parseUtils';
 import { TextDocument } from 'vscode-languageserver';
 import { JSONValidation } from 'vscode-json-languageservice/lib/umd/services/jsonValidation';
-import { YAML_SOURCE } from '../parser/jsonParser07';
+import { DiagnosticExt, YAML_SOURCE } from '../parser/jsonParser07';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -28,6 +28,8 @@ export const yamlDiagToLSDiag = (yamlDiag: YAMLDocDiagnostic, textDocument: Text
 
   return Diagnostic.create(range, yamlDiag.message, yamlDiag.severity, undefined, YAML_SOURCE);
 };
+
+export const LATEST_DIAGNOSTIC = new Map<string, DiagnosticExt[]>();
 
 export class YAMLValidation {
   private validationEnabled: boolean;
@@ -102,7 +104,7 @@ export class YAMLValidation {
         foundSignatures.add(errSig);
       }
     }
-
+    LATEST_DIAGNOSTIC.set(textDocument.uri, duplicateMessagesRemoved);
     return duplicateMessagesRemoved;
   }
 }

--- a/src/languageservice/utils/ranges.ts
+++ b/src/languageservice/utils/ranges.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Range } from 'vscode-languageserver';
+
+/**
+ * Check if rangeA and rangeB is intersect
+ * @param rangeA
+ * @param rangeB
+ */
+export function isIntersect(rangeA: Range, rangeB: Range): boolean {
+  if (
+    rangeA.start.line >= rangeB.start.line &&
+    rangeA.start.character >= rangeB.start.character &&
+    rangeA.start.line <= rangeB.end.line &&
+    rangeA.start.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  if (
+    rangeA.end.line >= rangeB.start.line &&
+    rangeA.end.character >= rangeB.start.character &&
+    rangeA.end.line <= rangeB.end.line &&
+    rangeA.end.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  if (
+    rangeA.start.line >= rangeB.start.line &&
+    rangeA.start.character >= rangeB.start.character &&
+    rangeA.end.line <= rangeB.end.line &&
+    rangeA.end.character <= rangeB.end.character
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -134,7 +134,7 @@ export function getLanguageService(
   const yamlDocumentSymbols = new YAMLDocumentSymbols(schemaService);
   const yamlValidation = new YAMLValidation(schemaService);
   const formatter = new YAMLFormatter();
-  const yamlCodeActions = new YamlCodeActions(commandExecutor, connection);
+  const yamlCodeActions = new YamlCodeActions(commandExecutor, connection, clientCapabilities);
 
   return {
     configure: (settings) => {

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -8,35 +8,35 @@ export type ISchemaAssociations = Record<string, string[]>;
 
 export namespace SchemaAssociationNotification {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export const type: NotificationType<ISchemaAssociations | SchemaConfiguration[], any> = new NotificationType(
+  export const type: NotificationType<ISchemaAssociations | SchemaConfiguration[]> = new NotificationType(
     'json/schemaAssociations'
   );
 }
 
 export namespace DynamicCustomSchemaRequestRegistration {
-  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerCustomSchemaRequest');
+  export const type: NotificationType<{}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
 export namespace VSCodeContentRequestRegistration {
-  export const type: NotificationType<{}, {}> = new NotificationType('yaml/registerContentRequest');
+  export const type: NotificationType<{}> = new NotificationType('yaml/registerContentRequest');
 }
 
 export namespace VSCodeContentRequest {
-  export const type: RequestType<{}, {}, {}, {}> = new RequestType('vscode/content');
+  export const type: RequestType<{}, {}, {}> = new RequestType('vscode/content');
 }
 
 export namespace CustomSchemaContentRequest {
-  export const type: RequestType<{}, {}, {}, {}> = new RequestType('custom/schema/content');
+  export const type: RequestType<{}, {}, {}> = new RequestType('custom/schema/content');
 }
 
 export namespace CustomSchemaRequest {
-  export const type: RequestType<{}, {}, {}, {}> = new RequestType('custom/schema/request');
+  export const type: RequestType<{}, {}, {}> = new RequestType('custom/schema/request');
 }
 
 export namespace ColorSymbolRequest {
-  export const type: RequestType<{}, {}, {}, {}> = new RequestType('json/colorSymbols');
+  export const type: RequestType<{}, {}, {}> = new RequestType('json/colorSymbols');
 }
 
 export namespace SchemaModificationNotification {
-  export const type: RequestType<SchemaAdditions | SchemaDeletions, void, {}, {}> = new RequestType('json/schema/modify');
+  export const type: RequestType<SchemaAdditions | SchemaDeletions, void, {}> = new RequestType('json/schema/modify');
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { createConnection, IConnection, ProposedFeatures } from 'vscode-languageserver';
+import { createConnection, Connection, ProposedFeatures } from 'vscode-languageserver/node';
 import * as nls from 'vscode-nls';
 import { schemaRequestHandler, workspaceContext } from './languageservice/services/schemaRequestHandler';
 import { YAMLServerInit } from './yamlServerInit';
@@ -16,7 +16,7 @@ import { SettingsState } from './yamlSettings';
 nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
 
 // Create a connection for the server.
-let connection: IConnection = null;
+let connection: Connection = null;
 
 if (process.argv.indexOf('--stdio') === -1) {
   connection = createConnection(ProposedFeatures.all);
@@ -33,7 +33,7 @@ const yamlSettings = new SettingsState();
  * Handles schema content requests given the schema URI
  * @param uri can be a local file, vscode request, http(s) request or a custom request
  */
-const schemaRequestHandlerWrapper = (connection: IConnection, uri: string): Promise<string> => {
+const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promise<string> => {
   return schemaRequestHandler(
     connection,
     uri,

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -1,4 +1,4 @@
-import { TextDocuments, Disposable, ClientCapabilities, WorkspaceFolder } from 'vscode-languageserver';
+import { TextDocuments, Disposable, ClientCapabilities, WorkspaceFolder } from 'vscode-languageserver/node';
 import { CustomFormatterOptions, SchemaConfiguration } from './languageservice/yamlLanguageService';
 import { ISchemaAssociations } from './requestTypes';
 import { URI } from 'vscode-uri';
@@ -61,7 +61,7 @@ export class SettingsState {
 
   // Create a simple text document manager. The text document manager
   // supports full document sync only
-  documents: TextDocuments | TextDocumentTestManager = new TextDocuments();
+  documents: TextDocuments<TextDocument> | TextDocumentTestManager = new TextDocuments(TextDocument);
 
   // Language client configuration
   capabilities: ClientCapabilities;
@@ -73,8 +73,12 @@ export class SettingsState {
   useVSCodeContentRequest = false;
 }
 
-export class TextDocumentTestManager extends TextDocuments {
+export class TextDocumentTestManager extends TextDocuments<TextDocument> {
   testTextDocuments = new Map<string, TextDocument>();
+
+  constructor() {
+    super(TextDocument);
+  }
 
   get(uri: string): TextDocument | undefined {
     return this.testTextDocuments.get(uri);

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -8,7 +8,7 @@ import path = require('path');
 import { ServiceSetup } from './utils/serviceSetup';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
-import { CompletionList } from 'vscode-languageserver-types';
+import { CompletionList, TextEdit } from 'vscode-languageserver';
 import { expect } from 'chai';
 
 suite('Default Snippet Tests', () => {
@@ -270,11 +270,12 @@ suite('Default Snippet Tests', () => {
 
       assert.notEqual(result.items.length, 0);
       assert.equal(result.items[0].label, 'My boolean item');
-      assert.equal(result.items[0].textEdit.newText, 'false');
-      assert.equal(result.items[0].textEdit.range.start.line, 0);
-      assert.equal(result.items[0].textEdit.range.start.character, 9);
-      assert.equal(result.items[0].textEdit.range.end.line, 0);
-      assert.equal(result.items[0].textEdit.range.end.character, 9);
+      const textEdit = result.items[0].textEdit as TextEdit;
+      assert.equal(textEdit.newText, 'false');
+      assert.equal(textEdit.range.start.line, 0);
+      assert.equal(textEdit.range.start.character, 9);
+      assert.equal(textEdit.range.end.line, 0);
+      assert.equal(textEdit.range.end.character, 9);
     });
 
     it('should preserve space after ":"', async () => {
@@ -283,11 +284,12 @@ suite('Default Snippet Tests', () => {
 
       assert.notEqual(result.items.length, 0);
       assert.equal(result.items[0].label, 'My boolean item');
-      assert.equal(result.items[0].textEdit.newText, 'false');
-      assert.equal(result.items[0].textEdit.range.start.line, 0);
-      assert.equal(result.items[0].textEdit.range.start.character, 9);
-      assert.equal(result.items[0].textEdit.range.end.line, 0);
-      assert.equal(result.items[0].textEdit.range.end.character, 9);
+      const textEdit = result.items[0].textEdit as TextEdit;
+      assert.equal(textEdit.newText, 'false');
+      assert.equal(textEdit.range.start.line, 0);
+      assert.equal(textEdit.range.start.character, 9);
+      assert.equal(textEdit.range.end.line, 0);
+      assert.equal(textEdit.range.end.character, 9);
     });
 
     it('should add space before value on root node', async () => {

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -9,7 +9,7 @@ import { DocumentLink } from 'vscode-languageserver';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 
-suite('FindDefintion Tests', () => {
+suite('FindDefinition Tests', () => {
   let languageHandler: LanguageHandlers;
   let yamlSettings: SettingsState;
 
@@ -20,7 +20,7 @@ suite('FindDefintion Tests', () => {
     yamlSettings = settings;
   });
 
-  describe('Jump to defintion', function () {
+  describe('Jump to definition', function () {
     function findLinks(content: string): Promise<DocumentLink[]> {
       const testTextDocument = setupTextDocument(content);
       yamlSettings.documents = new TextDocumentTestManager();
@@ -30,7 +30,7 @@ suite('FindDefintion Tests', () => {
       });
     }
 
-    it('Find source defintion', (done) => {
+    it('Find source definition', (done) => {
       const content =
         "definitions:\n  link:\n    type: string\ntype: object\nproperties:\n  uri:\n    $ref: '#/definitions/link'\n";
       const definitions = findLinks(content);

--- a/test/schemaRequestHandler.test.ts
+++ b/test/schemaRequestHandler.test.ts
@@ -6,7 +6,7 @@
 import { schemaRequestHandler } from '../src/languageservice/services/schemaRequestHandler';
 import * as sinon from 'sinon';
 import * as fs from 'fs';
-import { IConnection } from 'vscode-languageserver';
+import { Connection } from 'vscode-languageserver';
 import * as assert from 'assert';
 import { URI } from 'vscode-uri';
 
@@ -23,7 +23,7 @@ suite('Schema Request Handler Tests', () => {
       sandbox.restore();
     });
     test('Should care Win URI', async () => {
-      const connection = <IConnection>{};
+      const connection = <Connection>{};
       const resultPromise = schemaRequestHandler(connection, 'c:\\some\\window\\path\\scheme.json', [], URI.parse(''), false);
       assert.ok(readFileStub.calledOnceWith('c:\\some\\window\\path\\scheme.json'));
       readFileStub.callArgWith(2, undefined, '{some: "json"}');
@@ -32,7 +32,7 @@ suite('Schema Request Handler Tests', () => {
     });
 
     test('UNIX URI should works', async () => {
-      const connection = <IConnection>{};
+      const connection = <Connection>{};
       const resultPromise = schemaRequestHandler(connection, '/some/unix/path/', [], URI.parse(''), false);
       readFileStub.callArgWith(2, undefined, '{some: "json"}');
       const result = await resultPromise;

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { createDiagnosticExt, createExpectedError } from './utils/verifyError';
+import { createDiagnosticWithData, createExpectedError } from './utils/verifyError';
 import { ServiceSetup } from './utils/serviceSetup';
 import {
   StringTypeError,
@@ -128,7 +128,7 @@ suite('Validation Tests', () => {
           assert.strictEqual(result.length, 1);
           assert.deepStrictEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               BooleanTypeError,
               0,
               11,
@@ -159,7 +159,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               StringTypeError,
               0,
               5,
@@ -251,7 +251,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               BooleanTypeError,
               0,
               11,
@@ -282,7 +282,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               StringTypeError,
               0,
               5,
@@ -333,7 +333,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               StringTypeError,
               0,
               5,
@@ -452,7 +452,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               ObjectTypeError,
               0,
               9,
@@ -506,7 +506,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               ArrayTypeError,
               0,
               11,
@@ -748,7 +748,7 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createDiagnosticExt(
+            createDiagnosticWithData(
               StringTypeError,
               0,
               4,
@@ -954,7 +954,7 @@ suite('Validation Tests', () => {
       const content = 'analytics: 1';
       const result = await parseSetup(content);
       expect(result[0]).deep.equal(
-        createDiagnosticExt(
+        createDiagnosticWithData(
           StringTypeError,
           0,
           11,
@@ -979,7 +979,7 @@ suite('Validation Tests', () => {
       yamlSettings.specificValidatorPaths = ['*.yml', '*.yaml'];
       const result = await parseSetup(content, 'file://~/Desktop/vscode-yaml/test.yml');
       expect(result[0]).deep.equal(
-        createDiagnosticExt(
+        createDiagnosticWithData(
           ArrayTypeError,
           4,
           10,
@@ -1000,7 +1000,7 @@ suite('Validation Tests', () => {
 
       const result = await parseSetup(content, 'file://~/Desktop/vscode-yaml/.drone.yml');
       expect(result[5]).deep.equal(
-        createDiagnosticExt(
+        createDiagnosticWithData(
           propertyIsNotAllowed('apiVersion'),
           1,
           6,

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { createExpectedError } from './utils/verifyError';
+import { createDiagnosticExt, createExpectedError } from './utils/verifyError';
 import { ServiceSetup } from './utils/serviceSetup';
 import {
   StringTypeError,
@@ -125,10 +125,19 @@ suite('Validation Tests', () => {
       const validator = parseSetup(content);
       validator
         .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
+          assert.strictEqual(result.length, 1);
+          assert.deepStrictEqual(
             result[0],
-            createExpectedError(BooleanTypeError, 0, 11, 0, 15, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              BooleanTypeError,
+              0,
+              11,
+              0,
+              15,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -150,7 +159,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(StringTypeError, 0, 5, 0, 10, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              StringTypeError,
+              0,
+              5,
+              0,
+              10,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -233,7 +251,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(BooleanTypeError, 0, 11, 0, 16, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              BooleanTypeError,
+              0,
+              11,
+              0,
+              16,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -255,7 +282,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(StringTypeError, 0, 5, 0, 7, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              StringTypeError,
+              0,
+              5,
+              0,
+              7,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -297,7 +333,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(StringTypeError, 0, 5, 0, 11, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              StringTypeError,
+              0,
+              5,
+              0,
+              11,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -407,7 +452,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(ObjectTypeError, 0, 9, 0, 13, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              ObjectTypeError,
+              0,
+              9,
+              0,
+              13,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -452,7 +506,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(ArrayTypeError, 0, 11, 0, 15, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              ArrayTypeError,
+              0,
+              11,
+              0,
+              15,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -685,7 +748,16 @@ suite('Validation Tests', () => {
           assert.equal(result.length, 1);
           assert.deepEqual(
             result[0],
-            createExpectedError(StringTypeError, 0, 4, 0, 4, DiagnosticSeverity.Error, `yaml-schema: file:///${SCHEMA_ID}`)
+            createDiagnosticExt(
+              StringTypeError,
+              0,
+              4,
+              0,
+              4,
+              DiagnosticSeverity.Error,
+              `yaml-schema: file:///${SCHEMA_ID}`,
+              `file:///${SCHEMA_ID}`
+            )
           );
         })
         .then(done, done);
@@ -882,7 +954,16 @@ suite('Validation Tests', () => {
       const content = 'analytics: 1';
       const result = await parseSetup(content);
       expect(result[0]).deep.equal(
-        createExpectedError(StringTypeError, 0, 11, 0, 12, DiagnosticSeverity.Error, 'yaml-schema: Schema Super title')
+        createDiagnosticExt(
+          StringTypeError,
+          0,
+          11,
+          0,
+          12,
+          DiagnosticSeverity.Error,
+          'yaml-schema: Schema Super title',
+          'file:///default_schema_id.yaml'
+        )
       );
     });
   });
@@ -898,7 +979,16 @@ suite('Validation Tests', () => {
       yamlSettings.specificValidatorPaths = ['*.yml', '*.yaml'];
       const result = await parseSetup(content, 'file://~/Desktop/vscode-yaml/test.yml');
       expect(result[0]).deep.equal(
-        createExpectedError(ArrayTypeError, 4, 10, 4, 18, DiagnosticSeverity.Error, 'yaml-schema: Package')
+        createDiagnosticExt(
+          ArrayTypeError,
+          4,
+          10,
+          4,
+          18,
+          DiagnosticSeverity.Error,
+          'yaml-schema: Package',
+          'https://json.schemastore.org/composer'
+        )
       );
     });
 
@@ -910,14 +1000,15 @@ suite('Validation Tests', () => {
 
       const result = await parseSetup(content, 'file://~/Desktop/vscode-yaml/.drone.yml');
       expect(result[5]).deep.equal(
-        createExpectedError(
+        createDiagnosticExt(
           propertyIsNotAllowed('apiVersion'),
           1,
           6,
           1,
           16,
           DiagnosticSeverity.Error,
-          'yaml-schema: Drone CI configuration file'
+          'yaml-schema: Drone CI configuration file',
+          'https://json.schemastore.org/drone'
         )
       );
     });

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { createConnection, Connection, TextDocument } from 'vscode-languageserver/node';
+import { createConnection, Connection } from 'vscode-languageserver/node';
 import path = require('path');
 import { SettingsState } from '../../src/yamlSettings';
 import { schemaRequestHandler, workspaceContext } from '../../src/languageservice/services/schemaRequestHandler';
@@ -10,6 +10,7 @@ import { YAMLServerInit } from '../../src/yamlServerInit';
 import { LanguageService, LanguageSettings } from '../../src';
 import { ValidationHandler } from '../../src/languageserver/handlers/validationHandlers';
 import { LanguageHandlers } from '../../src/languageserver/handlers/languageHandlers';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 export function toFsPath(str: unknown): string {
   if (typeof str !== 'string') {

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { createConnection, IConnection, TextDocument } from 'vscode-languageserver';
+import { createConnection, Connection, TextDocument } from 'vscode-languageserver/node';
 import path = require('path');
 import { SettingsState } from '../../src/yamlSettings';
 import { schemaRequestHandler, workspaceContext } from '../../src/languageservice/services/schemaRequestHandler';
@@ -52,7 +52,7 @@ export function setupLanguageService(languageSettings: LanguageSettings): TestLa
   const yamlSettings = new SettingsState();
   process.argv.push('--node-ipc');
   const connection = createConnection();
-  const schemaRequestHandlerWrapper = (connection: IConnection, uri: string): Promise<string> => {
+  const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promise<string> => {
     return schemaRequestHandler(
       connection,
       uri,

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { createConnection, Connection } from 'vscode-languageserver/node';
+import { createConnection, Connection, ClientCapabilities as LSPClientCapabilities } from 'vscode-languageserver/node';
 import path = require('path');
 import { SettingsState } from '../../src/yamlSettings';
 import { schemaRequestHandler, workspaceContext } from '../../src/languageservice/services/schemaRequestHandler';
@@ -67,7 +67,7 @@ export function setupLanguageService(languageSettings: LanguageSettings): TestLa
   const serverInit = new YAMLServerInit(connection, yamlSettings, workspaceContext, schemaRequestService);
   serverInit.connectionInitialized({
     processId: null,
-    capabilities: ClientCapabilities.LATEST,
+    capabilities: ClientCapabilities.LATEST as LSPClientCapabilities,
     rootUri: null,
     workspaceFolders: null,
   });

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -5,6 +5,7 @@
 
 import { DocumentSymbol, SymbolKind, InsertTextFormat, Range } from 'vscode-languageserver-types';
 import { CompletionItem, CompletionItemKind, SymbolInformation, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { DiagnosticExt } from '../../src/languageservice/parser/jsonParser07';
 
 export function createExpectedError(
   message: string,
@@ -16,6 +17,29 @@ export function createExpectedError(
   source = 'YAML'
 ): Diagnostic {
   return Diagnostic.create(Range.create(startLine, startCharacter, endLine, endCharacter), message, severity, undefined, source);
+}
+
+export function createDiagnosticExt(
+  message: string,
+  startLine: number,
+  startCharacter: number,
+  endLine: number,
+  endCharacter: number,
+  severity: DiagnosticSeverity = 1,
+  source = 'YAML',
+  schemaUri: string
+): DiagnosticExt {
+  const diagnostic: DiagnosticExt = createExpectedError(
+    message,
+    startLine,
+    startCharacter,
+    endLine,
+    endCharacter,
+    severity,
+    source
+  );
+  diagnostic.schemaUri = schemaUri;
+  return diagnostic;
 }
 
 export function createExpectedSymbolInformation(

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -5,7 +5,6 @@
 
 import { DocumentSymbol, SymbolKind, InsertTextFormat, Range } from 'vscode-languageserver-types';
 import { CompletionItem, CompletionItemKind, SymbolInformation, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { DiagnosticExt } from '../../src/languageservice/parser/jsonParser07';
 
 export function createExpectedError(
   message: string,
@@ -19,7 +18,7 @@ export function createExpectedError(
   return Diagnostic.create(Range.create(startLine, startCharacter, endLine, endCharacter), message, severity, undefined, source);
 }
 
-export function createDiagnosticExt(
+export function createDiagnosticWithData(
   message: string,
   startLine: number,
   startCharacter: number,
@@ -28,17 +27,9 @@ export function createDiagnosticExt(
   severity: DiagnosticSeverity = 1,
   source = 'YAML',
   schemaUri: string
-): DiagnosticExt {
-  const diagnostic: DiagnosticExt = createExpectedError(
-    message,
-    startLine,
-    startCharacter,
-    endLine,
-    endCharacter,
-    severity,
-    source
-  );
-  diagnostic.schemaUri = schemaUri;
+): Diagnostic {
+  const diagnostic: Diagnostic = createExpectedError(message, startLine, startCharacter, endLine, endCharacter, severity, source);
+  diagnostic.data = { schemaUri };
   return diagnostic;
 }
 

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -26,27 +26,27 @@ chai.use(sinonChai);
 
 const JSON_SCHEMA_LOCAL = 'file://some/path/schema.json';
 
-suite('CodeActions Tests', () => {
+describe('CodeActions Tests', () => {
   const sandbox = sinon.createSandbox();
 
   let commandExecutorStub: sinon.SinonStub;
   let clientCapabilities: ClientCapabilities;
-  setup(() => {
+  beforeEach(() => {
     commandExecutorStub = sandbox.stub(commandExecutor, 'registerCommand');
     clientCapabilities = {};
   });
 
-  teardown(() => {
+  afterEach(() => {
     sandbox.restore();
   });
 
-  suite('JumpToSchema tests', () => {
-    test('should register handler for "JumpToSchema" command', () => {
+  describe('JumpToSchema tests', () => {
+    it('should register handler for "JumpToSchema" command', () => {
       new YamlCodeActions(commandExecutor, ({} as unknown) as Connection, clientCapabilities);
       expect(commandExecutorStub).to.have.been.calledWithMatch(sinon.match('jumpToSchema'), sinon.match.func);
     });
 
-    test('JumpToSchema handler should call "showDocument"', async () => {
+    it('JumpToSchema handler should call "showDocument"', async () => {
       const showDocumentStub = sandbox.stub();
       const connection = ({
         window: {
@@ -60,7 +60,7 @@ suite('CodeActions Tests', () => {
       expect(showDocumentStub).to.have.been.calledWith({ uri: JSON_SCHEMA_LOCAL, external: false, takeFocus: true });
     });
 
-    test('should not provide any actions if there are no diagnostics', () => {
+    it('should not provide any actions if there are no diagnostics', () => {
       const doc = setupTextDocument('');
       const params: CodeActionParams = {
         context: CodeActionContext.create(undefined),
@@ -72,7 +72,7 @@ suite('CodeActions Tests', () => {
       expect(result).to.be.undefined;
     });
 
-    test('should provide action if diagnostic has uri for schema', () => {
+    it('should provide action if diagnostic has uri for schema', () => {
       const doc = setupTextDocument('');
       const diagnostics = [createDiagnosticWithData('foo', 0, 0, 0, 0, 1, JSON_SCHEMA_LOCAL, JSON_SCHEMA_LOCAL)];
       const params: CodeActionParams = {

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as chai from 'chai';
+import { commandExecutor } from '../src/languageserver/commandExecutor';
+import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
+import {
+  CodeAction,
+  CodeActionContext,
+  CodeActionParams,
+  Command,
+  Connection,
+  TextDocumentIdentifier,
+} from 'vscode-languageserver';
+import { setupTextDocument, TEST_URI } from './utils/testHelper';
+import { createDiagnosticWithData } from './utils/verifyError';
+import { YamlCommands } from '../src/commands';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const JSON_SCHEMA_LOCAL = 'file://some/path/schema.json';
+const JSON_SCHEMA_REMOTE = 'https://some.come/path/schema.json';
+
+suite('CodeActions Tests', () => {
+  const sandbox = sinon.createSandbox();
+
+  let commandExecutorStub: sinon.SinonStub;
+  setup(() => {
+    commandExecutorStub = sandbox.stub(commandExecutor, 'registerCommand');
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  suite('JumpToSchema tests', () => {
+    test('should register handler for "JumpToSchema" command', () => {
+      new YamlCodeActions(commandExecutor, ({} as unknown) as Connection);
+      expect(commandExecutorStub).to.have.been.calledWithMatch(sinon.match('jumpToSchema'), sinon.match.func);
+    });
+
+    test('JumpToSchema handler should call "showDocument"', async () => {
+      const showDocumentStub = sandbox.stub();
+      const connection = ({
+        window: {
+          showDocument: showDocumentStub,
+        },
+      } as unknown) as Connection;
+      showDocumentStub.resolves(true);
+      new YamlCodeActions(commandExecutor, connection);
+      const arg = commandExecutorStub.args[0];
+      await arg[1](JSON_SCHEMA_LOCAL);
+      expect(showDocumentStub).to.have.been.calledWith({ uri: JSON_SCHEMA_LOCAL, external: false, takeFocus: true });
+    });
+
+    test('should not provide any actions if there are no diagnostics', () => {
+      const doc = setupTextDocument('');
+      const params: CodeActionParams = {
+        context: CodeActionContext.create(undefined),
+        range: undefined,
+        textDocument: TextDocumentIdentifier.create(TEST_URI),
+      };
+      const actions = new YamlCodeActions(commandExecutor, ({} as unknown) as Connection);
+      const result = actions.getCodeAction(doc, params);
+      expect(result).to.be.undefined;
+    });
+
+    test('should provide action if diagnostic has uri for schema', () => {
+      const doc = setupTextDocument('');
+      const diagnostics = [createDiagnosticWithData('foo', 0, 0, 0, 0, 1, JSON_SCHEMA_LOCAL, JSON_SCHEMA_LOCAL)];
+      const params: CodeActionParams = {
+        context: CodeActionContext.create(diagnostics),
+        range: undefined,
+        textDocument: TextDocumentIdentifier.create(TEST_URI),
+      };
+      const actions = new YamlCodeActions(commandExecutor, ({} as unknown) as Connection);
+      const result = actions.getCodeAction(doc, params);
+
+      const codeAction = CodeAction.create(
+        'Jump to schema location',
+        Command.create('JumpToSchema', YamlCommands.JUMP_TO_SCHEMA, JSON_SCHEMA_LOCAL)
+      );
+      codeAction.diagnostics = diagnostics;
+      expect(result[0]).to.deep.equal(codeAction);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,28 +2235,28 @@ vscode-json-languageservice@^3.10.0:
     vscode-nls "^5.0.0"
     vscode-uri "^2.1.2"
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+vscode-jsonrpc@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
+  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+vscode-languageserver-protocol@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
+  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
   dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
+    vscode-jsonrpc "6.0.0"
+    vscode-languageserver-types "3.16.0"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
+vscode-languageserver-types@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
 vscode-languageserver-types@3.16.0-next.2:
   version "3.16.0-next.2"
@@ -2268,13 +2268,12 @@ vscode-languageserver-types@^3.15.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
-vscode-languageserver@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
-  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
+vscode-languageserver@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz#49b068c87cfcca93a356969d20f5d9bdd501c6b0"
+  integrity sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==
   dependencies:
-    vscode-languageserver-protocol "3.14.1"
-    vscode-uri "^1.0.6"
+    vscode-languageserver-protocol "3.16.0"
 
 vscode-nls@^4.1.1, vscode-nls@^4.1.2:
   version "4.1.2"
@@ -2285,11 +2284,6 @@ vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
 vscode-uri@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@types/chai@*":
+  version "4.2.14"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
+  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
+
 "@types/chai@^4.2.12":
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.12.tgz#6160ae454cd89dae05adc3bb97997f488b608201"
@@ -164,6 +169,21 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
+
+"@types/sinon-chai@^3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.5.tgz#df21ae57b10757da0b26f512145c065f2ad45c48"
+  integrity sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==
+  dependencies:
+    "@types/chai" "*"
+    "@types/sinon" "*"
+
+"@types/sinon@*":
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.10.tgz#7fb9bcb6794262482859cab66d59132fca18fcf7"
+  integrity sha512-/faDC0erR06wMdybwI/uR8wEKV/E83T0k4sepIpB7gXuy2gzx2xiOjmztq6a2Y6rIGJ04D+6UU0VBmWy+4HEMA==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
 
 "@types/sinon@^9.0.5":
   version "9.0.5"
@@ -2253,7 +2273,7 @@ vscode-languageserver-textdocument@^1.0.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
   integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
 
-vscode-languageserver-types@3.16.0:
+vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
@@ -2262,11 +2282,6 @@ vscode-languageserver-types@3.16.0-next.2:
   version "3.16.0-next.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz#940bd15c992295a65eae8ab6b8568a1e8daa3083"
   integrity sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==
-
-vscode-languageserver-types@^3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
 
 vscode-languageserver@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
### What does this PR do?
Adds code action to open json schema, this code action will be available only for JSON Schema specific error/warnings, only for schemas which URI has `file`(local schemas) or `https` (remote, usually for schema store).

Demo:
![ezgif com-gif-maker (10)](https://user-images.githubusercontent.com/929743/104919855-9afee400-599f-11eb-8893-4f0fc318417d.gif)

![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/929743/104919648-422f4b80-599f-11eb-810a-b7ba3aa13e0e.gif)

> Note: to be able to open files from LS this PR also update `vscode-languageclient` to `7.0.0` version

VSCode extension part: https://github.com/redhat-developer/vscode-yaml/pull/418

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/174

### Is it tested? How?

To test this you need https://github.com/redhat-developer/vscode-yaml/pull/418 also, just build both and run extension, open any yaml file with schema associated, make some error in it, after error appeared  in editor, there are yellow bulb should appeared for line with error, just click on it, an click on `Jump to schema location` and you should see JSON scheme opened in editor.
