### PR TITLE
Add support $ref in additionalItems

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1016,12 +1016,16 @@ export class YAMLCompletion extends JSONCompletion {
           document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
 
         // For when missing semi colon case
-      } else {
+      } else if (trimmedText.indexOf('[') === -1) {
         // Add a semicolon to the end of the current line so we can validate the node
         newText =
           document.getText().substring(0, start + textLine.length) +
           ':\r\n' +
           document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
+      }
+
+      if (newText.length === 0) {
+        newText = document.getText();
       }
 
       return {

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -244,6 +244,7 @@ export class YAMLSchemaService extends JSONSchemaService {
 
         collectEntries(
           <JSONSchema>next.items,
+          next.additionalItems,
           <JSONSchema>next.additionalProperties,
           next.not,
           next.contains,

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1840,6 +1840,70 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('kind', 'kind', 0, 0, 0, 2, 10, InsertTextFormat.Snippet, { documentation: '' })
       );
     });
+
+    it('should follow $ref in additionalItems', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            $ref: '#/definitions/Recur',
+          },
+        },
+        definitions: {
+          Recur: {
+            type: 'array',
+            items: [
+              {
+                type: 'string',
+                enum: ['and'],
+              },
+            ],
+            additionalItems: {
+              $ref: '#/definitions/Recur',
+            },
+          },
+        },
+      });
+
+      const content = 'test:\n  - and\n  - - ';
+      const completion = await parseSetup(content, 19);
+      expect(completion.items).lengthOf(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('and', 'and', 2, 4, 2, 5, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+    });
+
+    it('should follow $ref in additionalItems for flow style array', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            $ref: '#/definitions/Recur',
+          },
+        },
+        definitions: {
+          Recur: {
+            type: 'array',
+            items: [
+              {
+                type: 'string',
+                enum: ['and'],
+              },
+            ],
+            additionalItems: {
+              $ref: '#/definitions/Recur',
+            },
+          },
+        },
+      });
+
+      const content = 'test:\n  - and\n  - []';
+      const completion = await parseSetup(content, 18);
+      expect(completion.items).lengthOf(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('and', 'and', 2, 4, 2, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+    });
   });
   describe('Array completion', () => {
     it('Simple array object completion with "-" without any item', async () => {


### PR DESCRIPTION
### What does this PR do?
It add support for `$ref` in `additionalItems`
Schema used from #408 description
Demo:
<img width="565" alt="Screenshot 2021-03-31 at 11 59 40" src="https://user-images.githubusercontent.com/929743/113119728-703fd000-9219-11eb-8695-3c49c7f456ed.png">
<img width="565" alt="Screenshot 2021-03-31 at 11 59 31" src="https://user-images.githubusercontent.com/929743/113119751-746bed80-9219-11eb-9e55-3eb9ecc4039c.png">


### What issues does this PR fix or reference?
Fix: #408

### Is it tested? How?
With tests
