### PR TITLE
feat: add option to specify custom schema store

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following settings are supported:
 - `yaml.completion`: Enable/disable autocompletion
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org/json/)
+- `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
 - `yaml.maxItemsComputed`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).
 - `[yaml].editor.tabSize`: the number of spaces to use when autocompleting. Takes priority over editor.tabSize.

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -51,6 +51,9 @@ export class SettingsHandler {
 
       if (settings.yaml.schemaStore) {
         this.yamlSettings.schemaStoreEnabled = settings.yaml.schemaStore.enable;
+        if (settings.yaml.schemaStore.url.length !== 0) {
+          this.yamlSettings.schemaStoreUrl = settings.yaml.schemaStore.url;
+        }
       }
 
       if (settings.yaml.format) {
@@ -120,10 +123,16 @@ export class SettingsHandler {
    */
   public async setSchemaStoreSettingsIfNotSet(): Promise<void> {
     const schemaStoreIsSet = this.yamlSettings.schemaStoreSettings.length !== 0;
+    let schemaStoreUrl = '';
+    if (this.yamlSettings.schemaStoreUrl.length !== 0) {
+      schemaStoreUrl = this.yamlSettings.schemaStoreUrl;
+    } else {
+      schemaStoreUrl = JSON_SCHEMASTORE_URL;
+    }
 
     if (this.yamlSettings.schemaStoreEnabled && !schemaStoreIsSet) {
       try {
-        const schemaStore = await this.getSchemaStoreMatchingSchemas();
+        const schemaStore = await this.getSchemaStoreMatchingSchemas(schemaStoreUrl);
         this.yamlSettings.schemaStoreSettings = schemaStore.schemas;
         this.updateConfiguration();
       } catch (err) {
@@ -139,8 +148,8 @@ export class SettingsHandler {
    * When the schema store is enabled, download and store YAML schema associations
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getSchemaStoreMatchingSchemas(): Promise<{ schemas: any[] }> {
-    return xhr({ url: JSON_SCHEMASTORE_URL }).then((response) => {
+  private getSchemaStoreMatchingSchemas(schemaStoreUrl: string): Promise<{ schemas: any[] }> {
+    return xhr({ url: schemaStoreUrl }).then((response) => {
       const languageSettings = {
         schemas: [],
       };

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -4,6 +4,7 @@ import { ISchemaAssociations } from './requestTypes';
 import { URI } from 'vscode-uri';
 import { JSONSchema } from './languageservice/jsonSchema';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { JSON_SCHEMASTORE_URL } from './languageservice/utils/schemaUrls';
 
 // Client settings interface to grab settings relevant for the language server
 export interface Settings {
@@ -55,7 +56,7 @@ export class SettingsState {
   schemaStoreSettings = [];
   customTags = [];
   schemaStoreEnabled = true;
-  schemaStoreUrl = 'https://www.schemastore.org/api/json/catalog.json';
+  schemaStoreUrl = JSON_SCHEMASTORE_URL;
   indentation: string | undefined = undefined;
   maxItemsComputed = 5000;
 

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -15,6 +15,7 @@ export interface Settings {
     completion: boolean;
     customTags: Array<string>;
     schemaStore: {
+      url: string;
       enable: boolean;
     };
     maxItemsComputed: number;
@@ -54,6 +55,7 @@ export class SettingsState {
   schemaStoreSettings = [];
   customTags = [];
   schemaStoreEnabled = true;
+  schemaStoreUrl = 'https://www.schemastore.org/api/json/catalog.json';
   indentation: string | undefined = undefined;
   maxItemsComputed = 5000;
 


### PR DESCRIPTION
### What does this PR do?
Adds option to specify custom schema store schema

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/294
https://github.com/redhat-developer/vscode-yaml/issues/406

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
This change is published here: https://www.npmjs.com/package/@hackercat/yaml-language-server (with few changes in tests and my own schema store mirror) since I've tested it few times with custom store and clearing cache.
I think that the change is fairly small and easy to review. I'd appreciate any pointers since I never had any experience (except JS) with NodeJS/TS/NPM/etc. before and this whole thing was hacked in few hours (90% of time trying to figure out how to build this whole thing with `vscode-yaml` extension, it was a lot of `yarn this`, `yarn that`, I've not run `yarn test` for `vscode-yaml` extension since `vscode` breaks on my Alpine machine with `musl` instead of `glibc`).
