### PR TITLE
feat(prettier): Support doNotIndent and commentSpacesFromContent

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
   "optionalDependencies": {
-    "prettier": "2.0.5"
+    "prettier": "2.4.0"
   },
   "dependencies": {
     "js-yaml": "^4.1.0",

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -72,6 +72,14 @@ export class SettingsHandler {
           this.yamlSettings.yamlFormatterSettings.bracketSpacing = settings.yaml.format.bracketSpacing;
         }
 
+        if (settings.yaml.format.doNotIndent !== undefined) {
+          this.yamlSettings.yamlFormatterSettings.doNotIndent = settings.yaml.format.doNotIndent;
+        }
+
+        if (settings.yaml.format.commentSpacesFromContent !== undefined) {
+          this.yamlSettings.yamlFormatterSettings.commentSpacesFromContent = settings.yaml.format.commentSpacesFromContent;
+        }
+
         if (settings.yaml.format.enable !== undefined) {
           this.yamlSettings.yamlFormatterSettings.enable = settings.yaml.format.enable;
         }

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -42,6 +42,8 @@ export class YAMLFormatter {
         // 'preserve' is the default for Options.proseWrap. See also server.ts
         proseWrap: 'always' === options.proseWrap ? 'always' : 'never' === options.proseWrap ? 'never' : 'preserve',
         printWidth: options.printWidth,
+        commentSpacesFromContent: options.commentSpacesFromContent,
+        doNotIndent: options.doNotIndent,
       };
 
       const formatted = prettier.format(text, prettierOptions);

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -116,6 +116,8 @@ export interface CustomFormatterOptions {
   proseWrap?: string;
   printWidth?: number;
   enable?: boolean;
+  commentSpacesFromContent?: number;
+  doNotIndent?: boolean;
 }
 
 export interface LanguageService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -51,6 +51,8 @@ export class SettingsState {
     proseWrap: 'preserve',
     printWidth: 80,
     enable: true,
+    doNotIndent: false,
+    commentSpacesFromContent: 1,
   } as CustomFormatterOptions;
   yamlShouldHover = true;
   yamlShouldCompletion = true;


### PR DESCRIPTION
### What does this PR do?
Pass `doNotIndent` and `commentSpacesFromContent` options to Prettier, upgrades Prettier dependency to `2.4.0`

### What issues does this PR fix or reference?

### What issues does this PR fix or reference?
Resolves: 
- https://github.com/redhat-developer/vscode-yaml/issues/433
- https://github.com/redhat-developer/vscode-yaml/issues/172

Depends on:
- https://github.com/prettier/prettier/pull/10927 (requires new Prettier release)
- https://github.com/prettier/prettier/pull/10926 (requires new Prettier release)

Required by:
- https://github.com/redhat-developer/vscode-yaml/pull/519


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
