### PR TITLE
Fix validation for empty file

### DIFF
--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -49,11 +49,6 @@ export class ValidationHandler {
       return;
     }
 
-    if (textDocument.getText().length === 0) {
-      this.connection.sendDiagnostics({ uri: textDocument.uri, diagnostics: [] });
-      return;
-    }
-
     return this.languageService
       .doValidation(textDocument, isKubernetesAssociatedDocument(textDocument, this.yamlSettings.specificValidatorPaths))
       .then(

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -57,7 +57,12 @@ export class YAMLValidation {
       return Promise.resolve([]);
     }
 
-    const yamlDocument: YAMLDocument = parseYAML(textDocument.getText(), this.customTags);
+    let text = textDocument.getText();
+    // if text is contains only whitespace wrap all text in object to force schema selection
+    if (!/\S/.test(text)) {
+      text = `{${text}}`;
+    }
+    const yamlDocument: YAMLDocument = parseYAML(text, this.customTags);
     const validationResult = [];
 
     let index = 0;


### PR DESCRIPTION
### What does this PR do?
Fixes validation for empty file or for file which contains only whitespace's (` `, `\n`, `\t`).

<img width="916" alt="Screenshot 2021-03-18 at 11 21 50" src="https://user-images.githubusercontent.com/929743/111602995-93f82480-87dc-11eb-9e9f-a1c15d8f6200.png">


### What issues does this PR fix or reference?
Fix: #413 

### Is it tested? How?
With tests.
To test manually open any yaml file with json schema associated, schema should contain required fields for root object, and yaml file should be empty or contains only whitespace characters, validation should work for such yaml file.   
