### PR TITLE
Disable folding range provider

### DIFF
--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -91,7 +91,8 @@ export class YAMLServerInit {
         },
         documentRangeFormattingProvider: false,
         documentLinkProvider: {},
-        foldingRangeProvider: true,
+        // disabled until we not get parser which parse comments as separate nodes
+        foldingRangeProvider: false,
         codeActionProvider: true,
         executeCommandProvider: {
           commands: Object.keys(YamlCommands).map((k) => YamlCommands[k]),


### PR DESCRIPTION
### What does this PR do?
Disable folding range provider, as with current parser we cannot implement it correctly, as it eats comments so we cannot calculate correct AST node end.
https://github.com/redhat-developer/yaml-language-server/issues/421 can help as thous parser correctly works with comments.

### What issues does this PR fix or reference?
Fix: #400

