### PR TITLE
Invalidate document cache if custom tags provided

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,11 @@
       "name": "Launch Tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "args": ["-u", "bdd", "--timeout", "999999", "--colors", "-r", "ts-node/register", "${workspaceRoot}/test/*.test.ts"],
-      "preLaunchTask": "watch typescript"
+      "preLaunchTask": "watch typescript",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
     }
   ]
 }

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -249,7 +249,7 @@ export class SettingsHandler {
   private configureSchemas(
     uri: string,
     fileMatch: string[],
-    schema: any,
+    schema: unknown,
     languageSettings: LanguageSettings,
     priorityLevel: number
   ): LanguageSettings {

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -4,10 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { isArrayEqual } from '../utils/arrUtils';
 import { YAMLDocument, parse as parseYAML } from './yamlParser07';
 
 interface YamlCachedDocument {
   version: number;
+  customTags: string[];
   document: YAMLDocument;
 }
 export class YamlDocuments {
@@ -21,7 +23,7 @@ export class YamlDocuments {
    * @param addRootObject if true and document is empty add empty object {} to force schema usage
    * @returns the YAMLDocument
    */
-  getYamlDocument(document: TextDocument, customTags: string[] = [], addRootObject = false): YAMLDocument {
+  getYamlDocument(document: TextDocument, customTags?: string[], addRootObject = false): YAMLDocument {
     this.ensureCache(document, customTags, addRootObject);
     return this.cache.get(document.uri).document;
   }
@@ -36,18 +38,19 @@ export class YamlDocuments {
   private ensureCache(document: TextDocument, customTags: string[], addRootObject: boolean): void {
     const key = document.uri;
     if (!this.cache.has(key)) {
-      this.cache.set(key, { version: -1, document: new YAMLDocument([]) });
+      this.cache.set(key, { version: -1, document: new YAMLDocument([]), customTags: [] });
     }
-
-    if (this.cache.get(key).version !== document.version) {
+    const cacheEntry = this.cache.get(key);
+    if (cacheEntry.version !== document.version || (customTags && !isArrayEqual(cacheEntry.customTags, customTags))) {
       let text = document.getText();
       // if text is contains only whitespace wrap all text in object to force schema selection
       if (addRootObject && !/\S/.test(text)) {
         text = `{${text}}`;
       }
       const doc = parseYAML(text, customTags);
-      this.cache.get(key).document = doc;
-      this.cache.get(key).version = document.version;
+      cacheEntry.document = doc;
+      cacheEntry.version = document.version;
+      cacheEntry.customTags = customTags;
     }
   }
 }

--- a/src/languageservice/utils/arrUtils.ts
+++ b/src/languageservice/utils/arrUtils.ts
@@ -73,7 +73,7 @@ export function filterInvalidCustomTags(customTags: string[]): string[] {
   });
 }
 export function isArrayEqual(fst: Array<unknown>, snd: Array<unknown>): boolean {
-  if (!snd) {
+  if (!snd || !fst) {
     return false;
   }
   if (snd.length !== fst.length) {

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as chai from 'chai';
+import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
+import { setupTextDocument } from './utils/testHelper';
+import * as yamlParser from '../src/languageservice/parser/yamlParser07';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('YAML Documents Cache Tests', () => {
+  const sandbox = sinon.createSandbox();
+  let parseStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    parseStub = sandbox.stub(yamlParser, 'parse');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should cache parsed document', () => {
+    const cache = new YamlDocuments();
+    const doc = setupTextDocument('foo: bar');
+    parseStub.returns({});
+
+    const result1 = cache.getYamlDocument(doc);
+    const result2 = cache.getYamlDocument(doc);
+
+    expect(parseStub).calledOnce;
+    expect(result1).to.be.equal(result2);
+  });
+
+  it('should re parse document if document changed', () => {
+    const cache = new YamlDocuments();
+    const doc = setupTextDocument('foo: bar');
+
+    parseStub.onFirstCall().returns({});
+    parseStub.onSecondCall().returns({ foo: 'bar' });
+
+    const result1 = cache.getYamlDocument(doc);
+    TextDocument.update(doc, [], 2);
+    const result2 = cache.getYamlDocument(doc);
+
+    expect(parseStub).calledTwice;
+    expect(result1).to.be.not.equal(result2);
+  });
+
+  it('should invalidate cache if custom tags provided', () => {
+    const cache = new YamlDocuments();
+    const doc = setupTextDocument('foo: bar');
+    parseStub.onFirstCall().returns({});
+    parseStub.onSecondCall().returns({ foo: 'bar' });
+
+    const result1 = cache.getYamlDocument(doc);
+    const result2 = cache.getYamlDocument(doc, ['some']);
+
+    expect(parseStub).calledTwice;
+    expect(result1).to.not.equal(result2);
+  });
+
+  it('should use cache if custom tags are same', () => {
+    const cache = new YamlDocuments();
+    const doc = setupTextDocument('foo: bar');
+    parseStub.onFirstCall().returns({});
+    parseStub.onSecondCall().returns({ foo: 'bar' });
+
+    const result1 = cache.getYamlDocument(doc, ['some']);
+    const result2 = cache.getYamlDocument(doc, ['some']);
+
+    expect(parseStub).calledOnce;
+    expect(result1).to.be.equal(result2);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Fixes errors related to custom tags

>Also it add fix which removes warnings on test output window related to sourcemap if launch test with VSCode launch

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/461

### Is it tested? How?
With tests and manually, just follow https://github.com/redhat-developer/vscode-yaml/issues/461 add custom tags and open any yaml file which contains custom tags, there are no errors should present.
