### PR TITLE
Update kubernetes schema to 1.20.5

### DIFF
--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -3,7 +3,7 @@ import { URI } from 'vscode-uri';
 import { isRelativePath, relativeToAbsolutePath } from './paths';
 
 export const KUBERNETES_SCHEMA_URL =
-  'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.18.1-standalone-strict/all.json';
+  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.20.5-standalone-strict/all.json';
 export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';
 
 export function checkSchemaURI(workspaceFolders: WorkspaceFolder[], workspaceRoot: URI, uri: string): string {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -19,7 +19,7 @@ describe('Kubernetes Integration Tests', () => {
   let yamlSettings: SettingsState;
 
   before(() => {
-    const uri = 'https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.18.1-standalone-strict/all.json';
+    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.20.5-standalone-strict/all.json';
     const fileMatch = ['*.yml', '*.yaml'];
     languageSettingsSetup = new ServiceSetup()
       .withHover()


### PR DESCRIPTION
According to https://github.com/instrumenta/kubernetes-json-schema/issues/26 we also need to change the referenced schema repository to https://github.com/yannh/kubernetes-json-schema/ that now contains latest/daily updated schemas.