### PR TITLE
Remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,6 @@
       "name": "Google LLC"
     }
   ],
-  "engines": {
-    "node": "*",
-    "npm": "\n\nERROR: Please use yarn, npm is not supported in this repository!!!\n\n",
-    "yarn": "^1.22.5"
-  },
   "bin": {
     "yaml-language-server": "./bin/yaml-language-server"
   },


### PR DESCRIPTION
### What does this PR do?

The intention was to enforce developers of the project to use a minimal version of yarn. However, the yarn and npm engines determine which version of those package managers may be used to install `yaml-language-server`. This caused warnings for users using npm or older yarn versions.

The node engines field signals required node version that’s needed. Setting it to `*` is equivalent to not setting it at all.

### What issues does this PR fix or reference?

Closes #521

### Is it tested? How?

The CI logs in https://github.com/remcohaszing/monaco-yaml/pull/88/checks?check_run_id=3390781647 show the annoying warning. This is the closest reference to a test case I could think of.