### PR TITLE
Include call stack when console error called with null

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,18 @@ if (process.argv.indexOf('--stdio') === -1) {
 console.log = connection.console.log.bind(connection.console);
 console.error = connection.console.error.bind(connection.console);
 
+// temporary, if some code call console.log(null), we log trace to find the place where it was called
+console.error = (arg) => {
+  connection.console.error(arg);
+  if (arg === null) {
+    try {
+      throw new Error();
+    } catch (err) {
+      connection.console.error(err.stack);
+    }
+  }
+};
+
 const yamlSettings = new SettingsState();
 
 /**


### PR DESCRIPTION
### What does this PR do?
Include call stack when `console.error` called with null.
As in yaml-ls we bind `console` to `connection.console` all calls of `console.error` and `console.log` goes to `connection` and if they contains `Error` we send such messages to telemetry. But `console.error` may be used in yaml-ls dependencies,
so this PR add ability to find which exactly code call `console.error` with `null` argument.

### What issues does this PR fix or reference?
Part of https://github.com/redhat-developer/vscode-yaml/pull/552

