### PR TITLE
Add support of URL fragments in schema URL

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -24,7 +24,6 @@ import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { JSONDocument } from '../parser/jsonParser07';
 import { load } from 'js-yaml';
 import * as path from 'path';
-import { settings } from 'cluster';
 
 const localize = nls.loadMessageBundle();
 

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -24,6 +24,7 @@ import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { JSONDocument } from '../parser/jsonParser07';
 import { load } from 'js-yaml';
 import * as path from 'path';
+import { settings } from 'cluster';
 
 const localize = nls.loadMessageBundle();
 
@@ -256,6 +257,13 @@ export class YAMLSchemaService extends JSONSchemaService {
         collectMapEntries(next.definitions, next.properties, next.patternProperties, <JSONSchemaMap>next.dependencies);
         collectArrayEntries(next.anyOf, next.allOf, next.oneOf, <JSONSchema[]>next.items, next.schemaSequence);
       };
+
+      if (parentSchemaURL.indexOf('#') > 0) {
+        const segments = parentSchemaURL.split('#', 2);
+        if (segments[0].length > 0 && segments[1].length > 0) {
+          openPromises.push(resolveExternalLink(node, segments[0], segments[1], parentSchemaURL, parentSchemaDependencies));
+        }
+      }
 
       while (toWalk.length) {
         const next = toWalk.pop();

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -45,5 +45,25 @@ describe('YAML Schema Service', () => {
 
       expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });
+
+    it('should handle url with fragments', async () => {
+      const content = `# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#/definitions/schemaArray`;
+      const yamlDock = parse(content);
+
+      requestServiceMock = sandbox.fake.resolves(`{"definitions": {"schemaArray": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#" }
+    }}, "properties": {}}`);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      const schema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledTwice;
+      expect(requestServiceMock).calledWithExactly('https://json-schema.org/draft-07/schema');
+      expect(requestServiceMock).calledWithExactly('https://json-schema.org/draft-07/schema#/definitions/schemaArray');
+
+      expect(schema.schema.type).eqls('array');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
It add support of referencing to `#/definitions/{SomeObjectInSchema}`  in JSON Schema URL.
Before `0.21.0` we have support of such URL, but that support was because of bug in schema priority code.
In  `0.21.0` that bug was fixed and we loose of support. This PR add proper implementation of referencing in schema URL.

### What issues does this PR fix or reference?
Resolve: https://github.com/redhat-developer/vscode-yaml/issues/557

### Is it tested? How?
With test. 
To test manually reproduce steps from https://github.com/redhat-developer/vscode-yaml/issues/557
