### PR TITLE
Remove fileMatch workaround

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -170,8 +170,7 @@ export class SettingsHandler {
             if (currFileMatch.indexOf('.yml') !== -1 || currFileMatch.indexOf('.yaml') !== -1) {
               languageSettings.schemas.push({
                 uri: schema.url,
-                // this is workaround to fix file matcher, adding '/' force to match full file name instead of just file name ends
-                fileMatch: [currFileMatch.indexOf('/') === -1 ? '/' + currFileMatch : currFileMatch],
+                fileMatch: [currFileMatch],
                 priority: SchemaPriority.SchemaStore,
               });
             }

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -38,7 +38,7 @@ describe('Settings Handlers Tests', () => {
     sandbox.restore();
   });
 
-  it('SettingsHandler should modify file match patterns', async () => {
+  it('SettingsHandler should not modify file match patterns', async () => {
     xhrStub.resolves({
       responseText: `{"schemas": [
       {
@@ -64,7 +64,7 @@ describe('Settings Handlers Tests', () => {
 
     expect(settingsState.schemaStoreSettings).deep.include({
       uri: 'https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json',
-      fileMatch: ['/.adonisrc.yaml'],
+      fileMatch: ['.adonisrc.yaml'],
       priority: SchemaPriority.SchemaStore,
     });
   });


### PR DESCRIPTION
### What does this PR do?
Remove fileMatch workaround as now we have proper glob patterns support.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/508

### Is it tested? How?
with test
