### PR TITLE
Fix relative file paths with fragments

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -328,11 +328,23 @@ export class YAMLSchemaService extends JSONSchemaService {
       let schemaFromModeline = getSchemaFromModeline(doc);
       if (schemaFromModeline !== undefined) {
         if (!schemaFromModeline.startsWith('file:') && !schemaFromModeline.startsWith('http')) {
+          // If path contains a fragment and it is left intact, "#" will be
+          // considered part of the filename and converted to "%23" by
+          // path.resolve() -> take it out and add back after path.resolve
+          let appendix = '';
+          if (schemaFromModeline.indexOf('#') > 0) {
+            const segments = schemaFromModeline.split('#', 2);
+            schemaFromModeline = segments[0];
+            appendix = segments[1];
+          }
           if (!path.isAbsolute(schemaFromModeline)) {
             const resUri = URI.parse(resource);
             schemaFromModeline = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaFromModeline)).toString();
           } else {
             schemaFromModeline = URI.file(schemaFromModeline).toString();
+          }
+          if (appendix.length > 0) {
+            schemaFromModeline += '#' + appendix;
           }
         }
         this.addSchemaPriority(schemaFromModeline, SchemaPriority.Modeline);

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -106,8 +106,13 @@ describe('YAML Schema Service', () => {
       const schema = await service.getSchemaForResource('', yamlDock.documents[0]);
 
       expect(requestServiceMock).calledTwice;
-      expect(requestServiceMock).calledWithExactly('file:///schema.json');
-      expect(requestServiceMock).calledWithExactly('file:///schema.json#/definitions/schemaArray');
+      if (process.platform === 'win32') {
+        expect(requestServiceMock).calledWithExactly('file:///d%3A/schema.json');
+        expect(requestServiceMock).calledWithExactly('file:///d%3A/schema.json#/definitions/schemaArray');
+      } else {
+        expect(requestServiceMock).calledWithExactly('file:///schema.json');
+        expect(requestServiceMock).calledWithExactly('file:///schema.json#/definitions/schemaArray');
+      }
 
       expect(schema.schema.type).eqls('array');
     });


### PR DESCRIPTION
### What does this PR do?
Fixes fragments when schema URL is a local file.

Example of such a reference:

```
# yaml-language-server: $schema=../../schemas/example.schema.json#/definitions/CustomSpec
```

Currently this doesn't work in VS Code:

![image](https://user-images.githubusercontent.com/211543/144464522-fcd1b885-0051-4a87-9f43-60a72215623a.png)

Error on hover is:

```
Unable to load schema from '/path/to/schemas/example.schema.json#/definitions/CustomSpec': No content.YAML(768)
```

The issue is caused by "#" being turned into "%23" during some path resolve operations. This PR fixes it by excluding the fragment during those operations.

### What issues does this PR fix or reference?
Couldn't find a GitHub issue.
Relates somewhat to old PR which added fragment support: #530

### Is it tested? How?
Includes automated test in existing suite.
I don't know how to test this with VS Code directly (if you could advice, I'll happily test locally; as a sidenote, CONTRIBUTING.md in this regard would be helpful).
