### PR TITLE
Provide completion for schema ids in modeline #560

### DIFF
--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+import { SingleYAMLDocument } from '../parser/yamlParser07';
+import { JSONDocument } from '../parser/jsonParser07';
+
+/**
+ * Retrieve schema if declared as modeline.
+ * Public for testing purpose, not part of the API.
+ * @param doc
+ */
+export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): string {
+  if (doc instanceof SingleYAMLDocument) {
+    const yamlLanguageServerModeline = doc.lineComments.find((lineComment) => {
+      return isModeline(lineComment);
+    });
+    if (yamlLanguageServerModeline != undefined) {
+      const schemaMatchs = yamlLanguageServerModeline.match(/\$schema=\S+/g);
+      if (schemaMatchs !== null && schemaMatchs.length >= 1) {
+        if (schemaMatchs.length >= 2) {
+          console.log(
+            'Several $schema attributes have been found on the yaml-language-server modeline. The first one will be picked.'
+          );
+        }
+        return schemaMatchs[0].substring('$schema='.length);
+      }
+    }
+  }
+  return undefined;
+}
+
+export function isModeline(lineText: string): boolean {
+  const matchModeline = lineText.match(/^#\s+yaml-language-server\s*:/g);
+  return matchModeline !== null && matchModeline.length === 1;
+}

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1625,7 +1625,7 @@ describe('Auto Completion Tests', () => {
     });
 
     it('should not provide modeline completion on first character when modeline already present', async () => {
-      const testTextDocument = setupSchemaIDTextDocument('# yaml-language-server', path.join(__dirname, 'test.yaml'));
+      const testTextDocument = setupSchemaIDTextDocument('# yaml-language-server:', path.join(__dirname, 'test.yaml'));
       yamlSettings.documents = new TextDocumentTestManager();
       (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
       const result = await languageHandler.completionHandler({
@@ -1633,6 +1633,19 @@ describe('Auto Completion Tests', () => {
         textDocument: testTextDocument,
       });
       assert.strictEqual(result.items.length, 0, `Expecting 0 item in completion but found ${result.items.length}`);
+    });
+
+    it('should provide schema id completion in modeline', async () => {
+      const modeline = '# yaml-language-server: $schema=';
+      const testTextDocument = setupSchemaIDTextDocument(modeline, path.join(__dirname, 'test.yaml'));
+      yamlSettings.documents = new TextDocumentTestManager();
+      (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+      const result = await languageHandler.completionHandler({
+        position: testTextDocument.positionAt(modeline.length),
+        textDocument: testTextDocument,
+      });
+      assert.strictEqual(result.items.length, 1, `Expecting 1 item in completion but found ${result.items.length}`);
+      assert.strictEqual(result.items[0].label, 'http://google.com/');
     });
   });
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -15,6 +15,7 @@ import { setupLanguageService, setupTextDocument, TEST_URI } from './utils/testH
 import { LanguageService, SchemaPriority } from '../src';
 import { Position } from 'vscode-languageserver';
 import { LineCounter } from 'yaml';
+import { getSchemaFromModeline } from '../src/languageservice/services/modelineUtil';
 
 const requestServiceMock = function (uri: string): Promise<string> {
   return Promise.reject<string>(`Resource ${uri} not found.`);
@@ -737,10 +738,9 @@ describe('JSON Schema', () => {
     });
 
     function checkReturnSchemaUrl(modeline: string, expectedResult: string): void {
-      const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
       const yamlDoc = new parser.SingleYAMLDocument(new LineCounter());
       yamlDoc.lineComments = [modeline];
-      assert.equal(service.getSchemaFromModeline(yamlDoc), expectedResult);
+      assert.strictEqual(getSchemaFromModeline(yamlDoc), expectedResult);
     }
   });
 });


### PR DESCRIPTION
potential improvements:
- support range when there is already a value provided
- provide completion for local yaml schema files

Extracted a specific file for modeline related things.

### What does this PR do?

Provide completion for schema ids in modeline. So when we have `# yaml-language-server: $schema=`

### What issues does this PR fix or reference?

fixes #560

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
i wasn't abel to test the yaml-language-server