### PR TITLE
Improve telemetry errors

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { xhr, configure as configureHttpRequests } from 'request-light';
 import { DocumentFormattingRequest, Connection, DidChangeConfigurationNotification } from 'vscode-languageserver';
+import { convertErrorToTelemetryMsg } from '../../languageservice/utils/objects';
 import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
 import { checkSchemaURI, JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from '../../languageservice/utils/schemaUrls';
 import { LanguageService, LanguageSettings, SchemaPriority } from '../../languageservice/yamlLanguageService';
@@ -27,8 +28,7 @@ export class SettingsHandler {
         // Register for all configuration changes.
         await this.connection.client.register(DidChangeConfigurationNotification.type, undefined);
       } catch (err) {
-        console.warn(err);
-        this.telemetry.sendError('yaml.settings.error', { error: err });
+        this.telemetry.sendError('yaml.settings.error', { error: convertErrorToTelemetryMsg(err) });
       }
     }
     this.connection.onDidChangeConfiguration(() => this.pullConfiguration());

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -13,6 +13,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { Telemetry } from '../../languageserver/telemetry';
 import { isMap, isSeq, Node } from 'yaml';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 
 export class YAMLDocumentSymbols {
   private jsonDocumentSymbols;
@@ -53,7 +54,7 @@ export class YAMLDocumentSymbols {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.documentSymbols.error', { error: err.toString() });
+      this.telemetry.sendError('yaml.documentSymbols.error', { error: convertErrorToTelemetryMsg(err) });
     }
     return results;
   }
@@ -75,7 +76,7 @@ export class YAMLDocumentSymbols {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.hierarchicalDocumentSymbols.error', { error: err.toString() });
+      this.telemetry.sendError('yaml.hierarchicalDocumentSymbols.error', { error: convertErrorToTelemetryMsg(err) });
     }
 
     return results;

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -14,6 +14,7 @@ import { JSONSchema } from '../jsonSchema';
 import { CodeLensParams } from 'vscode-languageserver-protocol';
 import { Telemetry } from '../../languageserver/telemetry';
 import { getSchemaUrls } from '../utils/schemaUrls';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 
 export class YamlCodeLens {
   constructor(private schemaService: YAMLSchemaService, private readonly telemetry: Telemetry) {}
@@ -42,7 +43,7 @@ export class YamlCodeLens {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.codeLens.error', { error: err.toString() });
+      this.telemetry.sendError('yaml.codeLens.error', { error: convertErrorToTelemetryMsg(err) });
     }
 
     return result;

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -29,7 +29,7 @@ import { YAMLSchemaService } from './yamlSchemaService';
 import { ResolvedSchema } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { stringifyObject, StringifySettings } from '../utils/json';
-import { isDefined, isString } from '../utils/objects';
+import { convertErrorToTelemetryMsg, isDefined, isString } from '../utils/objects';
 import * as nls from 'vscode-nls';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { isInComment, isMapContainsEmptyPair } from '../utils/astUtils';
@@ -159,8 +159,7 @@ export class YamlCompletion {
         }
       },
       error: (message: string) => {
-        console.error(message);
-        this.telemetry.sendError('yaml.completion.error', { error: message });
+        this.telemetry.sendError('yaml.completion.error', { error: convertErrorToTelemetryMsg(message) });
       },
       log: (message: string) => {
         console.log(message);
@@ -384,12 +383,7 @@ export class YamlCompletion {
       const types: { [type: string]: boolean } = {};
       this.getValueCompletions(schema, currentDoc, node, offset, document, collector, types);
     } catch (err) {
-      if (err.stack) {
-        console.error(err.stack);
-      } else {
-        console.error(err);
-      }
-      this.telemetry.sendError('yaml.completion.error', { error: err });
+      this.telemetry.sendError('yaml.completion.error', { error: convertErrorToTelemetryMsg(err) });
     }
 
     return result;

--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -10,6 +10,7 @@ import { isAlias } from 'yaml';
 import { Telemetry } from '../../languageserver/telemetry';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { matchOffsetToDocument } from '../utils/arrUtils';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 import { TextBuffer } from '../utils/textBuffer';
 
 export class YamlDefinition {
@@ -32,7 +33,7 @@ export class YamlDefinition {
         }
       }
     } catch (err) {
-      this.telemetry.sendError('yaml.definition.error', { error: err.toString() });
+      this.telemetry.sendError('yaml.definition.error', { error: convertErrorToTelemetryMsg(err) });
     }
 
     return undefined;

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -18,6 +18,7 @@ import { JSONSchema } from '../jsonSchema';
 import { URI } from 'vscode-uri';
 import * as path from 'path';
 import { Telemetry } from '../../languageserver/telemetry';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 
 export class YAMLHover {
   private shouldHover: boolean;
@@ -51,7 +52,7 @@ export class YAMLHover {
       currentDoc.currentDocIndex = currentDocIndex;
       return this.getHover(document, position, currentDoc);
     } catch (error) {
-      this.telemetry.sendError('yaml.hover.error', { error: error.toString() });
+      this.telemetry.sendError('yaml.hover.error', { error: convertErrorToTelemetryMsg(error) });
     }
   }
 

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -7,6 +7,7 @@ import { DocumentLink } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Telemetry } from '../../languageserver/telemetry';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 
 export class YamlLinks {
   constructor(private readonly telemetry: Telemetry) {}
@@ -22,7 +23,7 @@ export class YamlLinks {
       // Wait for all the promises to return and then flatten them into one DocumentLink array
       return Promise.all(linkPromises).then((yamlLinkArray) => [].concat(...yamlLinkArray));
     } catch (err) {
-      this.telemetry.sendError('yaml.documentLink.error', { error: err.toString() });
+      this.telemetry.sendError('yaml.documentLink.error', { error: convertErrorToTelemetryMsg(err) });
     }
   }
 }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -16,6 +16,7 @@ import { JSONValidation } from 'vscode-json-languageservice/lib/umd/services/jso
 import { YAML_SOURCE } from '../parser/jsonParser07';
 import { TextBuffer } from '../utils/textBuffer';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { convertErrorToTelemetryMsg } from '../utils/objects';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -91,7 +92,7 @@ export class YAMLValidation {
         index++;
       }
     } catch (err) {
-      console.error(err.toString());
+      console.error(convertErrorToTelemetryMsg(err));
     }
 
     let previousErr: Diagnostic;

--- a/src/languageservice/utils/objects.ts
+++ b/src/languageservice/utils/objects.ts
@@ -82,3 +82,15 @@ export function isString(val: unknown): val is string {
 export function isIterable(val: unknown): boolean {
   return Symbol.iterator in Object(val);
 }
+
+/**
+ * Convert error to string witch should be sended to telemetry.
+ * @param err any error
+ */
+export function convertErrorToTelemetryMsg(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? err.toString();
+  }
+
+  return err.toString();
+}

--- a/src/languageservice/utils/objects.ts
+++ b/src/languageservice/utils/objects.ts
@@ -88,6 +88,8 @@ export function isIterable(val: unknown): boolean {
  * @param err any error
  */
 export function convertErrorToTelemetryMsg(err: unknown): string {
+  if (!err) return 'null';
+
   if (err instanceof Error) {
     return err.stack ?? err.toString();
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { schemaRequestHandler, workspaceContext } from './languageservice/servic
 import { YAMLServerInit } from './yamlServerInit';
 import { SettingsState } from './yamlSettings';
 import { promises as fs } from 'fs';
+import { convertErrorToTelemetryMsg } from './languageservice/utils/objects';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
@@ -24,6 +25,11 @@ if (process.argv.indexOf('--stdio') === -1) {
 } else {
   connection = createConnection();
 }
+
+process.on('uncaughtException', (err: Error) => {
+  // send all uncaught exception to telemetry with stack traces
+  connection.console.error(convertErrorToTelemetryMsg(err));
+});
 
 console.log = connection.console.log.bind(connection.console);
 console.error = connection.console.error.bind(connection.console);

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { equals } from '../src/languageservice/utils/objects';
+import { equals, convertErrorToTelemetryMsg } from '../src/languageservice/utils/objects';
 import * as assert from 'assert';
 
 describe('Object Equals Tests', () => {
@@ -108,5 +108,24 @@ describe('Object Equals Tests', () => {
       const result = equals(one, other);
       assert.equal(result, false);
     });
+  });
+});
+
+describe('Telemetry message conversion test', () => {
+  it('null values should not cause problems', () => {
+    assert.doesNotThrow(() => convertErrorToTelemetryMsg(null));
+  });
+
+  it('should convert errors with stack correctly', () => {
+    const e: Error = new Error('Test message');
+    const msg = convertErrorToTelemetryMsg(e);
+    assert.equal(msg, e.stack);
+  });
+
+  it('should convert errors with no stack correctly', () => {
+    const e: Error = new Error('Test message');
+    e.stack = null;
+    const msg = convertErrorToTelemetryMsg(e);
+    assert.equal(msg, e.toString());
   });
 });


### PR DESCRIPTION
### What does this PR do?
It ensures that we send errors to telemetry with stack traces. 
Also it add `uncaughtException` error handler for  yaml-ls `process` to track errors and sand them with stack trace to telemetry. That should add possibility to detect `Maximum call stack size exceeded` errors.

### What issues does this PR fix or reference?
None, but it help with issues like https://github.com/redhat-developer/vscode-yaml/issues/652 where we have only error message, but we don't have any trace.

### Is it tested? How?
manually