### PR TITLE
initialise 'customTags' parameter with default value

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -23,7 +23,7 @@ export class YamlDocuments {
    * @param addRootObject if true and document is empty add empty object {} to force schema usage
    * @returns the YAMLDocument
    */
-  getYamlDocument(document: TextDocument, customTags?: string[], addRootObject = false): YAMLDocument {
+  getYamlDocument(document: TextDocument, customTags: string[] = [], addRootObject = false): YAMLDocument {
     this.ensureCache(document, customTags, addRootObject);
     return this.cache.get(document.uri).document;
   }


### PR DESCRIPTION
### What does this PR do?
It fixes error:
```
Error - 2:38:37 pm] (node:5928) UnhandledPromiseRejectionWarning: TypeError: customTags.filter is not a function 
at Object.filterInvalidCustomTags (c:\Users\_username_\.vscode\extensions\redhat.vscode-yaml-0.20.0\node_modules\yaml-language-server\out\server\src\languageservice\utils\arrUtils.js:56:23)
at Object.customTagsToAdditionalOptions (c:\Users\_username_\.vscode\extensions\redhat.vscode-yaml-0.20.0\node_modules\yaml-language-server\out\server\src\languageservice\utils\parseUtils.js:51:37) 
at Object.parse (c:\Users\_username_\.vscode\extensions\redhat.vscode-yaml-0.20.0\node_modules\yaml-language-server\out\server\src\languageservice\parser\yamlParser07.js:79:44) 
at YamlDocuments.ensureCache (c:\Users\_username_\.vscode\extensions\redhat.vscode-yaml-0.20.0\node_modules\yaml-language-server\out\server\src\languageservice\parser\yaml-documents.js:44:40)
at YamlDocuments.getYamlDocument (c:\Users\_username_\.vscode\extensions\redhat.vscode-yaml-0.20.0\node_modules\yaml-language-server\
```
Find by telemetry
