### PR TITLE
Use 'workspace/configuration' to fetch settings

### DIFF
--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -26,8 +26,10 @@ export interface Settings {
     proxy: string;
     proxyStrictSSL: boolean;
   };
-  editor: {
-    tabSize: number;
+  yamlEditor: {
+    'editor.tabSize': number;
+    'editor.insertSpaces': boolean;
+    'editor.formatOnType': boolean;
   };
 }
 
@@ -77,6 +79,7 @@ export class SettingsState {
   clientDynamicRegisterSupport = false;
   hierarchicalDocumentSymbolSupport = false;
   hasWorkspaceFolderCapability = false;
+  hasConfigurationCapability = false;
   useVSCodeContentRequest = false;
 }
 

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -7,27 +7,30 @@ import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers
 import * as sinon from 'sinon';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
-import { Connection } from 'vscode-languageserver';
+import { Connection, RemoteWorkspace } from 'vscode-languageserver';
 import { SettingsState } from '../src/yamlSettings';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
 import { LanguageService, LanguageSettings, SchemaConfiguration, SchemaPriority } from '../src';
 import * as request from 'request-light';
 import { setupLanguageService } from './utils/testHelper';
 import { Telemetry } from '../src/languageserver/telemetry';
+import { TestWorkspace } from './utils/testsTypes';
 
 const expect = chai.expect;
 chai.use(sinonChai);
 
 describe('Settings Handlers Tests', () => {
   const sandbox = sinon.createSandbox();
-  let connectionStub: sinon.SinonMockStatic;
+  const connection: Connection = {} as Connection;
+  let workspaceStub: sinon.SinonStubbedInstance<RemoteWorkspace>;
   let languageService: sinon.SinonMockStatic;
   let settingsState: SettingsState;
   let validationHandler: sinon.SinonMock;
   let xhrStub: sinon.SinonStub;
 
   beforeEach(() => {
-    connectionStub = sandbox.mock();
+    workspaceStub = sandbox.createStubInstance(TestWorkspace);
+    connection.workspace = (workspaceStub as unknown) as RemoteWorkspace;
     languageService = sandbox.mock();
     settingsState = new SettingsState();
     validationHandler = sandbox.mock(ValidationHandler);
@@ -51,7 +54,7 @@ describe('Settings Handlers Tests', () => {
       }]}`,
     });
     const settingsHandler = new SettingsHandler(
-      (connectionStub as unknown) as Connection,
+      connection,
       (languageService as unknown) as LanguageService,
       settingsState,
       (validationHandler as unknown) as ValidationHandler,
@@ -78,7 +81,7 @@ describe('Settings Handlers Tests', () => {
 
       const languageService = languageServerSetup.languageService;
       const settingsHandler = new SettingsHandler(
-        (connectionStub as unknown) as Connection,
+        connection,
         languageService,
         settingsState,
         (validationHandler as unknown) as ValidationHandler,
@@ -141,6 +144,31 @@ describe('Settings Handlers Tests', () => {
         fileMatch: testSchemaFileMatch,
         priority: SchemaPriority.SchemaAssociation,
       });
+    });
+  });
+
+  describe('Settings fetch', () => {
+    it('should fetch preferences', async () => {
+      const settingsHandler = new SettingsHandler(
+        connection,
+        (languageService as unknown) as LanguageService,
+        settingsState,
+        (validationHandler as unknown) as ValidationHandler,
+        {} as Telemetry
+      );
+      workspaceStub.getConfiguration.resolves([{}, {}, {}, {}]);
+      const setConfigurationStub = sandbox.stub(settingsHandler, 'setConfiguration');
+
+      await settingsHandler.pullConfiguration();
+
+      expect(workspaceStub.getConfiguration).calledOnceWith([
+        { section: 'yaml' },
+        { section: 'http.proxy' },
+        { section: 'http.proxyStrictSSL' },
+        { section: '[yaml]' },
+      ]);
+
+      expect(setConfigurationStub).calledOnce;
     });
   });
 });

--- a/test/utils/testsTypes.ts
+++ b/test/utils/testsTypes.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event, NotificationHandler, RequestHandler } from 'vscode-jsonrpc';
+import {
+  ApplyWorkspaceEditParams,
+  WorkspaceEdit,
+  ApplyWorkspaceEditResponse,
+  ConfigurationItem,
+  WorkspaceFolder,
+  WorkspaceFoldersChangeEvent,
+  CreateFilesParams,
+  RenameFilesParams,
+  DeleteFilesParams,
+} from 'vscode-languageserver-protocol';
+import { Connection, RemoteWorkspace } from 'vscode-languageserver/lib/common/server';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+export class TestWorkspace implements RemoteWorkspace {
+  connection: Connection;
+  applyEdit(paramOrEdit: ApplyWorkspaceEditParams | WorkspaceEdit): Promise<ApplyWorkspaceEditResponse> {
+    throw new Error('Method not implemented.');
+  }
+  getConfiguration(): Promise<any>;
+  getConfiguration(section: string): Promise<any>;
+  getConfiguration(item: ConfigurationItem): Promise<any>;
+  getConfiguration(items: ConfigurationItem[]): Promise<any[]>;
+  getConfiguration(items?: any): Promise<any | any[]> {
+    throw new Error('Method not implemented.');
+  }
+  getWorkspaceFolders(): Promise<WorkspaceFolder[]> {
+    throw new Error('Method not implemented.');
+  }
+  onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
+  onDidCreateFiles(handler: NotificationHandler<CreateFilesParams>): void {
+    throw new Error('Method not implemented.');
+  }
+  onDidRenameFiles(handler: NotificationHandler<RenameFilesParams>): void {
+    throw new Error('Method not implemented.');
+  }
+  onDidDeleteFiles(handler: NotificationHandler<DeleteFilesParams>): void {
+    throw new Error('Method not implemented.');
+  }
+  onWillCreateFiles(handler: RequestHandler<CreateFilesParams, WorkspaceEdit, never>): void {
+    throw new Error('Method not implemented.');
+  }
+  onWillRenameFiles(handler: RequestHandler<RenameFilesParams, WorkspaceEdit, never>): void {
+    throw new Error('Method not implemented.');
+  }
+  onWillDeleteFiles(handler: RequestHandler<DeleteFilesParams, WorkspaceEdit, never>): void {
+    throw new Error('Method not implemented.');
+  }
+}


### PR DESCRIPTION
### What does this PR do?
It changes the way how LS receives settings/preferences, previously we fully rely on client, which use deprecated API to push settings to server. Now we use proper API to fetch settings from client.

### What issues does this PR fix or reference?
Resolve #327

### Is it tested? How?
with test, and manually, just run vscode-yaml and make sure that your preferences used on yaml-ls.
