### PR TITLE
Upgrade vscode-json-languageservice

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "js-yaml": "^3.13.1",
     "jsonc-parser": "^2.2.1",
     "request-light": "^0.2.4",
-    "vscode-json-languageservice": "^4.0.2",
+    "vscode-json-languageservice": "^4.1.0",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,12 +2410,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-json-languageservice@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.0.2.tgz#8f91dc3a33dac180063067f8277f4facdc0795b6"
-  integrity sha512-d8Ahw990Cq/G60CzN26rehXcbhbMgMGMmXeN6C/V/RYZUhfs16EELRK+EL7b/3Y8ZGshtKqboePSeDVa94qqFg==
+vscode-json-languageservice@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.0.tgz#0dc38f22d3a6983b2105199dffd9ace244125f61"
+  integrity sha512-QW2SFk4kln5lTPQajGNuXWtmr2z9hVA6Sfi4qPFEW2vjt2XaUAp38/1OrcUQYiJXOyXntbWN2jZJaGxg+hDUxw==
   dependencies:
     jsonc-parser "^3.0.0"
+    minimatch "^3.0.4"
     vscode-languageserver-textdocument "^1.0.1"
     vscode-languageserver-types "^3.16.0"
     vscode-nls "^5.0.0"


### PR DESCRIPTION
Upgrade to the newer 4.1.0 version of vscode-json-languageservice
which enables used of the extended glob patterns.

Related: https://github.com/microsoft/vscode-json-languageservice/pull/93
