### PR TITLE
Support relative path in inline schema comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,20 @@ yaml.schemas: {
 
 It is possible to specify a yaml schema using a modeline.
 
-```
+```yaml
 # yaml-language-server: $schema=<urlToTheSchema>
+```
+
+Also it is possible to use relative path in a modeline:
+
+```yaml
+# yaml-language-server: $schema=../relative/path/to/schema
+```
+
+or absolute path:
+
+```yaml
+# yaml-language-server: $schema=/absolute/path/to/schema
 ```
 
 ## Containerized Language Server

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -284,9 +284,9 @@ export class YAMLSchemaService extends JSONSchemaService {
         if (!schemaFromModeline.startsWith('file:')) {
           if (!path.isAbsolute(schemaFromModeline)) {
             const resUri = URI.parse(resource);
-            schemaFromModeline = URI.parse(path.resolve(path.parse(resUri.fsPath).dir, schemaFromModeline)).toString();
+            schemaFromModeline = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaFromModeline)).toString();
           } else {
-            schemaFromModeline = URI.parse(schemaFromModeline).toString();
+            schemaFromModeline = URI.file(schemaFromModeline).toString();
           }
         }
         this.addSchemaPriority(schemaFromModeline, SchemaPriority.Modeline);

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1567,6 +1567,31 @@ describe('Auto Completion Tests', () => {
           .then(done, done);
       }, done);
     });
+
+    it('should handle absolute path', async () => {
+      const documentContent = `# yaml-language-server: $schema=${path.join(
+        __dirname,
+        './fixtures/testArrayMaxProperties.json'
+      )} anothermodeline=value\n- `;
+      const content = `${documentContent}\n---\n- `;
+      const result = await parseSetup(content, documentContent.length);
+      assert.strictEqual(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
+    });
+
+    it('should handle relative path', async () => {
+      const documentContent = `# yaml-language-server: $schema=./fixtures/testArrayMaxProperties.json anothermodeline=value\n- `;
+      const content = `${documentContent}\n---\n- `;
+      // const result = await parseSetup(content, documentContent.length);
+
+      const testTextDocument = setupSchemaIDTextDocument(content, path.join(__dirname, 'test.yaml'));
+      yamlSettings.documents = new TextDocumentTestManager();
+      (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+      const result = await languageHandler.completionHandler({
+        position: testTextDocument.positionAt(documentContent.length),
+        textDocument: testTextDocument,
+      });
+      assert.strictEqual(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
+    });
   });
 
   describe('Configuration based indentation', () => {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1581,7 +1581,6 @@ describe('Auto Completion Tests', () => {
     it('should handle relative path', async () => {
       const documentContent = `# yaml-language-server: $schema=./fixtures/testArrayMaxProperties.json anothermodeline=value\n- `;
       const content = `${documentContent}\n---\n- `;
-      // const result = await parseSetup(content, documentContent.length);
 
       const testTextDocument = setupSchemaIDTextDocument(content, path.join(__dirname, 'test.yaml'));
       yamlSettings.documents = new TextDocumentTestManager();


### PR DESCRIPTION
### What does this PR do?
Add support for relative and absolute path in inline schema comment:

```yaml
# yaml-language-server: $schema=../relative/path/to/schema
```

### What issues does this PR fix or reference?
Resolve: #371

### Is it tested? How?
With tests
