### PR TITLE
Remove escape character from default values

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -33,6 +33,8 @@ import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { ClientCapabilities, MarkupContent } from 'vscode-languageserver';
 const localize = nls.loadMessageBundle();
 
+const doubleQuotesEscapeRegExp = /\\"/g;
+
 export class YAMLCompletion extends JSONCompletion {
   private schemaService: YAMLSchemaService;
   private customTags: Array<string>;
@@ -490,7 +492,7 @@ export class YAMLCompletion extends JSONCompletion {
       if (typeof value == 'object') {
         label = 'Default value';
       } else {
-        label = (value as unknown).toString();
+        label = (value as unknown).toString().replace(doubleQuotesEscapeRegExp, '"');
       }
       collector.add({
         kind: this.getSuggestionKind(type),
@@ -1065,6 +1067,8 @@ const isNumberExp = /^\d+$/;
 function convertToStringValue(value: string): string {
   if (value === 'true' || value === 'false' || value === 'null' || isNumberExp.test(value)) {
     return `"${value}"`;
+  } else {
+    value = value.replace(doubleQuotesEscapeRegExp, '"');
   }
 
   return value;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -152,7 +152,8 @@ describe('Auto Completion Tests', () => {
           properties: {
             name: {
               type: 'string',
-              default: '\\"yaml\\"',
+              // eslint-disable-next-line prettier/prettier, no-useless-escape
+              default: '\"yaml\"',
             },
           },
         });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -146,6 +146,27 @@ describe('Auto Completion Tests', () => {
           .then(done, done);
       });
 
+      it('Autocomplete on default value with \\"', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              default: '\\"yaml\\"',
+            },
+          },
+        });
+        const content = 'name: ';
+        const completion = await parseSetup(content, 6);
+        assert.strictEqual(completion.items.length, 1);
+        assert.deepStrictEqual(
+          completion.items[0],
+          createExpectedCompletion('"yaml"', '"yaml"', 0, 6, 0, 6, 12, 2, {
+            detail: 'Default value',
+          })
+        );
+      });
+
       it('Autocomplete on default value (with value content)', (done) => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',


### PR DESCRIPTION
### What does this PR do?
Remove escape character `\"` from default values.
Demo:

https://user-images.githubusercontent.com/929743/113821333-a256b200-9784-11eb-8b1a-92e091a4b9d0.mov


### What issues does this PR fix or reference?
#353 

### Is it tested? How?
With test and manually, use schema provided in #353 description, and try to complete `property1` value, it should be inserted without `\"` just `"`

