### PR TITLE
Fix fetching nested http settings

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -34,17 +34,16 @@ export class SettingsHandler {
   async pullConfiguration(): Promise<void> {
     const config = await this.connection.workspace.getConfiguration([
       { section: 'yaml' },
-      { section: 'http.proxy' },
-      { section: 'http.proxyStrictSSL' },
+      { section: 'http' },
       { section: '[yaml]' },
     ]);
     const settings: Settings = {
       yaml: config[0],
       http: {
-        proxy: config[1],
-        proxyStrictSSL: config[2],
+        proxy: config[1]?.proxy ?? '',
+        proxyStrictSSL: config[1]?.proxyStrictSSL ?? false,
       },
-      yamlEditor: config[3],
+      yamlEditor: config[2],
     };
     this.setConfiguration(settings);
   }

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -156,19 +156,25 @@ describe('Settings Handlers Tests', () => {
         (validationHandler as unknown) as ValidationHandler,
         {} as Telemetry
       );
-      workspaceStub.getConfiguration.resolves([{}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{}, {}, {}]);
       const setConfigurationStub = sandbox.stub(settingsHandler, 'setConfiguration');
 
       await settingsHandler.pullConfiguration();
 
       expect(workspaceStub.getConfiguration).calledOnceWith([
         { section: 'yaml' },
-        { section: 'http.proxy' },
-        { section: 'http.proxyStrictSSL' },
+        { section: 'http' },
         { section: '[yaml]' },
       ]);
 
-      expect(setConfigurationStub).calledOnce;
+      expect(setConfigurationStub).calledOnceWith({
+        yaml: {},
+        http: {
+          proxy: '',
+          proxyStrictSSL: false,
+        },
+        yamlEditor: {}
+      });
     });
   });
 });

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -161,11 +161,7 @@ describe('Settings Handlers Tests', () => {
 
       await settingsHandler.pullConfiguration();
 
-      expect(workspaceStub.getConfiguration).calledOnceWith([
-        { section: 'yaml' },
-        { section: 'http' },
-        { section: '[yaml]' },
-      ]);
+      expect(workspaceStub.getConfiguration).calledOnceWith([{ section: 'yaml' }, { section: 'http' }, { section: '[yaml]' }]);
 
       expect(setConfigurationStub).calledOnceWith({
         yaml: {},
@@ -173,7 +169,7 @@ describe('Settings Handlers Tests', () => {
           proxy: '',
           proxyStrictSSL: false,
         },
-        yamlEditor: {}
+        yamlEditor: {},
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

This PR tweaks the way the `http` configuration section is pulled from the client. It pulls the entire `http` section at once then plucks out the values it needs. I do assume there is no sensitive client information other that `proxy` and `proxyStrictSSL` on the `http` section which shouldn't be pulled.

In my research I've found no solid definition for what a `section` in the LSP is so my thinking is that usage of it should be as simple as possible for most clients to support it.

### What issues does this PR fix or reference?

[Nova](https://nova.app) doesn't currently have a way to configure how workspace settings are passed to the server and it does it in a bit of an odd way at the moment, which I've described in the issue below. Requesting `http.proxy` in Nova returns `{}` which was getting passed straight to `requests_light` and breaking it.

- https://github.com/robb-j/nova-yaml/issues/20

### Is it tested? How?

With unit tests. I updated the existing unit test to follow the new LSP message structure and added an assertion for the shape of settings passed to `setConfiguration`.

I ran the modified server in Nova using `npm link` and confirmed that schemas were being loaded and tooltips were showing again.

I can try running it with VSCode if you like but I don't currently have an extension development setup for it.