### PR TITLE
Fix range convert to offset+length

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,19 @@
         "${workspaceFolder}/**",
         "!**/node_modules/**"
       ],
+    },
+    // A launch configuration that compiles the server and runs mocha unit tests
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Single File Tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": ["-u", "bdd", "--timeout", "999999", "--colors", "-r", "ts-node/register", "${workspaceRoot}/${relativeFile}"],
+      "preLaunchTask": "watch typescript",
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
     }
   ]
 }

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -5,27 +5,29 @@
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { JSONDocument } from './jsonParser07';
-import { Document, visit, YAMLError } from 'yaml';
+import { Document, LineCounter, visit, YAMLError } from 'yaml';
 import { ASTNode } from '../jsonASTTypes';
 import { parse as parseYAML } from './yamlParser07';
 import { ErrorCode } from 'vscode-json-languageservice';
 import { Node } from 'yaml/dist/nodes/Node';
 import { convertAST } from './ast-converter';
+import { YAMLDocDiagnostic } from '../utils/parseUtils';
+import { isArrayEqual } from '../utils/arrUtils';
 
 /**
  * These documents are collected into a final YAMLDocument
  * and passed to the `parseYAML` caller.
  */
 export class SingleYAMLDocument extends JSONDocument {
-  private lines: number[];
+  private lineCounter: LineCounter;
   private _internalDocument: Document;
   public root: ASTNode;
   public currentDocIndex: number;
   private _lineComments: string[];
 
-  constructor(lines?: number[]) {
+  constructor(lineCounter?: LineCounter) {
     super(null, []);
-    this.lines = lines;
+    this.lineCounter = lineCounter;
   }
 
   private collectLineComments(): void {
@@ -42,7 +44,7 @@ export class SingleYAMLDocument extends JSONDocument {
 
   set internalDocument(document: Document) {
     this._internalDocument = document;
-    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument);
+    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument, this.lineCounter);
   }
 
   get internalDocument(): Document {

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -7,8 +7,7 @@
 
 import { Parser, Composer, Document, LineCounter, Tags, ParseOptions, DocumentOptions, SchemaOptions } from 'yaml';
 import { YAMLDocument, SingleYAMLDocument } from './yaml-documents';
-import { customTagsToTags } from '../utils/parseUtils';
-
+import { customTagsToAdditionalOptions } from '../utils/parseUtils';
 
 export { YAMLDocument, SingleYAMLDocument };
 
@@ -20,7 +19,7 @@ export { YAMLDocument, SingleYAMLDocument };
 export function parse(text: string, customTags = []): YAMLDocument {
   const options: ParseOptions & DocumentOptions & SchemaOptions = {
     strict: true,
-    customTags: customTagsToTags(customTags),
+    customTags: customTagsToAdditionalOptions(customTags),
   };
   const composer = new Composer(options);
   const lineCounter = new LineCounter();
@@ -29,14 +28,14 @@ export function parse(text: string, customTags = []): YAMLDocument {
   const docs = composer.compose(tokens);
 
   // Generate the SingleYAMLDocs from the AST nodes
-  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc) => parsedDocToSingleYAMLDocument(doc, lineCounter.lineStarts));
+  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc) => parsedDocToSingleYAMLDocument(doc, lineCounter));
 
   // Consolidate the SingleYAMLDocs
   return new YAMLDocument(yamlDocs);
 }
 
-function parsedDocToSingleYAMLDocument(parsedDoc: Document, lineStarts: number[]): SingleYAMLDocument {
-  const syd = new SingleYAMLDocument(lineStarts);
+function parsedDocToSingleYAMLDocument(parsedDoc: Document, lineCounter: LineCounter): SingleYAMLDocument {
+  const syd = new SingleYAMLDocument(lineCounter);
   syd.internalDocument = parsedDoc;
   return syd;
 }

--- a/src/languageservice/utils/parseUtils.ts
+++ b/src/languageservice/utils/parseUtils.ts
@@ -1,9 +1,6 @@
-import * as Yaml from 'yaml';
-import { Schema } from 'yaml-language-server-parser/dist/src/schema';
-import { Type } from 'yaml-language-server-parser/dist/src/type';
-
 import { filterInvalidCustomTags } from './arrUtils';
 import { ErrorCode } from 'vscode-json-languageservice/lib/umd/jsonLanguageTypes';
+import { Tags } from 'yaml';
 
 export const DUPLICATE_KEY_REASON = 'duplicate key';
 
@@ -23,7 +20,7 @@ export interface YAMLDocDiagnostic {
   code: ErrorCode;
 }
 
-export function customTagsToAdditionalOptions(customTags: string[]): Type {
+export function customTagsToAdditionalOptions(customTags: string[]): Tags {
   const yamlTags = [];
   const filteredTags = filterInvalidCustomTags(customTags);
 

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -263,7 +263,7 @@ describe('Document Symbols Tests', () => {
 
       const height = createExpectedDocumentSymbol('height', SymbolKind.Number, 10, 18, 10, 28, 10, 18, 10, 24, [], '41');
       const style = createExpectedDocumentSymbol('style', SymbolKind.Module, 9, 16, 10, 28, 9, 16, 9, 21, [height]);
-      const root2 = createExpectedDocumentSymbol('root', SymbolKind.Module, 7, 17, 10, 28, 7, 17, 7, 21, [style]);
+      const root2 = createExpectedDocumentSymbol('root', SymbolKind.Module, 7, 16, 10, 28, 7, 16, 7, 21, [style]);
 
       assert.deepEqual(
         symbols[1],

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -14,6 +14,7 @@ import { ServiceSetup } from './utils/serviceSetup';
 import { setupLanguageService, setupTextDocument, TEST_URI } from './utils/testHelper';
 import { LanguageService, SchemaPriority } from '../src';
 import { Position } from 'vscode-languageserver';
+import { LineCounter } from 'yaml';
 
 const requestServiceMock = function (uri: string): Promise<string> {
   return Promise.reject<string>(`Resource ${uri} not found.`);
@@ -737,7 +738,7 @@ describe('JSON Schema', () => {
 
     function checkReturnSchemaUrl(modeline: string, expectedResult: string): void {
       const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
-      const yamlDoc = new parser.SingleYAMLDocument([]);
+      const yamlDoc = new parser.SingleYAMLDocument(new LineCounter());
       yamlDoc.lineComments = [modeline];
       assert.equal(service.getSchemaFromModeline(yamlDoc), expectedResult);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,10 +2535,10 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yaml-language-server-parser@next:
-  version "0.1.3-fa8245c.0"
-  resolved "https://registry.yarnpkg.com/yaml-language-server-parser/-/yaml-language-server-parser-0.1.3-fa8245c.0.tgz#da6c241bd23ee7303d035a99fdc01554e0193f70"
-  integrity sha512-0QPUSsmMXHDpqj00xUrlMyqlEAwHHIAuz3wPMyprcCVYx7jh7oo91Z0nC/jhott4XAKp3iY3vjBsMxqszoZosA==
+yaml@2.0.0-5:
+  version "2.0.0-5"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-5.tgz#00906046dc119427b2b4f7cf9041d34682d1480b"
+  integrity sha512-qH5L5eqW8cyv/N1U6rkK/O0M7kOK3BSo48d05Ptm03ITNsVFwg6TQ47wR72Db/ULWH5RfNJv+CqnG17Pyn8eqQ==
 
 yargs-parser@^13.0.0, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
### What does this PR do?
Fix build.
Fix new parser AST range convert to offset + length.
This is fix all Document Symbols tests.

>Note: This PR changed convert of `Alias` node, nowit converted to `StringASTNodeImpl` instead of resolving to declaration node. As JSON AST don't support such nodes, Document Symbols calculation is breaking LSP rules on `SelectionRange`