### PR TITLE
Fallback to regular regexp if we cannot create unicode

### DIFF
--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -89,9 +89,16 @@ const replaceEscapedChars: [RegExp, string][] = [
 ];
 
 export function safeCreateUnicodeRegExp(pattern: string): RegExp {
+  const origPattern = pattern;
+
   for (const unEscape of replaceEscapedChars) {
     pattern = pattern.replace(unEscape[0], unEscape[1]);
   }
 
-  return new RegExp(pattern, 'u');
+  // fall back to regular regexp if we cannot create Unicode one
+  try {
+    return new RegExp(pattern, 'u');
+  } catch (ignore) {
+    return new RegExp(origPattern);
+  }
 }

--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -67,38 +67,11 @@ export function getIndentation(lineContent: string, position: number): number {
   return position;
 }
 
-const replaceEscapedChars: [RegExp, string][] = [
-  [new RegExp('\\\\ ', 'g'), ' '],
-  [new RegExp('\\\\!', 'g'), '!'],
-  [new RegExp('\\\\"', 'g'), '"'],
-  [new RegExp('\\\\#', 'g'), '#'],
-  [new RegExp('\\\\%', 'g'), '%'],
-  [new RegExp('\\\\&', 'g'), '&'],
-  [new RegExp("\\\\'", 'g'), "'"],
-  [new RegExp('\\\\,', 'g'), ','],
-  [new RegExp('\\\\-', 'g'), '-'],
-  [new RegExp('\\\\:', 'g'), ':'],
-  [new RegExp('\\\\;', 'g'), ';'],
-  [new RegExp('\\\\<', 'g'), '<'],
-  [new RegExp('\\\\=', 'g'), '='],
-  [new RegExp('\\\\>', 'g'), '>'],
-  [new RegExp('\\\\@', 'g'), '@'],
-  [new RegExp('\\\\_', 'g'), '_'],
-  [new RegExp('\\\\`', 'g'), '`'],
-  [new RegExp('\\\\~', 'g'), '~'],
-];
-
 export function safeCreateUnicodeRegExp(pattern: string): RegExp {
-  const origPattern = pattern;
-
-  for (const unEscape of replaceEscapedChars) {
-    pattern = pattern.replace(unEscape[0], unEscape[1]);
-  }
-
   // fall back to regular regexp if we cannot create Unicode one
   try {
     return new RegExp(pattern, 'u');
   } catch (ignore) {
-    return new RegExp(origPattern);
+    return new RegExp(pattern);
   }
 }

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -100,5 +100,11 @@ describe('String Tests', () => {
       const result = safeCreateUnicodeRegExp('^x-[\\w\\d\\.\\-\\_]+$');
       expect(result).is.not.undefined;
     });
+
+    it('should create unicode RegExp for non unicode patterns5', () => {
+      // eslint-disable-next-line prettier/prettier
+      const result = safeCreateUnicodeRegExp('^[\\w\\-_]+$');
+      expect(result).is.not.undefined;
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Provide fallback to regular regexp if we cannot create unicode. As JSON schema spec, before `2020-12` version, doesn’t describe that regexp should support unicode, most of existing patterns will not work with `u` flag.

### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/636

### Is it tested? How?
With test
