### PR TITLE
Fix collecting comments from AST

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -37,11 +37,13 @@ export class SingleYAMLDocument extends JSONDocument {
   private collectLineComments(): void {
     this._lineComments = [];
     if (this._internalDocument.commentBefore) {
-      this._lineComments.push(`#${this._internalDocument.commentBefore}`);
+      const comments = this._internalDocument.commentBefore.split('\n');
+      comments.forEach((comment) => this._lineComments.push(`#${comment}`));
     }
     visit(this.internalDocument, (_key, node: Node) => {
       if (node?.commentBefore) {
-        this._lineComments.push(`#${node.commentBefore}`);
+        const comments = node?.commentBefore.split('\n');
+        comments.forEach((comment) => this._lineComments.push(`#${comment}`));
       }
 
       if (node?.comment) {

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -102,5 +102,16 @@ describe('YAML Schema Service', () => {
 
       expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });
+
+    it('should handle modeline schema comment in multiline comments', () => {
+      const documentContent = `foo:\n  bar\n#first comment\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const content = `${documentContent}`;
+      const yamlDock = parse(content);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix collecting comments, in case when document contains several commented line in a row, like:
```yaml
#first comment
#second comment
foo: bar
```

### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/vscode-yaml/issues/629

### Is it tested? How?
With test
