### PR TITLE
Add support for maxItemsComputed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following settings are supported:
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org/json/)
 - `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
+- `yaml.maxItemsComputed`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).
 - `[yaml].editor.tabSize`: the number of spaces to use when autocompleting. Takes priority over editor.tabSize.
 - `editor.tabSize`: the number of spaces to use when autocompleting. Default is 2.
 - `http.proxy`: The URL of the proxy server that will be used when attempting to download a schema. If it is not set or it is undefined no proxy server will be used.

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -47,6 +47,8 @@ export class SettingsHandler {
       }
       this.yamlSettings.customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
+      this.yamlSettings.maxItemsComputed = Math.trunc(Math.max(0, Number(settings.yaml.maxItemsComputed))) || 5000;
+
       if (settings.yaml.schemaStore) {
         this.yamlSettings.schemaStoreEnabled = settings.yaml.schemaStore.enable;
       }

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -8,6 +8,7 @@
 import { SymbolInformation, DocumentSymbol } from 'vscode-languageserver-types';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { JSONDocumentSymbols } from 'vscode-json-languageservice/lib/umd/services/jsonDocumentSymbols';
+import { DocumentSymbolsContext } from 'vscode-json-languageservice/lib/umd/jsonLanguageTypes';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 
@@ -29,7 +30,10 @@ export class YAMLDocumentSymbols {
     };
   }
 
-  public findDocumentSymbols(document: TextDocument): SymbolInformation[] {
+  public findDocumentSymbols(
+    document: TextDocument,
+    context: DocumentSymbolsContext = { resultLimit: Number.MAX_VALUE }
+  ): SymbolInformation[] {
     const doc = yamlDocumentsCache.getYamlDocument(document);
     if (!doc || doc['documents'].length === 0) {
       return null;
@@ -38,14 +42,17 @@ export class YAMLDocumentSymbols {
     let results = [];
     for (const yamlDoc of doc['documents']) {
       if (yamlDoc.root) {
-        results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols(document, yamlDoc));
+        results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols(document, yamlDoc, context));
       }
     }
 
     return results;
   }
 
-  public findHierarchicalDocumentSymbols(document: TextDocument): DocumentSymbol[] {
+  public findHierarchicalDocumentSymbols(
+    document: TextDocument,
+    context: DocumentSymbolsContext = { resultLimit: Number.MAX_VALUE }
+  ): DocumentSymbol[] {
     const doc = yamlDocumentsCache.getYamlDocument(document);
     if (!doc || doc['documents'].length === 0) {
       return null;
@@ -54,7 +61,7 @@ export class YAMLDocumentSymbols {
     let results = [];
     for (const yamlDoc of doc['documents']) {
       if (yamlDoc.root) {
-        results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols2(document, yamlDoc));
+        results = results.concat(this.jsonDocumentSymbols.findDocumentSymbols2(document, yamlDoc, context));
       }
     }
 

--- a/src/languageservice/services/yamlFolding.ts
+++ b/src/languageservice/services/yamlFolding.ts
@@ -34,6 +34,9 @@ export function getFoldingRanges(document: TextDocument, context: FoldingRangesC
   if (typeof rangeLimit !== 'number' || result.length <= rangeLimit) {
     return result;
   }
+  if (context && context.onRangeLimitExceeded) {
+    context.onRangeLimitExceeded(document.uri);
+  }
 
   return result.slice(0, context.rangeLimit - 1);
 }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -28,7 +28,7 @@ import { YAMLCompletion } from './services/yamlCompletion';
 import { YAMLHover } from './services/yamlHover';
 import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
-import { JSONDocument, DefinitionLink, TextDocument } from 'vscode-json-languageservice';
+import { JSONDocument, DefinitionLink, TextDocument, DocumentSymbolsContext } from 'vscode-json-languageservice';
 import { findLinks } from './services/yamlLinks';
 import {
   FoldingRange,
@@ -117,8 +117,8 @@ export interface LanguageService {
   doComplete(document: TextDocument, position: Position, isKubernetes: boolean): Promise<CompletionList>;
   doValidation(document: TextDocument, isKubernetes: boolean): Promise<Diagnostic[]>;
   doHover(document: TextDocument, position: Position): Promise<Hover | null>;
-  findDocumentSymbols(document: TextDocument): SymbolInformation[];
-  findDocumentSymbols2(document: TextDocument): DocumentSymbol[];
+  findDocumentSymbols(document: TextDocument, context: DocumentSymbolsContext): SymbolInformation[];
+  findDocumentSymbols2(document: TextDocument, context: DocumentSymbolsContext): DocumentSymbol[];
   findDefinition(document: TextDocument, position: Position, doc: JSONDocument): Promise<DefinitionLink[]>;
   findLinks(document: TextDocument): Promise<DocumentLink[]>;
   resetSchema(uri: string): boolean;

--- a/src/languageservice/yamlTypes.ts
+++ b/src/languageservice/yamlTypes.ts
@@ -9,6 +9,10 @@ export interface FoldingRangesContext {
    */
   rangeLimit?: number;
   /**
+   * Called when the result was cropped.
+   */
+  onRangeLimitExceeded?: (uri: string) => void;
+  /**
    * If set, the client signals that it only supports folding complete lines. If set, client will
    * ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
    */

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -21,6 +21,10 @@ export namespace VSCodeContentRequestRegistration {
   export const type: NotificationType<{}> = new NotificationType('yaml/registerContentRequest');
 }
 
+export namespace ResultLimitReachedNotification {
+  export const type: NotificationType<string> = new NotificationType('yaml/resultLimitReached');
+}
+
 export namespace VSCodeContentRequest {
   export const type: RequestType<{}, {}, {}> = new RequestType('vscode/content');
 }

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -17,6 +17,7 @@ export interface Settings {
     schemaStore: {
       enable: boolean;
     };
+    maxItemsComputed: number;
   };
   http: {
     proxy: string;
@@ -54,6 +55,7 @@ export class SettingsState {
   customTags = [];
   schemaStoreEnabled = true;
   indentation: string | undefined = undefined;
+  maxItemsComputed = 5000;
 
   // File validation helpers
   pendingValidationRequests: { [uri: string]: NodeJS.Timer } = {};


### PR DESCRIPTION
### What does this PR do?
Adds support for a `yaml.maxItemsComputed` setting that mirrors `json.maxItemsComputed` from the built-in JSON language service. It caps the number of outline symbols and folding regions computed for performance reasons.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/485

### Is it tested? How?
TODO: write some automated tests

* Manually opened a very large YAML file with outline pane open as described in the issue.
* Observed a notification that the limit was exceeded.
* Did not observe large performance issues like I did before.

* Manually opened a smaller YAML file
* Changed the configuration to a small value (50)
* Observed the outline pane truncate to match the new configuration.