### PR TITLE
Make autocomplete automatically escape colon inside of a key

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1080,7 +1080,7 @@ function convertToStringValue(value: string): string {
     value = value.replace(doubleQuotesEscapeRegExp, '"');
   }
 
-  if (value.length > 0 && value.charAt(0) === '@') {
+  if ((value.length > 0 && value.charAt(0) === '@') || value.includes(':')) {
     value = `"${value}"`;
   }
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -729,7 +729,7 @@ describe('Auto Completion Tests', () => {
           .then(done, done);
       });
 
-      it('Autocompletion should escape key if needed', async () => {
+      it('Autocompletion should escape @', async () => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -744,6 +744,31 @@ describe('Auto Completion Tests', () => {
         expect(completion.items.length).to.be.equal(1);
         expect(completion.items[0]).to.deep.equal(
           createExpectedCompletion('@type', '"@type": ${1:foo}', 0, 0, 0, 0, 10, 2, {
+            documentation: '',
+          })
+        );
+      });
+
+      it('Autocompletion should escape colon', async () => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            'test: colon': {
+              type: 'object',
+              properties: {
+                none: {
+                  type: 'boolean',
+                  enum: [true],
+                },
+              },
+            },
+          },
+        });
+        const content = '';
+        const completion = await parseSetup(content, 0);
+        expect(completion.items.length).to.be.equal(1);
+        expect(completion.items[0]).to.deep.equal(
+          createExpectedCompletion('test: colon', '"test: colon":\n  $1', 0, 0, 0, 0, 10, 2, {
             documentation: '',
           })
         );


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes it so that colons inside of a yaml key are automatically quoted

![colon-fix](https://user-images.githubusercontent.com/8839537/119664635-888b3000-be01-11eb-96cc-f2fb8717780d.gif)

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/496 and https://github.com/redhat-developer/yaml-language-server/issues/474


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested manually through vscode and through the test I've created
