### PR TITLE
Fix services initialization

### DIFF
--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -10,6 +10,7 @@ import { YAMLServerInit } from '../../src/yamlServerInit';
 import { LanguageService, LanguageSettings } from '../../src';
 import { ValidationHandler } from '../../src/languageserver/handlers/validationHandlers';
 import { LanguageHandlers } from '../../src/languageserver/handlers/languageHandlers';
+import { ClientCapabilities } from 'vscode-json-languageservice';
 
 export function toFsPath(str: unknown): string {
   if (typeof str !== 'string') {
@@ -63,6 +64,12 @@ export function setupLanguageService(languageSettings: LanguageSettings): TestLa
   };
   const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
   const serverInit = new YAMLServerInit(connection, yamlSettings, workspaceContext, schemaRequestService);
+  serverInit.connectionInitialized({
+    processId: null,
+    capabilities: ClientCapabilities.LATEST,
+    rootUri: null,
+    workspaceFolders: null,
+  });
   const languageService = serverInit.languageService;
   const validationHandler = serverInit.validationHandler;
   const languageHandler = serverInit.languageHandler;


### PR DESCRIPTION
### What does this PR do?
Fixes services initialization, before we create two instances of `LanguageService` first with default client capabilities (for tests setup) and second when we receive real client capabilities, the problem in first as it was used to handle all requests from client. In that case we not handle client capabilities at all.

### What issues does this PR fix or reference?
Found during work on https://github.com/redhat-developer/yaml-language-server/pull/395

### Is it tested? How?
Just run yaml-ls with this PR changes, you should not see any differences in LS behaviour
