### PR TITLE
Unescape regexp string to be compatible with 'u' flag

### DIFF
--- a/src/languageservice/parser/json-schema07-validator.ts
+++ b/src/languageservice/parser/json-schema07-validator.ts
@@ -14,6 +14,7 @@ import { getSchemaTypeName } from '../utils/schemaUtils';
 import { isMap, isPair, isScalar, isSeq } from 'yaml';
 import { toOffsetLength } from './ast-converter';
 import { getParent } from '../utils/astUtils';
+import { safeCreateUnicodeRegExp } from '../utils/strings';
 
 const localize = nls.loadMessageBundle();
 
@@ -533,7 +534,7 @@ export function validate(
     }
 
     if (isString(schema.pattern)) {
-      const regex = new RegExp(schema.pattern, 'u');
+      const regex = safeCreateUnicodeRegExp(schema.pattern);
       if (!regex.test(node.value)) {
         const [offset, length] = toOffsetLength(node.range);
         validationResult.problems.push({
@@ -830,7 +831,7 @@ export function validate(
 
     if (schema.patternProperties) {
       for (const propertyPattern of Object.keys(schema.patternProperties)) {
-        const regex = new RegExp(propertyPattern, 'u');
+        const regex = safeCreateUnicodeRegExp(propertyPattern);
         for (const propertyName of unprocessedProperties.slice(0)) {
           if (regex.test(propertyName)) {
             propertyProcessed(propertyName);

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -26,6 +26,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic } from 'vscode-languageserver';
 import { isArrayEqual } from '../utils/arrUtils';
 import { Node } from 'yaml';
+import { safeCreateUnicodeRegExp } from '../utils/strings';
 
 const localize = nls.loadMessageBundle();
 
@@ -895,7 +896,7 @@ function validate(
     }
 
     if (isString(schema.pattern)) {
-      const regex = new RegExp(schema.pattern, 'u');
+      const regex = safeCreateUnicodeRegExp(schema.pattern);
       if (!regex.test(node.value)) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
@@ -1178,7 +1179,7 @@ function validate(
 
     if (schema.patternProperties) {
       for (const propertyPattern of Object.keys(schema.patternProperties)) {
-        const regex = new RegExp(propertyPattern, 'u');
+        const regex = safeCreateUnicodeRegExp(propertyPattern);
         for (const propertyName of unprocessedProperties.slice(0)) {
           if (regex.test(propertyName)) {
             propertyProcessed(propertyName);

--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -66,3 +66,32 @@ export function getIndentation(lineContent: string, position: number): number {
   // assuming that current position is indentation
   return position;
 }
+
+const replaceEscapedChars: [RegExp, string][] = [
+  [new RegExp('\\\\ ', 'g'), ' '],
+  [new RegExp('\\\\!', 'g'), '!'],
+  [new RegExp('\\\\"', 'g'), '"'],
+  [new RegExp('\\\\#', 'g'), '#'],
+  [new RegExp('\\\\%', 'g'), '%'],
+  [new RegExp('\\\\&', 'g'), '&'],
+  [new RegExp("\\\\'", 'g'), "'"],
+  [new RegExp('\\\\,', 'g'), ','],
+  [new RegExp('\\\\-', 'g'), '-'],
+  [new RegExp('\\\\:', 'g'), ':'],
+  [new RegExp('\\\\;', 'g'), ';'],
+  [new RegExp('\\\\<', 'g'), '<'],
+  [new RegExp('\\\\=', 'g'), '='],
+  [new RegExp('\\\\>', 'g'), '>'],
+  [new RegExp('\\\\@', 'g'), '@'],
+  [new RegExp('\\\\_', 'g'), '_'],
+  [new RegExp('\\\\`', 'g'), '`'],
+  [new RegExp('\\\\~', 'g'), '~'],
+];
+
+export function safeCreateUnicodeRegExp(pattern: string): RegExp {
+  for (const unEscape of replaceEscapedChars) {
+    pattern = pattern.replace(unEscape[0], unEscape[1]);
+  }
+
+  return new RegExp(pattern, 'u');
+}

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -2,8 +2,9 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { startsWith, endsWith, convertSimple2RegExp } from '../src/languageservice/utils/strings';
+import { startsWith, endsWith, convertSimple2RegExp, safeCreateUnicodeRegExp } from '../src/languageservice/utils/strings';
 import * as assert from 'assert';
+import { expect } from 'chai';
 
 describe('String Tests', () => {
   describe('startsWith', function () {
@@ -70,6 +71,34 @@ describe('String Tests', () => {
 
       result = convertSimple2RegExp('toc.yml').test('TOC.yml');
       assert.equal(result, false);
+    });
+  });
+
+  describe('safeCreateUnicodeRegExp', () => {
+    it('should create unicode RegExp for non unicode patterns', () => {
+      const result = safeCreateUnicodeRegExp(
+        // eslint-disable-next-line prettier/prettier
+        '^([2-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$'
+      );
+      expect(result).is.not.undefined;
+    });
+
+    it('should create unicode RegExp for non unicode patterns2', () => {
+      // eslint-disable-next-line prettier/prettier
+      const result = safeCreateUnicodeRegExp('^[^\\/~\\^\\: \\[\\]\\\\]+(\\/[^\\/~\\^\\: \\[\\]\\\\]+)*$');
+      expect(result).is.not.undefined;
+    });
+
+    it('should create unicode RegExp for non unicode patterns3', () => {
+      // eslint-disable-next-line prettier/prettier
+      const result = safeCreateUnicodeRegExp('^(\\s?)+=[^\\=](.+)');
+      expect(result).is.not.undefined;
+    });
+
+    it('should create unicode RegExp for non unicode patterns4', () => {
+      // eslint-disable-next-line prettier/prettier
+      const result = safeCreateUnicodeRegExp('^x-[\\w\\d\\.\\-\\_]+$');
+      expect(result).is.not.undefined;
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix `RegExp` object creating with `'u'` flag in case of old patterns, which not written with unicode support.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/633

### Is it tested? How?
With test
