### PR TITLE
Fix 't.replace is not a function'

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -28,7 +28,7 @@ import { YAMLSchemaService } from './yamlSchemaService';
 import { ResolvedSchema } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { stringifyObject, StringifySettings } from '../utils/json';
-import { isDefined } from '../utils/objects';
+import { isDefined, isString } from '../utils/objects';
 import * as nls from 'vscode-nls';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 
@@ -133,6 +133,9 @@ export class YamlCompletion {
           // we receive not valid CompletionItem as `label` is mandatory field, so just ignore it
           console.warn(`Ignoring CompletionItem without label: ${JSON.stringify(completionItem)}`);
           return;
+        }
+        if (!isString(label)) {
+          label = String(label);
         }
         const existing = proposed[label];
         if (!existing) {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2073,6 +2073,28 @@ describe('Auto Completion Tests', () => {
 
       expect(result.items).to.be.empty;
     });
+
+    it('should convert to string non string completion label', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          version: {
+            default: 2.1,
+            enum: [2, 2.1],
+          },
+        },
+      });
+
+      const content = 'version: ';
+      const completion = await parseSetup(content, 9);
+      expect(completion.items).lengthOf(2);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('2', '2', 0, 9, 0, 9, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+      expect(completion.items[1]).eql(
+        createExpectedCompletion('2.1', '2.1', 0, 9, 0, 9, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+    });
   });
 
   describe('Array completion', () => {


### PR DESCRIPTION
### What does this PR do?
Fix 't.replace is not a function' error. It converts completion item label to string if it not a string. 

### What issues does this PR fix or reference?
Fix #547

### Is it tested? How?
with test
