### PR TITLE
Fix indentation for object in array completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -893,10 +893,10 @@ export class YAMLCompletion extends JSONCompletion {
             value = ' $1';
             break;
           case 'object':
-            value = `\n${this.indentation}`;
+            value = `\n${ident}`;
             break;
           case 'array':
-            value = `\n${this.indentation}- `;
+            value = `\n${ident}- `;
             break;
           case 'number':
           case 'integer':

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1880,5 +1880,16 @@ describe('Auto Completion Tests', () => {
         assert.equal(result.items[0].label, '- (array item) 1');
       });
     });
+
+    it('Array anyOf two objects completion indentation', async () => {
+      const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'test_array_anyOf_2objects:\n  - obj';
+      const completion = await parseSetup(content, content.length);
+      expect(completion.items.length).is.equal(2);
+      const obj1 = completion.items.find((it) => it.label === 'obj1');
+      expect(obj1).is.not.undefined;
+      expect(obj1.textEdit.newText).equal('obj1:\n    ');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix indentation for object in array completion:

https://user-images.githubusercontent.com/929743/109007357-b5ba2c00-76b4-11eb-8fc5-8ab5d3083e0f.mov


### What issues does this PR fix or reference?
Fix: #392

### Is it tested? How?
With test and manually see video. 
