### PR TITLE
implemented the squeceItem identation based on the sequenceItemIndent…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following settings are supported:
 - `yaml.format.bracketSpacing`: Print spaces between brackets in objects
 - `yaml.format.proseWrap`: Always: wrap prose if it exeeds the print width, Never: never wrap the prose, Preserve: wrap prose as-is
 - `yaml.format.printWidth`: Specify the line length that the printer will wrap on
+- `yaml.format.sequenceItemIndent`: Specify the indent size of the sequence item from it parent
 - `yaml.validate`: Enable/disable validation feature
 - `yaml.hover`: Enable/disable hover
 - `yaml.completion`: Enable/disable autocompletion

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -87,6 +87,7 @@ export class SettingsHandler {
         this.yamlSettings.yamlFormatterSettings = {
           proseWrap: settings.yaml.format.proseWrap || 'preserve',
           printWidth: settings.yaml.format.printWidth || 80,
+          sequenceItemIndent: settings.yaml.format.sequenceItemIndent || 0,
         };
 
         if (settings.yaml.format.singleQuote !== undefined) {

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -44,11 +44,33 @@ export class YAMLFormatter {
         printWidth: options.printWidth,
       };
 
-      const formatted = prettier.format(text, prettierOptions);
-
+      let formatted = prettier.format(text, prettierOptions);
+      const regx = RegExp('[\\s]+[-][\\s]+[\\D]+[\\d]*', 'gm');
+      const matches = formatted.match(regx);
+      if (matches) {
+        for (const match of matches) {
+          if (match.indexOf(':') == -1) {
+            formatted = formatted.replace(
+              match,
+              '\n'.concat(this.doSequenceIndent(prettierOptions.tabWidth, options.sequenceItemIndent, match))
+            );
+          }
+        }
+      }
       return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
     } catch (error) {
       return [];
     }
+  }
+
+  /**
+   * do the indent on sequence item
+   *
+   */
+  public doSequenceIndent(actualTabWidth: number, customizedIndent: number, matchStr: string): string {
+    const regx = RegExp('\\s+(?=-)', 'gm');
+    const whiteSpaceLength = matchStr.match(regx)[0].length - 1;
+    const expectedIndentSize = whiteSpaceLength - actualTabWidth + customizedIndent;
+    return ' '.repeat(expectedIndentSize).concat(matchStr.trim());
   }
 }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -122,6 +122,7 @@ export interface CustomFormatterOptions {
   proseWrap?: string;
   printWidth?: number;
   enable?: boolean;
+  sequenceItemIndent?: number;
 }
 
 export interface LanguageService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -55,6 +55,7 @@ export class SettingsState {
     proseWrap: 'preserve',
     printWidth: 80,
     enable: true,
+    sequenceItemIndent: 0,
   } as CustomFormatterOptions;
   yamlShouldHover = true;
   yamlShouldCompletion = true;

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -76,8 +76,8 @@ list:
      k1: v1
      k2: v2
 list:
-     - item1
-     - item2
+- item1
+- item2
 `;
         assert.equal(edits[0].newText, expected);
       });
@@ -99,8 +99,8 @@ list:
      k1: v1
      k2: v2
 list:
-     - item1
-     - item2
+- item1
+- item2
 `;
         assert.equal(edits[0].newText, expected);
       });
@@ -123,10 +123,60 @@ list:
      k1: v1
      k2: v2
 list:
-     - item1
-     - item2
+- item1
+- item2
 `;
         assert.equal(edits[0].newText, expected);
+      });
+
+      it('do sequence indentation', () => {
+        const content = `simple_val: Testing 1
+object_val:
+  sub_object_val: Testing 2
+  array_val:
+    - Testing 3
+    - Testing 4
+`;
+
+        const edits = parseSetup(content, {
+          tabSize: 3,
+          tabWidth: 5,
+          sequenceItemIndent: 0,
+        });
+
+        const expected = `simple_val: Testing 1
+object_val:
+     sub_object_val: Testing 2
+     array_val:
+     - Testing 3
+     - Testing 4
+`;
+        assert.strictEqual(edits[0].newText, expected);
+      });
+
+      it('do not sequence indentation', () => {
+        const content = `simple_val: Testing 1
+object_val:
+  sub_object_val: Testing 2
+array_val:
+- Testing 3
+- Testing 4
+`;
+
+        const edits = parseSetup(content, {
+          tabSize: 3,
+          tabWidth: 5,
+          sequenceItemIndent: 2,
+        });
+
+        const expected = `simple_val: Testing 1
+object_val:
+     sub_object_val: Testing 2
+array_val:
+  - Testing 3
+  - Testing 4
+`;
+        assert.strictEqual(edits[0].newText, expected);
       });
     });
   });


### PR DESCRIPTION
… value

### What does this PR do?

Doing indentation on sequeceItem based on the settings. If sequenceItemIndent is 0 then the sequenceItem not perform any indentation and it acquire it parent value itself. Suppose sequenceItemIndent contains any values, it will do the indentation on sequenceItem.

- When sequenceItemIndent is 0
![image](https://user-images.githubusercontent.com/93245779/140015273-97924c48-e925-47a6-9186-636720756b19.png)

- When sequenceItemIndent is 2
![image](https://user-images.githubusercontent.com/93245779/140015343-2d1f93fb-8910-48b0-9c66-9c0b6716ac32.png)

### What issues does this PR fix or reference?

https://github.com/redhat-developer/vscode-yaml/issues/172

### Is it tested? How?
Yes. Using test cases
