### PR TITLE
Add implementation for definition request

### DIFF
--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DefinitionParams, LocationLink, Range } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DefinitionLink } from 'vscode-languageserver-types';
+import { isAlias } from 'yaml';
+import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { matchOffsetToDocument } from '../utils/arrUtils';
+import { TextBuffer } from '../utils/textBuffer';
+
+export function getDefinition(document: TextDocument, params: DefinitionParams): DefinitionLink[] | undefined {
+  try {
+    const yamlDocument = yamlDocumentsCache.getYamlDocument(document);
+    const offset = document.offsetAt(params.position);
+    const currentDoc = matchOffsetToDocument(offset, yamlDocument);
+    if (currentDoc) {
+      const [node] = currentDoc.getNodeFromPosition(offset, new TextBuffer(document));
+      if (node && isAlias(node)) {
+        const defNode = node.resolve(currentDoc.internalDocument);
+        if (defNode && defNode.range) {
+          const targetRange = Range.create(document.positionAt(defNode.range[0]), document.positionAt(defNode.range[2]));
+          const selectionRange = Range.create(document.positionAt(defNode.range[0]), document.positionAt(defNode.range[1]));
+          return [LocationLink.create(document.uri, targetRange, selectionRange)];
+        }
+      }
+    }
+  } catch (err) {
+    this.telemetry.sendError('yaml.definition.error', { error: err });
+  }
+
+  return undefined;
+}

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -101,6 +101,7 @@ export class YAMLServerInit {
           firstTriggerCharacter: '\n',
         },
         documentRangeFormattingProvider: false,
+        definitionProvider: true,
         documentLinkProvider: {},
         // disabled until we not get parser which parse comments as separate nodes
         foldingRangeProvider: false,

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -9,7 +9,7 @@ import { DocumentLink } from 'vscode-languageserver';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 
-describe('FindDefintion Tests', () => {
+describe('Find Links Tests', () => {
   let languageHandler: LanguageHandlers;
   let yamlSettings: SettingsState;
 

--- a/test/yamlDefinition.test.ts
+++ b/test/yamlDefinition.test.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { setupTextDocument, TEST_URI } from './utils/testHelper';
+import { expect } from 'chai';
+import { getDefinition } from '../src/languageservice/services/yamlDefinition';
+import { LocationLink, Position, Range } from 'vscode-languageserver-protocol';
+
+describe('YAML Definition', () => {
+  it('should not provide definition for non anchor node', () => {
+    const doc = setupTextDocument('foo: &bar some\naaa: *bar');
+    const result = getDefinition(doc, { position: Position.create(1, 2), textDocument: { uri: TEST_URI } });
+    expect(result).is.undefined;
+  });
+
+  it('should provide definition for anchor', () => {
+    const doc = setupTextDocument('foo: &bar some\naaa: *bar');
+    const result = getDefinition(doc, { position: Position.create(1, 7), textDocument: { uri: TEST_URI } });
+    expect(result).is.not.undefined;
+    expect(result[0]).is.eqls(LocationLink.create(TEST_URI, Range.create(0, 10, 1, 0), Range.create(0, 10, 0, 14)));
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Add implementation for definition request, which allows to navigate from alias to anchor node:


https://user-images.githubusercontent.com/929743/140951209-cf7de5a8-cfce-40a9-b720-38a0b716f4b0.mov


### What issues does this PR fix or reference?
Resolve https://github.com/redhat-developer/yaml-language-server/issues/541

### Is it tested? How?
With test
