### PR TITLE
Fix "Billion Laughs" attack and validation tests

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -113,8 +113,7 @@ export abstract class ASTNodeImpl {
     const foundNode = findNode(this);
     let currMinDist = Number.MAX_VALUE;
     let currMinNode = null;
-    for (const possibleNode in collector) {
-      const currNode = collector[possibleNode];
+    for (const currNode of collector) {
       const minDist = currNode.length + currNode.offset - offset + (offset - currNode.offset);
       if (minDist < currMinDist) {
         currMinNode = currNode;

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -36,7 +36,7 @@ export class SingleYAMLDocument extends JSONDocument {
       this._lineComments.push(`#${this._internalDocument.commentBefore}`);
     }
     visit(this.internalDocument, (_key, node: Node) => {
-      if (node.commentBefore) {
+      if (node?.commentBefore) {
         this._lineComments.push(`#${node.commentBefore}`);
       }
     });

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -27,7 +27,7 @@ export const yamlDiagToLSDiag = (yamlDiag: YAMLDocDiagnostic, textDocument: Text
   const range = {
     start,
     end: yamlDiag.location.toLineEnd
-      ? Position.create(start.line, new TextBuffer(textDocument).getLineLength(yamlDiag.location.start))
+      ? Position.create(start.line, new TextBuffer(textDocument).getLineLength(start.line))
       : textDocument.positionAt(yamlDiag.location.end),
   };
 

--- a/test/utils/errorMessages.ts
+++ b/test/utils/errorMessages.ts
@@ -26,8 +26,7 @@ export function propertyIsNotAllowed(name: string): string {
 /**
  * Parse errors
  */
-export const BlockMappingEntryError = 'can not read a block mapping entry; a multiline key may not be an implicit key';
-export const ColonMissingError = 'can not read an implicit mapping pair; a colon is missed';
+export const BlockMappingEntryError = 'Implicit map keys need to be followed by map values';
 
 /**
  * Value Errors

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -35,7 +35,7 @@ describe('YAML Validation Tests', () => {
       const result = await parseSetup(yaml);
       expect(result).is.not.empty;
       expect(result.length).to.be.equal(1);
-      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 11));
+      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 6));
     });
 
     it('Should report one error for TAB character present in a row', async () => {
@@ -43,7 +43,7 @@ describe('YAML Validation Tests', () => {
       const result = await parseSetup(yaml);
       expect(result).is.not.empty;
       expect(result.length).to.be.equal(1);
-      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 12));
+      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 7));
     });
 
     it('Should report one error for TAB`s characters present in the middle of indentation', async () => {
@@ -51,7 +51,7 @@ describe('YAML Validation Tests', () => {
       const result = await parseSetup(yaml);
       expect(result).is.not.empty;
       expect(result.length).to.be.equal(1);
-      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 1, 1, 15));
+      expect(result[0]).deep.equal(createExpectedError('Tabs are not allowed as indentation', 1, 1, 1, 10));
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
PR fix  "Billion Laughs" attack for new AST transformer.
Also changes AST transformer for `ref` mapping key and restore resolving `ref` nodes.
Also fix test in `schemaValidation.test.ts` (except one test related to duplicate keys) and `yamlValidation.test.ts`