### PR TITLE
Fix 'Cannot read property '0'' and other errors

### DIFF
--- a/src/languageservice/utils/astUtils.ts
+++ b/src/languageservice/utils/astUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Document, isDocument, Node, visit } from 'yaml';
+import { Document, isDocument, Node, visit, YAMLSeq } from 'yaml';
 
 export function getParent(doc: Document, nodeToFind: Node): Node | undefined {
   let parentNode: Node;
@@ -19,4 +19,13 @@ export function getParent(doc: Document, nodeToFind: Node): Node | undefined {
   }
 
   return parentNode;
+}
+
+export function indexOf(seq: YAMLSeq, item: Node): number | undefined {
+  for (const [i, obj] of seq.items.entries()) {
+    if (item === obj) {
+      return i;
+    }
+  }
+  return undefined;
 }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -59,4 +59,16 @@ spec:
     const completion = await parseSetup(content, 7, 6);
     expect(completion.items).length.greaterThan(1);
   });
+
+  it('should show completion on array item on first line', async () => {
+    const content = '-d';
+    const completion = await parseSetup(content, 0, 1);
+    expect(completion.items).is.empty;
+  });
+
+  it('should complete without error on map inside array', async () => {
+    const content = '- foo\n- bar:\n    so';
+    const completion = await parseSetup(content, 2, 6);
+    expect(completion.items).is.empty;
+  });
 });

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -20,16 +20,16 @@ describe('FindDefintion Tests', () => {
     yamlSettings = settings;
   });
 
-  describe('Jump to definition', function () {
-    function findLinks(content: string): Promise<DocumentLink[]> {
-      const testTextDocument = setupTextDocument(content);
-      yamlSettings.documents = new TextDocumentTestManager();
-      (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
-      return languageHandler.documentLinkHandler({
-        textDocument: testTextDocument,
-      });
-    }
+  function findLinks(content: string): Promise<DocumentLink[]> {
+    const testTextDocument = setupTextDocument(content);
+    yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+    return languageHandler.documentLinkHandler({
+      textDocument: testTextDocument,
+    });
+  }
 
+  describe('Jump to definition', function () {
     it('Find source definition', (done) => {
       const content =
         "definitions:\n  link:\n    type: string\ntype: object\nproperties:\n  uri:\n    $ref: '#/definitions/link'\n";
@@ -50,6 +50,15 @@ describe('FindDefintion Tests', () => {
           assert.deepEqual(results[0].target, 'file://~/Desktop/vscode-k8s/test.yaml#3,5');
         })
         .then(done, done);
+    });
+  });
+
+  describe('Bug fixes', () => {
+    it('should work with flow map', async () => {
+      const content = 'f: {ffff: fff, aa: [ddd, drr: {}]}';
+      const results = await findLinks(content);
+
+      assert.equal(results.length, 0);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
It fix errors found by telemetry:
- Cannot read property '0' of undefined
- Range#create called with invalid arguments[[object Object], [object Object], undefined, undefined] 
- Error: Expected a valid index, not shell.


### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/617

### Is it tested? How?
with tests
