### PR TITLE
Feat: Add config parameter to disable additional properties

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -69,6 +69,7 @@ export class SettingsHandler {
           this.yamlSettings.yamlFormatterSettings.enable = settings.yaml.format.enable;
         }
       }
+      this.yamlSettings.disableAdditionalProperties = settings.yaml.disableAdditionalProperties;
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -182,6 +183,7 @@ export class SettingsHandler {
       customTags: this.yamlSettings.customTags,
       format: this.yamlSettings.yamlFormatterSettings.enable,
       indentation: this.yamlSettings.indentation,
+      disableAdditionalProperties: this.yamlSettings.disableAdditionalProperties,
     };
 
     if (this.yamlSettings.schemaAssociations) {

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -469,6 +469,7 @@ export function contains(node: ASTNode, offset: number, includeRightBound = fals
 
 export class JSONDocument {
   public isKubernetes: boolean;
+  public disableAdditionalProperties: boolean;
 
   constructor(
     public readonly root: ASTNode,
@@ -506,7 +507,10 @@ export class JSONDocument {
   public validate(textDocument: TextDocument, schema: JSONSchema): Diagnostic[] {
     if (this.root && schema) {
       const validationResult = new ValidationResult(this.isKubernetes);
-      validate(this.root, schema, schema, validationResult, NoOpSchemaCollector.instance, this.isKubernetes);
+      validate(this.root, schema, schema, validationResult, NoOpSchemaCollector.instance, {
+        isKubernetes: this.isKubernetes,
+        disableAdditionalProperties: this.disableAdditionalProperties,
+      });
       return validationResult.problems.map((p) => {
         const range = Range.create(
           textDocument.positionAt(p.location.offset),
@@ -529,21 +533,28 @@ export class JSONDocument {
   public getMatchingSchemas(schema: JSONSchema, focusOffset = -1, exclude: ASTNode = null): IApplicableSchema[] {
     const matchingSchemas = new SchemaCollector(focusOffset, exclude);
     if (this.root && schema) {
-      validate(this.root, schema, schema, new ValidationResult(this.isKubernetes), matchingSchemas, this.isKubernetes);
+      validate(this.root, schema, schema, new ValidationResult(this.isKubernetes), matchingSchemas, {
+        isKubernetes: this.isKubernetes,
+        disableAdditionalProperties: this.disableAdditionalProperties,
+      });
     }
     return matchingSchemas.schemas;
   }
 }
-
+interface Options {
+  isKubernetes: boolean;
+  disableAdditionalProperties: boolean;
+}
 function validate(
   node: ASTNode,
   schema: JSONSchema,
   originalSchema: JSONSchema,
   validationResult: ValidationResult,
   matchingSchemas: ISchemaCollector,
-  isKubernetes: boolean
+  options: Options
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
+  const { isKubernetes } = options;
   if (!node || !matchingSchemas.include(node)) {
     return;
   }
@@ -569,7 +580,7 @@ function validate(
       _validateNumberNode(node, schema, validationResult);
       break;
     case 'property':
-      return validate(node.valueNode, schema, schema, validationResult, matchingSchemas, isKubernetes);
+      return validate(node.valueNode, schema, schema, validationResult, matchingSchemas, options);
   }
   _validateNode();
 
@@ -609,14 +620,14 @@ function validate(
     }
     if (Array.isArray(schema.allOf)) {
       for (const subSchemaRef of schema.allOf) {
-        validate(node, asSchema(subSchemaRef), schema, validationResult, matchingSchemas, isKubernetes);
+        validate(node, asSchema(subSchemaRef), schema, validationResult, matchingSchemas, options);
       }
     }
     const notSchema = asSchema(schema.not);
     if (notSchema) {
       const subValidationResult = new ValidationResult(isKubernetes);
       const subMatchingSchemas = matchingSchemas.newSub();
-      validate(node, notSchema, schema, subValidationResult, subMatchingSchemas, isKubernetes);
+      validate(node, notSchema, schema, subValidationResult, subMatchingSchemas, options);
       if (!subValidationResult.hasProblems()) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
@@ -645,7 +656,7 @@ function validate(
         const subSchema = asSchema(subSchemaRef);
         const subValidationResult = new ValidationResult(isKubernetes);
         const subMatchingSchemas = matchingSchemas.newSub();
-        validate(node, subSchema, schema, subValidationResult, subMatchingSchemas, isKubernetes);
+        validate(node, subSchema, schema, subValidationResult, subMatchingSchemas, options);
         if (!subValidationResult.hasProblems()) {
           matches.push(subSchema);
         }
@@ -690,7 +701,7 @@ function validate(
       const subValidationResult = new ValidationResult(isKubernetes);
       const subMatchingSchemas = matchingSchemas.newSub();
 
-      validate(node, asSchema(schema), originalSchema, subValidationResult, subMatchingSchemas, isKubernetes);
+      validate(node, asSchema(schema), originalSchema, subValidationResult, subMatchingSchemas, options);
 
       validationResult.merge(subValidationResult);
       validationResult.propertiesMatches += subValidationResult.propertiesMatches;
@@ -708,7 +719,7 @@ function validate(
       const subValidationResult = new ValidationResult(isKubernetes);
       const subMatchingSchemas = matchingSchemas.newSub();
 
-      validate(node, subSchema, originalSchema, subValidationResult, subMatchingSchemas, isKubernetes);
+      validate(node, subSchema, originalSchema, subValidationResult, subMatchingSchemas, options);
       matchingSchemas.merge(subMatchingSchemas);
 
       if (!subValidationResult.hasProblems()) {
@@ -965,7 +976,7 @@ function validate(
         const itemValidationResult = new ValidationResult(isKubernetes);
         const item = node.items[index];
         if (item) {
-          validate(item, subSchema, schema, itemValidationResult, matchingSchemas, isKubernetes);
+          validate(item, subSchema, schema, itemValidationResult, matchingSchemas, options);
           validationResult.mergePropertyMatch(itemValidationResult);
           validationResult.mergeEnumValues(itemValidationResult);
         } else if (node.items.length >= subSchemas.length) {
@@ -977,7 +988,7 @@ function validate(
           for (let i = subSchemas.length; i < node.items.length; i++) {
             const itemValidationResult = new ValidationResult(isKubernetes);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            validate(node.items[i], <any>schema.additionalItems, schema, itemValidationResult, matchingSchemas, isKubernetes);
+            validate(node.items[i], <any>schema.additionalItems, schema, itemValidationResult, matchingSchemas, options);
             validationResult.mergePropertyMatch(itemValidationResult);
             validationResult.mergeEnumValues(itemValidationResult);
           }
@@ -1000,7 +1011,7 @@ function validate(
       if (itemSchema) {
         for (const item of node.items) {
           const itemValidationResult = new ValidationResult(isKubernetes);
-          validate(item, itemSchema, schema, itemValidationResult, matchingSchemas, isKubernetes);
+          validate(item, itemSchema, schema, itemValidationResult, matchingSchemas, options);
           validationResult.mergePropertyMatch(itemValidationResult);
           validationResult.mergeEnumValues(itemValidationResult);
         }
@@ -1011,7 +1022,7 @@ function validate(
     if (containsSchema) {
       const doesContain = node.items.some((item) => {
         const itemValidationResult = new ValidationResult(isKubernetes);
-        validate(item, containsSchema, schema, itemValidationResult, NoOpSchemaCollector.instance, isKubernetes);
+        validate(item, containsSchema, schema, itemValidationResult, NoOpSchemaCollector.instance, options);
         return !itemValidationResult.hasProblems();
       });
 
@@ -1158,7 +1169,7 @@ function validate(
           } else {
             propertySchema.url = schema.url ?? originalSchema.url;
             const propertyValidationResult = new ValidationResult(isKubernetes);
-            validate(child, propertySchema, schema, propertyValidationResult, matchingSchemas, isKubernetes);
+            validate(child, propertySchema, schema, propertyValidationResult, matchingSchemas, options);
             validationResult.mergePropertyMatch(propertyValidationResult);
             validationResult.mergeEnumValues(propertyValidationResult);
           }
@@ -1195,7 +1206,7 @@ function validate(
                 }
               } else {
                 const propertyValidationResult = new ValidationResult(isKubernetes);
-                validate(child, propertySchema, schema, propertyValidationResult, matchingSchemas, isKubernetes);
+                validate(child, propertySchema, schema, propertyValidationResult, matchingSchemas, options);
                 validationResult.mergePropertyMatch(propertyValidationResult);
                 validationResult.mergeEnumValues(propertyValidationResult);
               }
@@ -1204,19 +1215,21 @@ function validate(
         }
       }
     }
-
     if (typeof schema.additionalProperties === 'object') {
       for (const propertyName of unprocessedProperties) {
         const child = seenKeys[propertyName];
         if (child) {
           const propertyValidationResult = new ValidationResult(isKubernetes);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          validate(child, <any>schema.additionalProperties, schema, propertyValidationResult, matchingSchemas, isKubernetes);
+          validate(child, <any>schema.additionalProperties, schema, propertyValidationResult, matchingSchemas, options);
           validationResult.mergePropertyMatch(propertyValidationResult);
           validationResult.mergeEnumValues(propertyValidationResult);
         }
       }
-    } else if (schema.additionalProperties === false) {
+    } else if (
+      schema.additionalProperties === false ||
+      (schema.type === 'object' && schema.additionalProperties === undefined && options.disableAdditionalProperties === true)
+    ) {
       if (unprocessedProperties.length > 0) {
         for (const propertyName of unprocessedProperties) {
           const child = seenKeys[propertyName];
@@ -1302,7 +1315,7 @@ function validate(
             const propertySchema = asSchema(propertyDep);
             if (propertySchema) {
               const propertyValidationResult = new ValidationResult(isKubernetes);
-              validate(node, propertySchema, schema, propertyValidationResult, matchingSchemas, isKubernetes);
+              validate(node, propertySchema, schema, propertyValidationResult, matchingSchemas, options);
               validationResult.mergePropertyMatch(propertyValidationResult);
               validationResult.mergeEnumValues(propertyValidationResult);
             }
@@ -1316,7 +1329,7 @@ function validate(
       for (const f of node.properties) {
         const key = f.keyNode;
         if (key) {
-          validate(key, propertyNames, schema, validationResult, NoOpSchemaCollector.instance, isKubernetes);
+          validate(key, propertyNames, schema, validationResult, NoOpSchemaCollector.instance, options);
         }
       }
     }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -38,6 +38,7 @@ export class YAMLValidation {
   private validationEnabled: boolean;
   private customTags: string[];
   private jsonValidation;
+  private disableAdditionalProperties: boolean;
 
   private MATCHES_MULTIPLE = 'Matches multiple schemas when only one must validate.';
 
@@ -50,6 +51,7 @@ export class YAMLValidation {
     if (settings) {
       this.validationEnabled = settings.validate;
       this.customTags = settings.customTags;
+      this.disableAdditionalProperties = settings.disableAdditionalProperties;
     }
   }
 
@@ -65,6 +67,7 @@ export class YAMLValidation {
     for (const currentYAMLDoc of yamlDocument.documents) {
       currentYAMLDoc.isKubernetes = isKubernetes;
       currentYAMLDoc.currentDocIndex = index;
+      currentYAMLDoc.disableAdditionalProperties = this.disableAdditionalProperties;
 
       const validation = await this.jsonValidation.doValidation(textDocument, currentYAMLDoc);
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -74,6 +74,12 @@ export interface LanguageSettings {
    * Default indentation size
    */
   indentation?: string;
+
+  /**
+   * Globally set additionalProperties to false if additionalProperties is not set and if schema.type is object.
+   * So if its true, no extra properties are allowed inside yaml.
+   */
+  disableAdditionalProperties?: boolean;
 }
 
 export interface WorkspaceContextService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -17,6 +17,7 @@ export interface Settings {
     schemaStore: {
       enable: boolean;
     };
+    disableAdditionalProperties: boolean;
   };
   http: {
     proxy: string;
@@ -54,7 +55,7 @@ export class SettingsState {
   customTags = [];
   schemaStoreEnabled = true;
   indentation: string | undefined = undefined;
-
+  disableAdditionalProperties = false;
   // File validation helpers
   pendingValidationRequests: { [uri: string]: NodeJS.Timer } = {};
   validationDelayMs = 200;

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1256,4 +1256,62 @@ describe('Validation Tests', () => {
       );
     });
   });
+  describe('Additional properties validation', () => {
+    it('should allow additional props on object by default', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          prop1: {
+            type: 'string',
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = `prop2: you could be there 'prop2'`;
+      const result = await parseSetup(content);
+      expect(result.length).to.eq(0);
+    });
+
+    describe('Additional properties validation with enabled disableAdditionalProperties', () => {
+      before(() => {
+        languageSettingsSetup.languageSettings.disableAdditionalProperties = true;
+        languageService.configure(languageSettingsSetup.languageSettings);
+      });
+      after(() => {
+        languageSettingsSetup.languageSettings.disableAdditionalProperties = false;
+      });
+
+      it('should return additional prop error when there is extra prop', async () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+          },
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = `prop2: you should not be there 'prop2'`;
+        const result = await parseSetup(content);
+        expect(result.length).to.eq(1);
+        expect(result[0].message).to.eq('Property prop2 is not allowed.');
+      });
+
+      it('should allow additional props on object when additionalProp is true on object', async () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+          },
+          additionalProperties: true,
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = `prop2: you could be there 'prop2'`;
+        const result = await parseSetup(content);
+        expect(result.length).to.eq(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Add `disableAdditionalProperties` into yaml configuration and if is set to true yaml validation won’t allow extra props that are not in schema (where type == 'object').

By default we can achieve same behave with setting each of schema object by property `additionalProperties = false`.
But this global `disableAdditionalParameters` set this globally for all object schemas.

For my purpose I'm using this to quickly switch between strict validation mode and not-strict.

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added tests