### PR TITLE
Add monaco-yaml in the readme under clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ This repository only contains the server implementation. Here are some known cli
 - [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs
 - [vim-lsp](https://github.com/prabirshrestha/vim-lsp) for Vim
 - [LSP-yaml](https://packagecontrol.io/packages/LSP-yaml) for Sublime Text
+- [monaco-yaml](https://github.com/pengx17/monaco-yaml) for Monaco editor
 
 ## Developer Support
 


### PR DESCRIPTION
### What does this PR do?
Add [monaco-yaml](https://github.com/pengx17/monaco-yaml) in the readme under clients.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
No