### PR TITLE
Do not send 'null' in to telemetry

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -27,15 +27,12 @@ if (process.argv.indexOf('--stdio') === -1) {
 console.log = connection.console.log.bind(connection.console);
 console.error = connection.console.error.bind(connection.console);
 
-// temporary, if some code call console.log(null), we log trace to find the place where it was called
+//vscode-nls calls console.error(null) in some cases, so we put that in info, to predict sending "null" in to telemetry
 console.error = (arg) => {
-  connection.console.error(arg);
   if (arg === null) {
-    try {
-      throw new Error();
-    } catch (err) {
-      connection.console.error(err.stack);
-    }
+    connection.console.info(arg);
+  } else {
+    connection.console.error(arg);
   }
 };
 


### PR DESCRIPTION
### What does this PR do?
Redirect `null` error to `console.log` instead of `console.error`.
To not track that `null` message in telemetry.

> That `null` message appears from `vscode-nls` library, which in some cases cannot load configuration file. 

