### PR TITLE
feat: add multiple schema deletions

### DIFF
--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -31,7 +31,7 @@ export class RequestHandlers {
       this.languageService.modifySchemaContent(modifications);
     } else if (modifications.action === MODIFICATION_ACTIONS.delete) {
       this.languageService.deleteSchemaContent(modifications);
-    } else if (modifications.action === MODIFICATION_ACTIONS.deleteWhole) {
+    } else if (modifications.action === MODIFICATION_ACTIONS.deleteAll) {
       this.languageService.deleteSchemasWhole(modifications);
     }
   }

--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -3,7 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { IConnection } from 'vscode-languageserver';
-import { MODIFICATION_ACTIONS, SchemaAdditions, SchemaDeletions } from '../../languageservice/services/yamlSchemaService';
+import {
+  MODIFICATION_ACTIONS,
+  SchemaAdditions,
+  SchemaDeletions,
+  SchemaDeletionsWhole,
+} from '../../languageservice/services/yamlSchemaService';
 import { LanguageService } from '../../languageservice/yamlLanguageService';
 import { SchemaModificationNotification } from '../../requestTypes';
 
@@ -19,11 +24,15 @@ export class RequestHandlers {
     );
   }
 
-  private registerSchemaModificationNotificationHandler(modifications: SchemaAdditions | SchemaDeletions): void {
+  private registerSchemaModificationNotificationHandler(
+    modifications: SchemaAdditions | SchemaDeletions | SchemaDeletionsWhole
+  ): void {
     if (modifications.action === MODIFICATION_ACTIONS.add) {
       this.languageService.modifySchemaContent(modifications);
     } else if (modifications.action === MODIFICATION_ACTIONS.delete) {
       this.languageService.deleteSchemaContent(modifications);
+    } else if (modifications.action === MODIFICATION_ACTIONS.deleteWhole) {
+      this.languageService.deleteSchemasWhole(modifications);
     }
   }
 }

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -31,6 +31,7 @@ export declare type CustomSchemaProvider = (uri: string) => Promise<string | str
 export enum MODIFICATION_ACTIONS {
   'delete',
   'add',
+  'deleteWhole',
 }
 
 export interface SchemaAdditions {
@@ -47,6 +48,11 @@ export interface SchemaDeletions {
   action: MODIFICATION_ACTIONS.delete;
   path: string;
   key: string;
+}
+
+export interface SchemaDeletionsWhole {
+  schemas: string[];
+  action: MODIFICATION_ACTIONS.deleteWhole;
 }
 
 export class FilePatternAssociation {
@@ -455,6 +461,15 @@ export class YAMLSchemaService extends JSONSchemaService {
     return Promise.resolve(undefined);
   }
 
+  /**
+   * Delete schemas on specific path
+   */
+  public async deleteSchemas(deletions: SchemaDeletionsWhole): Promise<void> {
+    deletions.schemas.forEach((s) => {
+      this.deleteSchema(s);
+    });
+    return Promise.resolve(undefined);
+  }
   /**
    * Delete a schema with schema ID.
    */

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -31,7 +31,7 @@ export declare type CustomSchemaProvider = (uri: string) => Promise<string | str
 export enum MODIFICATION_ACTIONS {
   'delete',
   'add',
-  'deleteWhole',
+  'deleteAll',
 }
 
 export interface SchemaAdditions {
@@ -52,7 +52,7 @@ export interface SchemaDeletions {
 
 export interface SchemaDeletionsWhole {
   schemas: string[];
-  action: MODIFICATION_ACTIONS.deleteWhole;
+  action: MODIFICATION_ACTIONS.deleteAll;
 }
 
 export class FilePatternAssociation {

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -4,7 +4,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { YAMLSchemaService, CustomSchemaProvider, SchemaAdditions, SchemaDeletions } from './services/yamlSchemaService';
+import {
+  YAMLSchemaService,
+  CustomSchemaProvider,
+  SchemaAdditions,
+  SchemaDeletions,
+  SchemaDeletionsWhole,
+} from './services/yamlSchemaService';
 import {
   Position,
   CompletionList,
@@ -107,6 +113,7 @@ export interface LanguageService {
   deleteSchema(schemaID: string): void;
   modifySchemaContent(schemaAdditions: SchemaAdditions): void;
   deleteSchemaContent(schemaDeletions: SchemaDeletions): void;
+  deleteSchemasWhole(schemaDeletions: SchemaDeletionsWhole): void;
   getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | null;
 }
 
@@ -164,6 +171,9 @@ export function getLanguageService(
     },
     deleteSchemaContent: (schemaDeletions: SchemaDeletions) => {
       return schemaService.deleteContent(schemaDeletions);
+    },
+    deleteSchemasWhole: (schemaDeletions: SchemaDeletionsWhole) => {
+      return schemaService.deleteSchemas(schemaDeletions);
     },
     getFoldingRanges,
   };

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -505,6 +505,23 @@ suite('JSON Schema', () => {
     });
   });
 
+  test('Deleting schemas', async () => {
+    const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+    service.setSchemaContributions({
+      schemas: {
+        'https://myschemastore/main/schema1.json': {
+          type: 'object',
+        },
+      },
+    });
+    await service.deleteSchemas({
+      action: MODIFICATION_ACTIONS.deleteWhole,
+      schemas: ['https://myschemastore/main/schema1.json'],
+    } as SchemaService.SchemaDeletionsWhole);
+    const fs = await service.getResolvedSchema('https://myschemastore/main/schema1.json');
+    assert.equal(fs, undefined);
+  });
+
   test('Modifying schema works with kubernetes resolution', async () => {
     const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
     service.registerExternalSchema(KUBERNETES_SCHEMA_URL);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -515,7 +515,7 @@ suite('JSON Schema', () => {
       },
     });
     await service.deleteSchemas({
-      action: MODIFICATION_ACTIONS.deleteWhole,
+      action: MODIFICATION_ACTIONS.deleteAll,
       schemas: ['https://myschemastore/main/schema1.json'],
     } as SchemaService.SchemaDeletionsWhole);
     const fs = await service.getResolvedSchema('https://myschemastore/main/schema1.json');


### PR DESCRIPTION
### What does this PR do?
add schema modification to delete schemas from cache.
```ts
export enum MODIFICATION_ACTIONS {
  'delete',
  'add',
  'deleteWhole',
}
```

#### Motivation:
when dynamically changing shared schema, I use this deleteWhole schema action to delete old parent schemas from cache. So language server will reload parents schemas with updated referenced schema. 


### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added unit test