### PR TITLE
Update monaco-yaml link

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This repository only contains the server implementation. Here are some known cli
 - [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs
 - [vim-lsp](https://github.com/prabirshrestha/vim-lsp) for Vim
 - [LSP-yaml](https://packagecontrol.io/packages/LSP-yaml) for Sublime Text
-- [monaco-yaml](https://github.com/pengx17/monaco-yaml) for Monaco editor
+- [monaco-yaml](https://monaco-yaml.js.org) for Monaco editor
 
 ## Developer Support
 


### PR DESCRIPTION
### What does this PR do?

This updates the link to the `monaco-yaml` project in the readme.

The project was transferred to my account. I created a demo on the updated link.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

I clicked the link. :)
