### PR TITLE
Fix links error reporting

### DIFF
--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -42,7 +42,7 @@ export class YamlCodeLens {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.codeLens.error', { error: err, documentUri: document.uri });
+      this.telemetry.sendError('yaml.codeLens.error', { error: err.toString() });
     }
 
     return result;

--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -28,7 +28,7 @@ export function getDefinition(document: TextDocument, params: DefinitionParams):
       }
     }
   } catch (err) {
-    this.telemetry.sendError('yaml.definition.error', { error: err });
+    this.telemetry.sendError('yaml.definition.error', { error: err.toString() });
   }
 
   return undefined;

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -51,7 +51,7 @@ export class YAMLHover {
       currentDoc.currentDocIndex = currentDocIndex;
       return this.getHover(document, position, currentDoc);
     } catch (error) {
-      this.telemetry.sendError('yaml.hover.error', { error, documentUri: document.uri });
+      this.telemetry.sendError('yaml.hover.error', { error: error.toString() });
     }
   }
 

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -5,19 +5,25 @@
 import { findLinks as JSONFindLinks } from 'vscode-json-languageservice/lib/umd/services/jsonLinks';
 import { DocumentLink } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Telemetry } from '../../languageserver/telemetry';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 
-export function findLinks(document: TextDocument): Promise<DocumentLink[]> {
-  try {
-    const doc = yamlDocumentsCache.getYamlDocument(document);
-    // Find links across all YAML Documents then report them back once finished
-    const linkPromises = [];
-    for (const yamlDoc of doc.documents) {
-      linkPromises.push(JSONFindLinks(document, yamlDoc));
+export class YamlLinks {
+  constructor(private readonly telemetry: Telemetry) {}
+
+  findLinks(document: TextDocument): Promise<DocumentLink[]> {
+    try {
+      const doc = yamlDocumentsCache.getYamlDocument(document);
+      // Find links across all YAML Documents then report them back once finished
+      const linkPromises = [];
+      for (const yamlDoc of doc.documents) {
+        linkPromises.push(JSONFindLinks(document, yamlDoc));
+      }
+      // Wait for all the promises to return and then flatten them into one DocumentLink array
+      return Promise.all(linkPromises).then((yamlLinkArray) => [].concat(...yamlLinkArray));
+    } catch (err) {
+      console.warn(err.toString());
+      this.telemetry.sendError('yaml.documentLink.error', { error: err.toString() });
     }
-    // Wait for all the promises to return and then flatten them into one DocumentLink array
-    return Promise.all(linkPromises).then((yamlLinkArray) => [].concat(...yamlLinkArray));
-  } catch (err) {
-    this.telemetry.sendError('yaml.documentLink.error', { error: err });
   }
 }

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -22,7 +22,6 @@ export class YamlLinks {
       // Wait for all the promises to return and then flatten them into one DocumentLink array
       return Promise.all(linkPromises).then((yamlLinkArray) => [].concat(...yamlLinkArray));
     } catch (err) {
-      console.warn(err.toString());
       this.telemetry.sendError('yaml.documentLink.error', { error: err.toString() });
     }
   }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -29,7 +29,7 @@ import { YAMLHover } from './services/yamlHover';
 import { YAMLValidation } from './services/yamlValidation';
 import { YAMLFormatter } from './services/yamlFormatter';
 import { DocumentSymbolsContext } from 'vscode-json-languageservice';
-import { findLinks } from './services/yamlLinks';
+import { YamlLinks } from './services/yamlLinks';
 import {
   FoldingRange,
   ClientCapabilities,
@@ -169,6 +169,7 @@ export function getLanguageService(
   const formatter = new YAMLFormatter();
   const yamlCodeActions = new YamlCodeActions(clientCapabilities);
   const yamlCodeLens = new YamlCodeLens(schemaService, telemetry);
+  const yamlLinks = new YamlLinks(telemetry);
   // register all commands
   registerCommands(commandExecutor, connection);
   return {
@@ -197,7 +198,7 @@ export function getLanguageService(
     registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => {
       schemaService.registerCustomSchemaProvider(schemaProvider);
     },
-    findLinks,
+    findLinks: yamlLinks.findLinks.bind(yamlLinks),
     doComplete: completer.doComplete.bind(completer),
     doValidation: yamlValidation.doValidation.bind(yamlValidation),
     doHover: hover.doHover.bind(hover),


### PR DESCRIPTION
### What does this PR do?
It fixes telemetry error reporting for `links` feature. 
Also it change sending errors to telemetry, as `JSON.stringify()` return empty string for `Error`

### What issues does this PR fix or reference?
None, we have a lot of `Request textDocument/documentLink failed. Message: Request textDocument/documentLink failed with message: Cannot read property 'sendError' of undefined`

### Is it tested? How?
manually
