### PR TITLE
Add on type conversion of tab char to spaces

### DIFF
--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -45,5 +45,14 @@ export function doDocumentOnTypeFormatting(
       return [TextEdit.insert(position, '  ')];
     }
   }
+
+  if (params.ch === '\t' && params.options.insertSpaces) {
+    return [
+      TextEdit.replace(
+        Range.create(position.line, position.character - 1, position.line, position.character),
+        ' '.repeat(params.options.tabSize)
+      ),
+    ];
+  }
   return;
 }

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -14,6 +14,7 @@ import { RequestHandlers } from './languageserver/handlers/requestHandlers';
 import { ValidationHandler } from './languageserver/handlers/validationHandlers';
 import { SettingsHandler } from './languageserver/handlers/settingsHandlers';
 import { ClientCapabilities } from 'vscode-json-languageservice';
+import { CharCode } from './languageservice/utils/charCode';
 
 export class YAMLServerInit {
   private yamlSettings: SettingsState;
@@ -69,6 +70,7 @@ export class YAMLServerInit {
             documentFormattingProvider: false,
             documentOnTypeFormattingProvider: {
               firstTriggerCharacter: '\n',
+              moreTriggerCharacter: ['\t'],
             },
             documentRangeFormattingProvider: false,
             documentLinkProvider: {},

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -16,58 +16,66 @@ function createParams(position: Position): DocumentOnTypeFormattingParams {
   };
 }
 suite('YAML On Type Formatter', () => {
-  it('should react on "\n" only', () => {
-    const doc = setupTextDocument('foo:');
-    const params = createParams(Position.create(1, 0));
-    params.ch = '\t';
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).is.undefined;
+  suite('On Enter Formatter', () => {
+    it('should add indentation for mapping', () => {
+      const doc = setupTextDocument('foo:\n');
+      const params = createParams(Position.create(1, 0));
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).to.deep.include(TextEdit.insert(Position.create(1, 0), '  '));
+    });
+
+    it('should add indentation for scalar array items', () => {
+      const doc = setupTextDocument('foo:\n  - some\n  ');
+      const pos = Position.create(2, 2);
+      const params = createParams(pos);
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result[0]).to.eqls(TextEdit.insert(pos, '- '));
+    });
+
+    it('should add indentation for mapping in array', () => {
+      const doc = setupTextDocument('some:\n  - arr:\n  ');
+      const pos = Position.create(2, 2);
+      const params = createParams(pos);
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).to.deep.include(TextEdit.insert(pos, '    '));
+    });
+
+    it('should replace all spaces in newline', () => {
+      const doc = setupTextDocument('some:\n    ');
+      const pos = Position.create(1, 0);
+      const params = createParams(pos);
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).to.deep.include.members([
+        TextEdit.del(Range.create(pos, Position.create(1, 3))),
+        TextEdit.insert(pos, '  '),
+      ]);
+    });
+
+    it('should keep all non white spaces characters in newline', () => {
+      const doc = setupTextDocument('some:\n  foo');
+      const pos = Position.create(1, 0);
+      const params = createParams(pos);
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).is.undefined;
+    });
+
+    it('should add indentation for multiline string', () => {
+      const doc = setupTextDocument('some: |\n');
+      const pos = Position.create(1, 0);
+      const params = createParams(pos);
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).to.deep.include(TextEdit.insert(pos, '  '));
+    });
   });
 
-  it('should add indentation for mapping', () => {
-    const doc = setupTextDocument('foo:\n');
-    const params = createParams(Position.create(1, 0));
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).to.deep.include(TextEdit.insert(Position.create(1, 0), '  '));
-  });
-
-  it('should add indentation for scalar array items', () => {
-    const doc = setupTextDocument('foo:\n  - some\n  ');
-    const pos = Position.create(2, 2);
-    const params = createParams(pos);
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result[0]).to.eqls(TextEdit.insert(pos, '- '));
-  });
-
-  it('should add indentation for mapping in array', () => {
-    const doc = setupTextDocument('some:\n  - arr:\n  ');
-    const pos = Position.create(2, 2);
-    const params = createParams(pos);
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).to.deep.include(TextEdit.insert(pos, '    '));
-  });
-
-  it('should replace all spaces in newline', () => {
-    const doc = setupTextDocument('some:\n    ');
-    const pos = Position.create(1, 0);
-    const params = createParams(pos);
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).to.deep.include.members([TextEdit.del(Range.create(pos, Position.create(1, 3))), TextEdit.insert(pos, '  ')]);
-  });
-
-  it('should keep all non white spaces characters in newline', () => {
-    const doc = setupTextDocument('some:\n  foo');
-    const pos = Position.create(1, 0);
-    const params = createParams(pos);
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).is.undefined;
-  });
-
-  it('should add indentation for multiline string', () => {
-    const doc = setupTextDocument('some: |\n');
-    const pos = Position.create(1, 0);
-    const params = createParams(pos);
-    const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).to.deep.include(TextEdit.insert(pos, '  '));
+  suite('On Tab Formatter', () => {
+    it('should replace Tab with spaces', () => {
+      const doc = setupTextDocument('some:\n\t');
+      const pos = Position.create(1, 1);
+      const params = createParams(pos);
+      params.ch = '\t';
+      const result = doDocumentOnTypeFormatting(doc, params);
+      expect(result).to.deep.include(TextEdit.replace(Range.create(1, 0, 1, 1), '  '));
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Add on type conversion of tab char to spaces

### What issues does this PR fix or reference?
#244

### Is it tested? How?
With unit test. Unfortunately vscode doesn't trigger onTypeFormatting when `\\t` character is typed, maybe I need to report an issue for it. 