### PR TITLE
Fix bad schema handle

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -162,7 +162,7 @@ export class YAMLCompletion extends JSONCompletion {
 
     currentDoc.currentDocIndex = currentDocIndex;
     return this.schemaService.getSchemaForResource(document.uri, currentDoc).then((schema) => {
-      if (!schema) {
+      if (!schema || schema.errors.length) {
         return Promise.resolve(result);
       }
       const newSchema = schema;

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -91,7 +91,7 @@ export class YAMLHover {
     };
 
     return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
-      if (schema && node) {
+      if (schema && node && !schema.errors.length) {
         const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
 
         let title: string | undefined = undefined;

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -321,7 +321,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         const highestPrioSchemas = this.highestPrioritySchemas(schemas);
         const schemaHandle = super.createCombinedSchema(resource, highestPrioSchemas);
         return schemaHandle.getResolvedSchema().then((schema) => {
-          if (schema.schema) {
+          if (schema.schema && typeof schema.schema !== 'string') {
             schema.schema.url = schemaHandle.url;
           }
 


### PR DESCRIPTION
### What does this PR do?
In some features (like codecompletion and hover) we miss checks, that ensures that JSON Schema was parsed,
this PR add them. It should fix errors like https://github.com/redhat-developer/vscode-yaml/issues/556 and https://github.com/redhat-developer/yaml-language-server/issues/497

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/556
https://github.com/redhat-developer/yaml-language-server/issues/497

### Is it tested? How?
With test and manually, try  https://github.com/redhat-developer/vscode-yaml/issues/556
