### PR TITLE
schema: interpret `pattern`/`patternProperties` as Unicode (WIP)

### DIFF
--- a/src/languageservice/parser/json-schema07-validator.ts
+++ b/src/languageservice/parser/json-schema07-validator.ts
@@ -533,7 +533,7 @@ export function validate(
     }
 
     if (isString(schema.pattern)) {
-      const regex = new RegExp(schema.pattern);
+      const regex = new RegExp(schema.pattern, 'u');
       if (!regex.test(node.value)) {
         const [offset, length] = toOffsetLength(node.range);
         validationResult.problems.push({
@@ -830,7 +830,7 @@ export function validate(
 
     if (schema.patternProperties) {
       for (const propertyPattern of Object.keys(schema.patternProperties)) {
-        const regex = new RegExp(propertyPattern);
+        const regex = new RegExp(propertyPattern, 'u');
         for (const propertyName of unprocessedProperties.slice(0)) {
           if (regex.test(propertyName)) {
             propertyProcessed(propertyName);

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -895,7 +895,7 @@ function validate(
     }
 
     if (isString(schema.pattern)) {
-      const regex = new RegExp(schema.pattern);
+      const regex = new RegExp(schema.pattern, 'u');
       if (!regex.test(node.value)) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
@@ -1178,7 +1178,7 @@ function validate(
 
     if (schema.patternProperties) {
       for (const propertyPattern of Object.keys(schema.patternProperties)) {
-        const regex = new RegExp(propertyPattern);
+        const regex = new RegExp(propertyPattern, 'u');
         for (const propertyName of unprocessedProperties.slice(0)) {
           if (regex.test(propertyName)) {
             propertyProcessed(propertyName);


### PR DESCRIPTION
This was under-specified in previous JSON schema drafts.

As of 2020-12, patterns are defined as Unicode:
https://json-schema.org/draft/2020-12/json-schema-core.html#regex

### What does this PR do?

It builds regular expressions from "pattern" and "patternProperties" JSON schema keywords with the 'u' Unicode flag.

### What issues does this PR fix or reference?

Issue #554 

### Is it tested? How?

Updated tests cover Unicode character groups.