### PR TITLE
Fix 'fileMatch' pattern to match whole file name

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -116,18 +116,17 @@ export class SettingsHandler {
    * AND the schema store setting is enabled. If the schema store setting
    * is not enabled we need to clear the schemas.
    */
-  public setSchemaStoreSettingsIfNotSet(): void {
+  public async setSchemaStoreSettingsIfNotSet(): Promise<void> {
     const schemaStoreIsSet = this.yamlSettings.schemaStoreSettings.length !== 0;
 
     if (this.yamlSettings.schemaStoreEnabled && !schemaStoreIsSet) {
-      this.getSchemaStoreMatchingSchemas()
-        .then((schemaStore) => {
-          this.yamlSettings.schemaStoreSettings = schemaStore.schemas;
-          this.updateConfiguration();
-        })
-        .catch(() => {
-          // ignore
-        });
+      try {
+        const schemaStore = await this.getSchemaStoreMatchingSchemas();
+        this.yamlSettings.schemaStoreSettings = schemaStore.schemas;
+        this.updateConfiguration();
+      } catch (err) {
+        // ignore
+      }
     } else if (!this.yamlSettings.schemaStoreEnabled) {
       this.yamlSettings.schemaStoreSettings = [];
       this.updateConfiguration();

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -152,12 +152,13 @@ export class SettingsHandler {
 
         if (schema && schema.fileMatch) {
           for (const fileMatch in schema.fileMatch) {
-            const currFileMatch = schema.fileMatch[fileMatch];
+            const currFileMatch: string = schema.fileMatch[fileMatch];
             // If the schema is for files with a YAML extension, save the schema association
             if (currFileMatch.indexOf('.yml') !== -1 || currFileMatch.indexOf('.yaml') !== -1) {
               languageSettings.schemas.push({
                 uri: schema.url,
-                fileMatch: [currFileMatch],
+                // this is workaround to fix file matcher, adding '/' force to match full file name instead of just file name ends
+                fileMatch: [currFileMatch.indexOf('/') === -1 ? '/' + currFileMatch : currFileMatch],
               });
             }
           }

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import { Connection } from 'vscode-languageserver';
+import { SettingsState } from '../src/yamlSettings';
+import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import { LanguageService } from '../src';
+import * as request from 'request-light';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('Settings Handlers Tests', () => {
+  const sandbox = sinon.createSandbox();
+  let connectionStub: sinon.SinonMockStatic;
+  let languageService: sinon.SinonMockStatic;
+  let settingsState: SettingsState;
+  let validationHandler: sinon.SinonMock;
+  let xhrStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    connectionStub = sandbox.mock();
+    languageService = sandbox.mock();
+    settingsState = new SettingsState();
+    validationHandler = sandbox.mock(ValidationHandler);
+    xhrStub = sandbox.stub(request, 'xhr');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('SettingsHandler should modify file match patters', async () => {
+    xhrStub.resolves({
+      responseText: `{"schemas": [
+      {
+        "name": ".adonisrc.json",
+        "description": "AdonisJS configuration file",
+        "fileMatch": [
+          ".adonisrc.yaml"
+        ],
+        "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
+      }]}`,
+    });
+    const settingsHandler = new SettingsHandler(
+      (connectionStub as unknown) as Connection,
+      (languageService as unknown) as LanguageService,
+      settingsState,
+      (validationHandler as unknown) as ValidationHandler
+    );
+
+    sandbox.stub(settingsHandler, 'updateConfiguration').returns();
+
+    await settingsHandler.setSchemaStoreSettingsIfNotSet();
+
+    expect(settingsState.schemaStoreSettings).deep.include({
+      uri: 'https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json',
+      fileMatch: ['/.adonisrc.yaml'],
+    });
+  });
+});

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { Diagnostic } from 'vscode-languageserver-types';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
 import { setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
@@ -13,15 +12,13 @@ import { createExpectedError } from './utils/verifyError';
 
 describe('YAML Validation Tests', () => {
   let languageSettingsSetup: ServiceSetup;
-  let languageService: LanguageService;
   let validationHandler: ValidationHandler;
   let yamlSettings: SettingsState;
   before(() => {
     languageSettingsSetup = new ServiceSetup().withValidate();
-    const { languageService: langService, validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
+    const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
       languageSettingsSetup.languageSettings
     );
-    languageService = langService;
     validationHandler = valHandler;
     yamlSettings = settings;
   });


### PR DESCRIPTION
### What does this PR do?
It add `/` to file match pattern, if pattern doesn't include it.
The original problem in `vscode-json-languageservice`, it the way how file match implemented there.
Basically it match only file name end(i.e. `arc.yaml` and `.mocharc.yaml` file patterns will match to `/some/path/.mocharc.yaml`) 
This PR is basically, trying to workaround that behaviour, by forcing matching against full file name.

`vscode-json-languageservice` has similar issues:

- https://github.com/microsoft/vscode/issues/67191
- https://github.com/microsoft/vscode/issues/44135

Demo:
<img width="433" alt="Screenshot 2021-03-01 at 14 16 14" src="https://user-images.githubusercontent.com/929743/109498071-a283d380-7a9b-11eb-9902-7bc2e8581bb1.png">


### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/354
and fix: https://github.com/redhat-developer/vscode-yaml/issues/397

### Is it tested? How?
Just create `.mocharc.yaml` file, open it and make sure that JSON Schema selected properly.
