### PR TITLE
Fixed on disabled call client/registerCapability when dynamicRegistra…

### DIFF
--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -44,7 +44,7 @@ export class YAMLServerInit {
       }
     );
     this.connection.onInitialized(() => {
-      if (this.yamlSettings.hasWorkspaceFolderCapability) {
+      if (this.yamlSettings.hasWsChangeWathedFileDynamicRegistraton) {
         this.connection.workspace.onDidChangeWorkspaceFolders((changedFolders) => {
           this.yamlSettings.workspaceFolders = workspaceFoldersChanged(this.yamlSettings.workspaceFolders, changedFolders);
         });
@@ -87,6 +87,12 @@ export class YAMLServerInit {
 
     this.yamlSettings.hasConfigurationCapability = !!(
       this.yamlSettings.capabilities.workspace && !!this.yamlSettings.capabilities.workspace.configuration
+    );
+
+    this.yamlSettings.hasWsChangeWathedFileDynamicRegistraton = !!(
+      this.yamlSettings.capabilities.workspace &&
+      this.yamlSettings.capabilities.workspace.didChangeWatchedFiles &&
+      this.yamlSettings.capabilities.workspace.didChangeWatchedFiles.dynamicRegistration
     );
     this.registerHandlers();
 

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -81,6 +81,7 @@ export class SettingsState {
   hasWorkspaceFolderCapability = false;
   hasConfigurationCapability = false;
   useVSCodeContentRequest = false;
+  hasWsChangeWathedFileDynamicRegistraton = false;
 }
 
 export class TextDocumentTestManager extends TextDocuments<TextDocument> {


### PR DESCRIPTION
…tion false

### What does this PR do?
It checked the client workspace dynamicRegistration true/false on didChangeWatchedFiles. If false, then disable the client/registerCapability call from server to client

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/583

### Is it tested?
Yes tested with tests and with latest changes on neovim.
