### PR TITLE
Use 'markdownDescription' for property completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -291,7 +291,7 @@ export class YAMLCompletion extends JSONCompletion {
                   label: key,
                   insertText,
                   insertTextFormat: InsertTextFormat.Snippet,
-                  documentation: propertySchema.description || '',
+                  documentation: super.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
                 });
               }
             });


### PR DESCRIPTION
### What does this PR do?
Use 'markdownDescription' for property completion.
Demo:
<img width="886" alt="Screenshot 2021-03-25 at 12 05 03" src="https://user-images.githubusercontent.com/929743/112455520-7a1d8b00-8d62-11eb-9d7d-e5e3f0785cd8.png">


### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/417

### Is it tested? How?
With test
