### PR TITLE
Handle nested anchors in validation expansion (Fixes #273)

### DIFF
--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -51,24 +51,19 @@ export class ValidationHandler {
 
     return this.languageService
       .doValidation(textDocument, isKubernetesAssociatedDocument(textDocument, this.yamlSettings.specificValidatorPaths))
-      .then(
-        (diagnosticResults) => {
-          const diagnostics = [];
-          for (const diagnosticItem in diagnosticResults) {
-            diagnosticResults[diagnosticItem].severity = 1; //Convert all warnings to errors
-            diagnostics.push(diagnosticResults[diagnosticItem]);
-          }
-
-          const removeDuplicatesDiagnostics = removeDuplicatesObj(diagnostics);
-          this.connection.sendDiagnostics({
-            uri: textDocument.uri,
-            diagnostics: removeDuplicatesDiagnostics,
-          });
-          return removeDuplicatesDiagnostics;
-        },
-        () => {
-          return [];
+      .then((diagnosticResults) => {
+        const diagnostics = [];
+        for (const diagnosticItem in diagnosticResults) {
+          diagnosticResults[diagnosticItem].severity = 1; //Convert all warnings to errors
+          diagnostics.push(diagnosticResults[diagnosticItem]);
         }
-      );
+
+        const removeDuplicatesDiagnostics = removeDuplicatesObj(diagnostics);
+        this.connection.sendDiagnostics({
+          uri: textDocument.uri,
+          diagnostics: removeDuplicatesDiagnostics,
+        });
+        return removeDuplicatesDiagnostics;
+      });
   }
 }

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1071,27 +1071,22 @@ function validate(
   ): void {
     const seenKeys: { [key: string]: ASTNode } = Object.create(null);
     const unprocessedProperties: string[] = [];
-    for (const propertyNode of node.properties) {
+    const unprocessedNodes: PropertyASTNode[] = [...node.properties];
+
+    while (unprocessedNodes.length > 0) {
+      const propertyNode = unprocessedNodes.pop();
       const key = propertyNode.keyNode.value;
 
       //Replace the merge key with the actual values of what the node value points to in seen keys
       if (key === '<<' && propertyNode.valueNode) {
         switch (propertyNode.valueNode.type) {
           case 'object': {
-            propertyNode.valueNode['properties'].forEach((propASTNode) => {
-              const propKey = propASTNode.keyNode.value;
-              seenKeys[propKey] = propASTNode.valueNode;
-              unprocessedProperties.push(propKey);
-            });
+            unprocessedNodes.push(...propertyNode.valueNode['properties']);
             break;
           }
           case 'array': {
             propertyNode.valueNode['items'].forEach((sequenceNode) => {
-              sequenceNode['properties'].forEach((propASTNode) => {
-                const seqKey = propASTNode.keyNode.value;
-                seenKeys[seqKey] = propASTNode.valueNode;
-                unprocessedProperties.push(seqKey);
-              });
+              unprocessedNodes.push(...sequenceNode['properties']);
             });
             break;
           }

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -526,7 +526,7 @@ describe('Validation Tests', () => {
   });
 
   describe('Anchor tests', () => {
-    it('Anchor should not not error', (done) => {
+    it('Anchor should not error', (done) => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -549,7 +549,7 @@ describe('Validation Tests', () => {
         .then(done, done);
     });
 
-    it('Anchor with multiple references should not not error', (done) => {
+    it('Anchor with multiple references should not error', (done) => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -572,7 +572,7 @@ describe('Validation Tests', () => {
         .then(done, done);
     });
 
-    it('Multiple Anchor in array of references should not not error', (done) => {
+    it('Multiple Anchor in array of references should not error', (done) => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -619,6 +619,42 @@ describe('Validation Tests', () => {
         })
         .then(done, done);
     });
+
+    it('Nested object anchors should expand properly', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            akey: {
+              type: 'string',
+            },
+          },
+          required: ['akey'],
+        },
+      });
+      const content = `
+        l1: &l1
+          akey: avalue
+
+        l2: &l2
+          <<: *l1
+
+        l3: &l3
+          <<: *l2
+
+        l4:
+          <<: *l3
+      `;
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          console.debug(result);
+          assert.equal(result.length, 0);
+        })
+        .then(done, done);
+    });
   });
 
   describe('Custom tag tests', () => {


### PR DESCRIPTION
### What does this PR do?
Primarily, this adds support for recursively expanding multiple levels of aliases. In the process I made some other minor changes:
* `validateTextDocument` was swallowing errors which made my test pass when it should have failed. I think propagating errors could result in "unhandled promise rejection" errors in logs but I think that's better than ignoring them?
* Double-negative typos in a few tests I saw
* I added a test for a very particular case of anchor error rendering. I initially thought this was broken, but it appears intentional so I wanted to encode it in a test since it seems easy to regress.

### What issues does this PR fix or reference?
#273

### Is it tested? How?
Wrote a test. Ran this in development against a YAML file/schema that was giving me trouble.
