### PR TITLE
Remove all '\' before '"' in completion text change

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -33,7 +33,7 @@ import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { ClientCapabilities, MarkupContent } from 'vscode-languageserver';
 const localize = nls.loadMessageBundle();
 
-const doubleQuotesEscapeRegExp = /\\"/g;
+const doubleQuotesEscapeRegExp = /[\\]+"/g;
 
 export class YAMLCompletion extends JSONCompletion {
   private schemaService: YAMLSchemaService;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -168,6 +168,28 @@ describe('Auto Completion Tests', () => {
         );
       });
 
+      it('Autocomplete name and value with \\"', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              // eslint-disable-next-line prettier/prettier, no-useless-escape
+              default: '\"yaml\"',
+            },
+          },
+        });
+        const content = 'name';
+        const completion = await parseSetup(content, 3);
+        assert.strictEqual(completion.items.length, 1);
+        assert.deepStrictEqual(
+          completion.items[0],
+          createExpectedCompletion('name', 'name: ${1:"yaml"}', 0, 0, 0, 4, 10, 2, {
+            documentation: '',
+          })
+        );
+      });
+
       it('Autocomplete on default value (with value content)', (done) => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',


### PR DESCRIPTION
### What does this PR do?
Proper remove any number of `\` before `"` in completion inserted text 

### What issues does this PR fix or reference?
Fix: #353 

### Is it tested? How?
with test
