### PR TITLE
Replace js-yaml with yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "prettier": "2.0.5"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
     "jsonc-parser": "^3.0.0",
     "request-light": "^0.2.4",
     "vscode-json-languageservice": "^4.1.0",
@@ -47,11 +46,11 @@
     "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^4.1.2",
     "vscode-uri": "^2.1.1",
+    "yaml": "2.0.0-7",
     "yaml-language-server-parser": "next"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",
-    "@types/js-yaml": "^4.0.1",
     "@types/mocha": "8.2.2",
     "@types/node": "^12.11.7",
     "@types/prettier": "2.0.2",

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -22,7 +22,7 @@ import * as nls from 'vscode-nls';
 import { convertSimple2RegExpPattern } from '../utils/strings';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { JSONDocument } from '../parser/jsonParser07';
-import { load } from 'js-yaml';
+import { parse } from 'yaml';
 import * as path from 'path';
 
 const localize = nls.loadMessageBundle();
@@ -602,7 +602,7 @@ export class YAMLSchemaService extends JSONSchemaService {
             }
 
             try {
-              const schemaContent = load(content) as JSONSchema;
+              const schemaContent = parse(content);
               return new UnresolvedSchema(schemaContent, []);
             } catch (yamlError) {
               const errorMessage = localize(

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,11 +194,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
   integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
 
-"@types/js-yaml@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.1.tgz#5544730b65a480b18ace6b6ce914e519cec2d43b"
-  integrity sha512-xdOvNmXmrZqqPy3kuCQ+fz6wA0xU5pji9cd1nDrflWaAWtYLLGk5ykW0H6yg5TVyehHP1pfmuuSaZkhP+kspVA==
-
 "@types/json-schema@^7.0.3":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
@@ -1467,7 +1462,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -2722,6 +2717,11 @@ yaml-language-server-parser@next:
   version "0.1.3-fa8245c.0"
   resolved "https://registry.yarnpkg.com/yaml-language-server-parser/-/yaml-language-server-parser-0.1.3-fa8245c.0.tgz#da6c241bd23ee7303d035a99fdc01554e0193f70"
   integrity sha512-0QPUSsmMXHDpqj00xUrlMyqlEAwHHIAuz3wPMyprcCVYx7jh7oo91Z0nC/jhott4XAKp3iY3vjBsMxqszoZosA==
+
+yaml@2.0.0-7:
+  version "2.0.0-7"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-7.tgz#9799d9d85dfc8f01e4cc425e18e09215364beef1"
+  integrity sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
### What does this PR do?

In #442 `yaml-language-server-parser` is being replaced with `yaml` for parsing the AST. `yaml` can also replace `js-yaml` for parsing YAML in other places. This saves a dependency.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

Existing unittests didn’t break.
