### PR TITLE
Update vscode-nls and vscode-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0",
-    "vscode-nls": "^4.1.2",
-    "vscode-uri": "^2.1.1",
+    "vscode-nls": "^5.0.0",
+    "vscode-uri": "^3.0.2",
     "yaml-language-server-parser": "next"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,7 +2610,7 @@ vscode-languageserver@^7.0.0:
   dependencies:
     vscode-languageserver-protocol "3.16.0"
 
-vscode-nls@^4.1.1, vscode-nls@^4.1.2:
+vscode-nls@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.2.tgz#ca8bf8bb82a0987b32801f9fddfdd2fb9fd3c167"
   integrity sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==
@@ -2619,11 +2619,6 @@ vscode-nls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
   integrity sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==
-
-vscode-uri@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
-  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
 vscode-uri@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### What does this PR do?

The updated dependencies match the ones from `vscode-json-languageservice`. This means they can be deduped. This is mostly interesting to decrease bundle size for usage in the browser, such as in `monaco-yaml`.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```sh
yarn test
```