### PR TITLE
Fix more tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "request": "launch",
       "name": "Launch Tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-      "args": ["-u", "bdd", "--timeout", "999999", "--colors", "-r", "ts-node/register", "${workspaceRoot}/test/*.test.ts"],
+      "args": ["-u", "bdd", "--timeout", "15000", "--colors", "-r", "ts-node/register", "${workspaceRoot}/test/*.test.ts"],
       "preLaunchTask": "watch typescript",
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",
@@ -31,7 +31,7 @@
       "request": "launch",
       "name": "Launch Single File Tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-      "args": ["-u", "bdd", "--timeout", "999999", "--colors", "-r", "ts-node/register", "${workspaceRoot}/${relativeFile}"],
+      "args": ["-u", "bdd", "--timeout", "15000", "--colors", "-r", "ts-node/register", "${workspaceRoot}/${relativeFile}"],
       "preLaunchTask": "watch typescript",
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -24,10 +24,12 @@ export class SingleYAMLDocument extends JSONDocument {
   public root: ASTNode;
   public currentDocIndex: number;
   private _lineComments: string[];
+  private text: string;
 
-  constructor(lineCounter?: LineCounter) {
+  constructor(text: string, lineCounter?: LineCounter) {
     super(null, []);
     this.lineCounter = lineCounter;
+    this.text = text;
   }
 
   private collectLineComments(): void {
@@ -44,7 +46,7 @@ export class SingleYAMLDocument extends JSONDocument {
 
   set internalDocument(document: Document) {
     this._internalDocument = document;
-    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument, this.lineCounter);
+    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument, this.text, this.lineCounter);
   }
 
   get internalDocument(): Document {

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -38,14 +38,14 @@ export function parse(text: string, parserOptions: ParserOptions = defaultOption
   const docs = composer.compose(tokens);
 
   // Generate the SingleYAMLDocs from the AST nodes
-  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc) => parsedDocToSingleYAMLDocument(doc, lineCounter));
+  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc) => parsedDocToSingleYAMLDocument(doc, text, lineCounter));
 
   // Consolidate the SingleYAMLDocs
   return new YAMLDocument(yamlDocs);
 }
 
-function parsedDocToSingleYAMLDocument(parsedDoc: Document, lineCounter: LineCounter): SingleYAMLDocument {
-  const syd = new SingleYAMLDocument(lineCounter);
+function parsedDocToSingleYAMLDocument(parsedDoc: Document, text: string, lineCounter: LineCounter): SingleYAMLDocument {
+  const syd = new SingleYAMLDocument(text, lineCounter);
   syd.internalDocument = parsedDoc;
   return syd;
 }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1020,7 +1020,7 @@ export class YAMLCompletion extends JSONCompletion {
         newText =
           document.getText().substring(0, start + spaceLength) +
           (trimmedText[0] === '-' && !textLine.endsWith(' ') ? ' ' : '') +
-          'holder:\r\n' +
+          'holder:\n' +
           document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
 
         // For when missing semi colon case
@@ -1028,7 +1028,7 @@ export class YAMLCompletion extends JSONCompletion {
         // Add a semicolon to the end of the current line so we can validate the node
         newText =
           document.getText().substring(0, start + textLine.length) +
-          ':\r\n' +
+          ':\n' +
           document.getText().substr(lineOffset[linePos + 1] || document.getText().length);
       }
 

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -7,7 +7,7 @@
 
 import { Diagnostic, Position } from 'vscode-languageserver';
 import { LanguageSettings } from '../yamlLanguageService';
-import { YAMLDocument, YamlVersion } from '../parser/yamlParser07';
+import { defaultOptions, YAMLDocument, YamlVersion } from '../parser/yamlParser07';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { YAMLDocDiagnostic } from '../utils/parseUtils';
@@ -52,7 +52,7 @@ export class YAMLValidation {
     if (settings) {
       this.validationEnabled = settings.validate;
       this.customTags = settings.customTags;
-      this.yamlVersion = settings.yamlVersion;
+      this.yamlVersion = settings.yamlVersion ?? defaultOptions.yamlVersion;
       this.disableAdditionalProperties = settings.disableAdditionalProperties;
     }
   }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -852,7 +852,7 @@ describe('Auto Completion Tests', () => {
           .then(done, done);
       });
 
-      it('Array autocomplete without word on space before array symbol', (done) => {
+      it('Array autocomplete without word on space before array symbol', async () => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -873,18 +873,15 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - name: test\n  ';
-        const completion = parseSetup(content, 24);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('- (array item)', '- $1', 2, 0, 2, 0, 9, 2, {
-                documentation: 'Create an item of an array',
-              })
-            );
+        const result = await parseSetup(content, 24);
+
+        assert.strictEqual(result.items.length, 1);
+        assert.deepStrictEqual(
+          result.items[0],
+          createExpectedCompletion('- (array item)', '- $1', 2, 0, 2, 0, 9, 2, {
+            documentation: 'Create an item of an array',
           })
-          .then(done, done);
+        );
       });
 
       it('Array autocomplete with letter', (done) => {
@@ -1553,19 +1550,15 @@ describe('Auto Completion Tests', () => {
         .then(done, done);
     });
 
-    it('Provide completion from schema declared in file with several documents', (done) => {
+    it('Provide completion from schema declared in file with several documents', async () => {
       const documentContent1 = `# yaml-language-server: $schema=${uri} anothermodeline=value\n- `;
       const content = `${documentContent1}\n---\n- `;
-      const completionDoc1 = parseSetup(content, documentContent1.length);
-      completionDoc1.then(function (result) {
-        assert.equal(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
-        const completionDoc2 = parseSetup(content, content.length);
-        completionDoc2
-          .then(function (resultDoc2) {
-            assert.equal(resultDoc2.items.length, 0, `Expecting no items in completion but found ${resultDoc2.items.length}`);
-          })
-          .then(done, done);
-      }, done);
+      const result = await parseSetup(content, documentContent1.length);
+
+      assert.equal(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
+      const resultDoc2 = await parseSetup(content, content.length);
+
+      assert.equal(resultDoc2.items.length, 0, `Expecting no items in completion but found ${resultDoc2.items.length}`);
     });
   });
 

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -74,16 +74,13 @@ describe('Default Snippet Tests', () => {
         .then(done, done);
     });
 
-    it('Snippet in array schema should autocomplete correctly on array level ', (done) => {
+    it('Snippet in array schema should autocomplete correctly on array level ', async () => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
     it('Snippet in array schema should autocomplete correctly inside array item ', (done) => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n    ';

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -738,7 +738,7 @@ describe('JSON Schema', () => {
 
     function checkReturnSchemaUrl(modeline: string, expectedResult: string): void {
       const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
-      const yamlDoc = new parser.SingleYAMLDocument(new LineCounter());
+      const yamlDoc = new parser.SingleYAMLDocument('', new LineCounter());
       yamlDoc.lineComments = [modeline];
       assert.equal(service.getSchemaFromModeline(yamlDoc), expectedResult);
     }

--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -255,6 +255,21 @@ describe('YAML parser', () => {
     });
   });
 
+  describe('YAML AST converting', () => {
+    it('should include array node to new line', () => {
+      const parsedDocument = parse('authors:\n  - name: test\n  holder:\r\n');
+      const node = parsedDocument.documents[0].getNodeFromOffsetEndInclusive(24);
+      assert.strictEqual(node.type, 'array');
+    });
+
+    it('should include array node to new line2', () => {
+      const content = 'array:\n  - item1: asd\n    item2: asd\n   holder:\n';
+      const parsedDocument = parse(content);
+      const node = parsedDocument.documents[0].getNodeFromOffsetEndInclusive(39);
+      assert.strictEqual(node.type, 'array');
+    });
+  });
+
   describe('YAML parser bugs', () => {
     it('should work with "Billion Laughs" attack', () => {
       const yaml = `apiVersion: v1


### PR DESCRIPTION
### What does this PR do?
Fix almost all tests, except one - `Snippet in array schema should autocomplete correctly on array level`

The problem with last test, is that, during codecompletion we modify original yaml, by adding `holder:\n` in cursor position(see https://github.com/redhat-developer/yaml-language-server/blob/main/src/languageservice/services/yamlCompletion.ts#L1026 ),
and current parser has a bug, it generate wrong ast node for `holder`(node has no text and wrong position)  and we calculate completion items from that, not correct AST tree. New parser doesn’t  have such bug, and AST differs.
