### PR TITLE
Add CodeAction to convert Tab characters to spaces

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -516,7 +516,13 @@ export class JSONDocument {
           textDocument.positionAt(p.location.offset),
           textDocument.positionAt(p.location.offset + p.location.length)
         );
-        const diagnostic: Diagnostic = Diagnostic.create(range, p.message, p.severity, p.code, p.source);
+        const diagnostic: Diagnostic = Diagnostic.create(
+          range,
+          p.message,
+          p.severity,
+          p.code ? p.code : ErrorCode.Undefined,
+          p.source
+        );
         diagnostic.data = { schemaUri: p.schemaUri };
         return diagnostic;
       });

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { Diagnostic } from 'vscode-languageserver';
+import { Diagnostic, Position } from 'vscode-languageserver';
 import { LanguageSettings } from '../yamlLanguageService';
 import { parse as parseYAML, YAMLDocument } from '../parser/yamlParser07';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
@@ -14,6 +14,7 @@ import { YAMLDocDiagnostic } from '../utils/parseUtils';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { JSONValidation } from 'vscode-json-languageservice/lib/umd/services/jsonValidation';
 import { YAML_SOURCE } from '../parser/jsonParser07';
+import { TextBuffer } from '../utils/textBuffer';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -21,12 +22,15 @@ import { YAML_SOURCE } from '../parser/jsonParser07';
  * @param textDocument TextDocument from the language server client
  */
 export const yamlDiagToLSDiag = (yamlDiag: YAMLDocDiagnostic, textDocument: TextDocument): Diagnostic => {
+  const start = textDocument.positionAt(yamlDiag.location.start);
   const range = {
-    start: textDocument.positionAt(yamlDiag.location.start),
-    end: textDocument.positionAt(yamlDiag.location.end),
+    start,
+    end: yamlDiag.location.toLineEnd
+      ? Position.create(start.line, new TextBuffer(textDocument).getLineLength(yamlDiag.location.start))
+      : textDocument.positionAt(yamlDiag.location.end),
   };
 
-  return Diagnostic.create(range, yamlDiag.message, yamlDiag.severity, undefined, YAML_SOURCE);
+  return Diagnostic.create(range, yamlDiag.message, yamlDiag.severity, yamlDiag.code, YAML_SOURCE);
 };
 
 export class YAMLValidation {
@@ -76,6 +80,7 @@ export class YAMLValidation {
       index++;
     }
 
+    let previousErr: Diagnostic;
     const foundSignatures = new Set();
     const duplicateMessagesRemoved: Diagnostic[] = [];
     for (let err of validationResult) {
@@ -94,6 +99,18 @@ export class YAMLValidation {
 
       if (!err.source) {
         err.source = YAML_SOURCE;
+      }
+
+      if (
+        previousErr &&
+        previousErr.message === err.message &&
+        previousErr.range.end.line === err.range.start.line &&
+        Math.abs(previousErr.range.end.character - err.range.end.character) >= 1
+      ) {
+        previousErr.range.end = err.range.end;
+        continue;
+      } else {
+        previousErr = err;
       }
 
       const errSig = err.range.start.line + ' ' + err.range.start.character + ' ' + err.message;

--- a/src/languageservice/utils/parseUtils.ts
+++ b/src/languageservice/utils/parseUtils.ts
@@ -2,6 +2,7 @@ import * as Yaml from 'yaml-language-server-parser';
 import { Schema, Type } from 'js-yaml';
 
 import { filterInvalidCustomTags } from './arrUtils';
+import { ErrorCode } from 'vscode-json-languageservice/lib/umd/jsonLanguageTypes';
 
 export const DUPLICATE_KEY_REASON = 'duplicate key';
 
@@ -14,9 +15,11 @@ export interface YAMLDocDiagnostic {
   location: {
     start: number;
     end: number;
+    toLineEnd: boolean;
   };
   severity: 1 | 2;
   source?: string;
+  code: ErrorCode;
 }
 
 /**
@@ -29,9 +32,11 @@ function exceptionToDiagnostic(e: Yaml.YAMLException): YAMLDocDiagnostic {
     message: `${e.reason}`,
     location: {
       start: e.mark.position,
-      end: e.mark.position + e.mark.column,
+      end: e.mark.position + 1, // we do not know actual end of error, so assuming that it 1 character
+      toLineEnd: e.mark.toLineEnd,
     },
     severity: 2,
+    code: ErrorCode.Undefined,
   };
 }
 

--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-json-languageservice';
 import { Range } from 'vscode-languageserver-types';
 
 interface FullTextDocument {

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -159,6 +159,7 @@ export function getLanguageService(
       const customTagsSetting = settings && settings['customTags'] ? settings['customTags'] : [];
       completer.configure(settings, customTagsSetting);
       formatter.configure(settings);
+      yamlCodeActions.configure(settings);
     },
     registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => {
       schemaService.registerCustomSchemaProvider(schemaProvider);

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -91,7 +91,7 @@ describe('Custom Tag tests Tests', () => {
       validator
         .then(function (result) {
           assert.equal(result.length, 1);
-          assert.deepEqual(result[0], createExpectedError('unknown tag <!test>', 0, 0, 0, 0));
+          assert.deepEqual(result[0], createExpectedError('unknown tag <!test>', 0, 0, 0, 5));
         })
         .then(done, done);
     });

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -773,8 +773,8 @@ describe('Validation Tests', () => {
       validator
         .then(function (result) {
           assert.equal(result.length, 2);
-          assert.deepEqual(result[0], createExpectedError(DuplicateKeyError, 2, 0, 2, 0));
-          assert.deepEqual(result[1], createExpectedError(DuplicateKeyError, 0, 0, 0, 0));
+          assert.deepEqual(result[0], createExpectedError(DuplicateKeyError, 2, 0, 2, 1));
+          assert.deepEqual(result[1], createExpectedError(DuplicateKeyError, 0, 0, 0, 1));
         })
         .then(done, done);
     });

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -5,6 +5,7 @@
 
 import { DocumentSymbol, SymbolKind, InsertTextFormat, Range } from 'vscode-languageserver-types';
 import { CompletionItem, CompletionItemKind, SymbolInformation, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { ErrorCode } from 'vscode-json-languageservice';
 
 export function createExpectedError(
   message: string,
@@ -13,9 +14,10 @@ export function createExpectedError(
   endLine: number,
   endCharacter: number,
   severity: DiagnosticSeverity = 1,
-  source = 'YAML'
+  source = 'YAML',
+  code = ErrorCode.Undefined
 ): Diagnostic {
-  return Diagnostic.create(Range.create(startLine, startCharacter, endLine, endCharacter), message, severity, undefined, source);
+  return Diagnostic.create(Range.create(startLine, startCharacter, endLine, endCharacter), message, severity, code, source);
 }
 
 export function createDiagnosticWithData(

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -137,7 +137,7 @@ describe('CodeActions Tests', () => {
       };
       const actions = new YamlCodeActions(commandExecutor, ({} as unknown) as Connection, clientCapabilities);
       const result = actions.getCodeAction(doc, params);
-      expect(result).to.has.length(1);
+      expect(result).to.has.length(2);
       expect(result[0].title).to.be.equal('Convert Tab to Spaces');
       expect(WorkspaceEdit.is(result[0].edit)).to.be.true;
       expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(1, 0, 1, 1), '  ')]);
@@ -157,6 +157,24 @@ describe('CodeActions Tests', () => {
 
       expect(result[0].title).to.be.equal('Convert Tab to Spaces');
       expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(1, 0, 1, 1), '   ')]);
+    });
+
+    it('should provide "Convert all Tabs to Spaces"', () => {
+      const doc = setupTextDocument('foo:\n\t\t\t- bar\n\t\t');
+      const diagnostics = [createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 3, 1, JSON_SCHEMA_LOCAL)];
+      const params: CodeActionParams = {
+        context: CodeActionContext.create(diagnostics),
+        range: undefined,
+        textDocument: TextDocumentIdentifier.create(TEST_URI),
+      };
+      const actions = new YamlCodeActions(commandExecutor, ({} as unknown) as Connection, clientCapabilities);
+      const result = actions.getCodeAction(doc, params);
+
+      expect(result[1].title).to.be.equal('Convert all Tabs to Spaces');
+      expect(result[1].edit.changes[TEST_URI]).deep.equal([
+        TextEdit.replace(Range.create(1, 0, 1, 3), '      '),
+        TextEdit.replace(Range.create(2, 0, 2, 2), '    '),
+      ]);
     });
   });
 });

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Diagnostic } from 'vscode-languageserver-types';
+import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import { LanguageService } from '../src/languageservice/yamlLanguageService';
+import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
+import { ServiceSetup } from './utils/serviceSetup';
+import { setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { expect } from 'chai';
+import { createExpectedError } from './utils/verifyError';
+
+describe('YAML Validation Tests', () => {
+  let languageSettingsSetup: ServiceSetup;
+  let languageService: LanguageService;
+  let validationHandler: ValidationHandler;
+  let yamlSettings: SettingsState;
+  before(() => {
+    languageSettingsSetup = new ServiceSetup().withValidate();
+    const { languageService: langService, validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
+      languageSettingsSetup.languageSettings
+    );
+    languageService = langService;
+    validationHandler = valHandler;
+    yamlSettings = settings;
+  });
+
+  function parseSetup(content: string, customSchemaID?: string): Promise<Diagnostic[]> {
+    const testTextDocument = setupSchemaIDTextDocument(content, customSchemaID);
+    yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+    return validationHandler.validateTextDocument(testTextDocument);
+  }
+  describe('TAB Character diagnostics', () => {
+    it('Should report if TAB character present', async () => {
+      const yaml = 'foo:\n\t- bar';
+      const result = await parseSetup(yaml);
+      expect(result).is.not.empty;
+      expect(result.length).to.be.equal(1);
+      expect(result[0]).deep.equal(createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 1));
+    });
+
+    it('Should report one error for TAB character present in a row', async () => {
+      const yaml = 'foo:\n\t\t- bar';
+      const result = await parseSetup(yaml);
+      expect(result).is.not.empty;
+      expect(result.length).to.be.equal(1);
+      expect(result[0]).deep.equal(createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 2));
+    });
+
+    it('Should report one error for TAB`s characters present in the middle of indentation', async () => {
+      const yaml = 'foo:\n \t\t\t - bar';
+      const result = await parseSetup(yaml);
+      expect(result).is.not.empty;
+      expect(result.length).to.be.equal(1);
+      expect(result[0]).deep.equal(createExpectedError('Using tabs can lead to unpredictable results', 1, 1, 1, 4));
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
This PR adds various things:

- Improves yaml parser diagnostics reporting, now diagnostics has proper text regions
- Collapse multiple `Using tabs can lead to unpredictable results` diagnostic in to one, previously we report each tab character separately
-  Add CodeAction to convert Tab characters to spaces

Demo:

https://user-images.githubusercontent.com/929743/109139137-d68d8a80-7763-11eb-995c-e1cd5e02462c.mov

Convert all tabs to spaces:

https://user-images.githubusercontent.com/929743/109173190-3f88f880-778c-11eb-8f69-acc9ca934657.mov



### What issues does this PR fix or reference?
Fix: #244 

### Is it tested? How?
With new tests and manually, just create yaml file with tab's characters and see that  `Using tabs can lead to unpredictable results` error has CodeAction `Convert Tab to Spaces` and when it executed tabs replaced with spaces according to current editor settings.
