### PR TITLE
bump request light version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "jsonc-parser": "^3.0.0",
-    "request-light": "^0.5.4",
+    "request-light": "^0.5.5",
     "vscode-json-languageservice": "^4.1.7",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
-request-light@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.5.4.tgz#497a98c6d8ae49536417a5e2d7f383b934f3e38c"
-  integrity sha512-t3566CMweOFlUk7Y1DJMu5OrtpoZEb6aSTsLQVT3wtrIEJ5NhcY9G/Oqxvjllzl4a15zXfFlcr9q40LbLVQJqw==
+request-light@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.5.5.tgz#254ab0b38a1db2192170b599b05181934e14932b"
+  integrity sha512-AvjfJuhyT6dYfhtIBF+IpTPQco+Td1QJ6PsIJ5xui110vQ5p9HxHk+m1XJqXazLQT6CxxSx9eNv6R/+fu4bZig==
 
 request@^2.88.2:
   version "2.88.2"


### PR DESCRIPTION
### What does this PR do?

Copy of https://github.com/redhat-developer/vscode-yaml/pull/644 , fixing a redirect follow bug in request-light v < 0.5.5

### What issues does this PR fix or reference?

THe non existend copy of https://github.com/redhat-developer/vscode-yaml/issues/586 in this repo :D

### Is it tested? How?
I'm using this with the neovim lsp installation. Before this patch a `.graphqlrc.yaml` file would error since the schema https://unpkg.com/graphql-config/config-schema.json does a relative redirect to https://unpkg.com/graphql-config@4.1.0/config-schema.json` (note the version). With this version it works.
