### PR TITLE
Fix document symbols, when key is not string

### DIFF
--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -12,7 +12,7 @@ import { DocumentSymbolsContext } from 'vscode-json-languageservice/lib/umd/json
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { Telemetry } from '../../languageserver/telemetry';
-import { isMap, isScalar, isSeq } from 'yaml';
+import { isMap, isSeq, Node } from 'yaml';
 
 export class YAMLDocumentSymbols {
   private jsonDocumentSymbols;
@@ -23,25 +23,16 @@ export class YAMLDocumentSymbols {
     // override 'getKeyLabel' to handle complex mapping
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.jsonDocumentSymbols.getKeyLabel = (property: any) => {
-      const keyNode = property.keyNode.internalNode;
+      const keyNode: Node = property.keyNode.internalNode;
       let name = '';
-      if (isScalar(keyNode)) {
-        name = keyNode.source;
-      } else if (isMap(keyNode)) {
+      if (isMap(keyNode)) {
         name = '{}';
       } else if (isSeq(keyNode)) {
         name = '[]';
       } else {
         name = keyNode.source;
       }
-
-      if (name) {
-        name = name.replace(/[\n]/g, '↵');
-      }
-      if (name && name.trim()) {
-        return name;
-      }
-      return `"${name}"`;
+      return name;
     };
   }
 

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -12,22 +12,36 @@ import { DocumentSymbolsContext } from 'vscode-json-languageservice/lib/umd/json
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { Telemetry } from '../../languageserver/telemetry';
+import { isMap, isScalar, isSeq } from 'yaml';
 
 export class YAMLDocumentSymbols {
   private jsonDocumentSymbols;
 
   constructor(schemaService: YAMLSchemaService, private readonly telemetry: Telemetry) {
     this.jsonDocumentSymbols = new JSONDocumentSymbols(schemaService);
-    const origKeyLabel = this.jsonDocumentSymbols.getKeyLabel;
 
     // override 'getKeyLabel' to handle complex mapping
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.jsonDocumentSymbols.getKeyLabel = (property: any) => {
-      if (typeof property.keyNode.value === 'object') {
-        return property.keyNode.value.value;
+      const keyNode = property.keyNode.internalNode;
+      let name = '';
+      if (isScalar(keyNode)) {
+        name = keyNode.source;
+      } else if (isMap(keyNode)) {
+        name = '{}';
+      } else if (isSeq(keyNode)) {
+        name = '[]';
       } else {
-        return origKeyLabel.call(this.jsonDocumentSymbols, property);
+        name = keyNode.source;
       }
+
+      if (name) {
+        name = name.replace(/[\n]/g, '↵');
+      }
+      if (name && name.trim()) {
+        return name;
+      }
+      return `"${name}"`;
     };
   }
 
@@ -48,7 +62,7 @@ export class YAMLDocumentSymbols {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.documentSymbols.error', { error: err, documentUri: document.uri });
+      this.telemetry.sendError('yaml.documentSymbols.error', { error: err.toString() });
     }
     return results;
   }
@@ -70,7 +84,7 @@ export class YAMLDocumentSymbols {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.hierarchicalDocumentSymbols.error', { error: err, documentUri: document.uri });
+      this.telemetry.sendError('yaml.hierarchicalDocumentSymbols.error', { error: err.toString() });
     }
 
     return results;

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -317,5 +317,22 @@ describe('Document Symbols Tests', () => {
 
       assertLimitWarning();
     });
+
+    it('Document Symbols with numbers as keys', () => {
+      const content = 'items:\n  1: test\n  2: test';
+      const symbols = parseHierarchicalSetup(content);
+      assert.equal(symbols.length, 1);
+      const child1 = createExpectedDocumentSymbol('1', SymbolKind.String, 1, 2, 1, 9, 1, 2, 1, 3, undefined, 'test');
+      const child2 = createExpectedDocumentSymbol('2', SymbolKind.String, 2, 2, 2, 9, 2, 2, 2, 3, undefined, 'test');
+      const children = [child1, child2];
+      assert.deepEqual(symbols[0], createExpectedDocumentSymbol('items', SymbolKind.Module, 0, 0, 2, 9, 0, 0, 0, 5, children));
+    });
+
+    it('Document Symbols with mapping as keys', () => {
+      const content = '{foo: bar}: foo';
+      const symbols = parseHierarchicalSetup(content);
+      assert.equal(symbols.length, 1);
+      assert.deepEqual(symbols[0], createExpectedDocumentSymbol('{}', SymbolKind.String, 0, 0, 0, 15, 0, 0, 0, 10, [], 'foo'));
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fix `yaml.hierarchicalDocumentSymbols.error` error message on telemetry.
That can be caused when mapping key is not string.

### What issues does this PR fix or reference?
none

### Is it tested? How?
with tests.
