### PR TITLE
Treat OpenAPI descriptions as markdown

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -101,13 +101,17 @@ export class YAMLHover {
         matchingSchemas.every((s) => {
           if (s.node === node && !s.inverted && s.schema) {
             title = title || s.schema.title;
-            markdownDescription = markdownDescription || s.schema.markdownDescription || toMarkdown(s.schema.description);
+            markdownDescription =
+              markdownDescription ||
+              s.schema.markdownDescription ||
+              ('openapi' in schema.schema ? s.schema.description : toMarkdown(s.schema.description));
             if (s.schema.enum) {
               const idx = s.schema.enum.indexOf(getNodeValue(node));
               if (s.schema.markdownEnumDescriptions) {
                 markdownEnumValueDescription = s.schema.markdownEnumDescriptions[idx];
               } else if (s.schema.enumDescriptions) {
-                markdownEnumValueDescription = toMarkdown(s.schema.enumDescriptions[idx]);
+                markdownEnumValueDescription =
+                  'openapi' in schema.schema ? s.schema.description : toMarkdown(s.schema.enumDescriptions[idx]);
               }
               if (markdownEnumValueDescription) {
                 enumValue = s.schema.enum[idx];

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -336,6 +336,29 @@ describe('Hover Tests', () => {
       );
     });
 
+    it('Hover treats descriptions as markdown for OpenAPI documents', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        // @ts-expect-error This property doesn’t exist on schemas,
+        // but OpenAPI documents are also supported through nested JSON references.
+        openapi: '3.1.0',
+        type: 'object',
+        properties: {
+          childObject: {
+            type: 'object',
+            description: 'should return **this**\ndescription',
+          },
+        },
+      });
+      const content = 'childObject: \n';
+      const result = await parseSetup(content, 1);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return **this**\ndescription\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('should work with bad schema', async () => {
       const doc = setupSchemaIDTextDocument('foo:\n bar', 'bad-schema.yaml');
       yamlSettings.documents = new TextDocumentTestManager();


### PR DESCRIPTION
### What does this PR do?

This treats descriptions in OpenAPI documents as markdown as per
https://spec.openapis.org/oas/latest.html#rich-text-formatting

### What issues does this PR fix or reference?

It fixes a specific, yet common use case for https://github.com/redhat-developer/vscode-yaml/issues/454

### Is it tested? How?

A test was added.
