### PR TITLE
feat: disable default props

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following settings are supported:
 - `http.proxy`: The URL of the proxy server that will be used when attempting to download a schema. If it is not set or it is undefined no proxy server will be used.
 - `http.proxyStrictSSL`: If true the proxy server certificate should be verified against the list of supplied CAs. Default is false.
 - `[yaml].editor.formatOnType`: Enable/disable on type indent and auto formatting array
+- `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text
 
 ##### Adding custom tags
 
@@ -241,11 +242,13 @@ or absolute path:
 ```
 
 ## Containerized Language Server
+
 An image is provided for users who would like to use the YAML language server without having to install dependencies locally.
 
 The image is located at `quay.io/redhat-developer/yaml-language-server`
 
 To run the image you can use:
+
 ```
 docker run -it quay.io/redhat-developer/yaml-language-server:latest
 ```
@@ -263,14 +266,16 @@ docker run -it quay.io/redhat-developer/yaml-language-server:latest
 The support schema selection notification is sent from a client to the server to inform server that client supports JSON Schema selection.
 
 _Notification:_
+
 - method: `'yaml/supportSchemaSelection'`
-- params: `void` 
+- params: `void`
 
 #### SchemaStoreInitialized Notification
 
 The schema store initialized notification is sent from the server to a client to inform client that server has finished initializing/loading schemas from schema store, and client now can ask for schemas.
 
 _Notification:_
+
 - method: `'yaml/schema/store/initialized'`
 - params: `void`
 
@@ -279,12 +284,14 @@ _Notification:_
 The get all schemas request sent from a client to server to get all known schemas.
 
 _Request:_
+
 - method: `'yaml/get/all/jsonSchemas'`;
 - params: the document uri, server will mark used schema for document
 
 _Response:_
 
 - result: `JSONSchemaDescriptionExt[]`
+
 ```typescript
 interface JSONSchemaDescriptionExt {
   /**
@@ -315,10 +322,12 @@ interface JSONSchemaDescriptionExt {
 The request sent from a client to server to get schemas used for current document. Client can use this method to indicate in UI which schemas used for current YAML document.
 
 _Request:_
+
 - method: `'yaml/get/jsonSchema'`;
 - params: the document uri to get used schemas
 
 _Response:_
+
 - result: `JSONSchemaDescription[]`
 
 ```typescript

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -102,6 +102,7 @@ export class SettingsHandler {
         }
       }
       this.yamlSettings.disableAdditionalProperties = settings.yaml.disableAdditionalProperties;
+      this.yamlSettings.disableDefaultProperties = settings.yaml.disableDefaultProperties;
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -221,6 +222,7 @@ export class SettingsHandler {
       format: this.yamlSettings.yamlFormatterSettings.enable,
       indentation: this.yamlSettings.indentation,
       disableAdditionalProperties: this.yamlSettings.disableAdditionalProperties,
+      disableDefaultProperties: this.yamlSettings.disableDefaultProperties,
       yamlVersion: this.yamlSettings.yamlVersion,
     };
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -89,6 +89,12 @@ export interface LanguageSettings {
    * So if its true, no extra properties are allowed inside yaml.
    */
   disableAdditionalProperties?: boolean;
+
+  /**
+   * Disable adding not required properties with default values into completion text.
+   */
+  disableDefaultProperties?: boolean;
+
   /**
    * Default yaml lang version
    */

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -20,6 +20,7 @@ export interface Settings {
       url: string;
       enable: boolean;
     };
+    disableDefaultProperties: boolean;
     disableAdditionalProperties: boolean;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
@@ -64,6 +65,7 @@ export class SettingsState {
   schemaStoreUrl = JSON_SCHEMASTORE_URL;
   indentation: string | undefined = undefined;
   disableAdditionalProperties = false;
+  disableDefaultProperties = false;
   maxItemsComputed = 5000;
 
   // File validation helpers

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -156,7 +156,7 @@ describe('Auto Completion Tests', () => {
             name: {
               type: 'string',
               // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -178,7 +178,7 @@ describe('Auto Completion Tests', () => {
             name: {
               type: 'string',
               // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -386,6 +386,62 @@ describe('Auto Completion Tests', () => {
             );
           })
           .then(done, done);
+      });
+
+      it('Autocomplete without default value - not required', async () => {
+        const languageSettingsSetup = new ServiceSetup().withCompletion();
+        languageSettingsSetup.languageSettings.disableDefaultProperties = true;
+        languageService.configure(languageSettingsSetup.languageSettings);
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            scripts: {
+              type: 'object',
+              properties: {
+                sample: {
+                  type: 'string',
+                  default: 'test',
+                },
+              },
+            },
+          },
+        });
+        const content = '';
+        const result = await parseSetup(content, 0);
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0]).to.deep.equal(
+          createExpectedCompletion('scripts', 'scripts:\n  $1', 0, 0, 0, 0, 10, 2, {
+            documentation: '',
+          })
+        );
+      });
+      it('Autocomplete without default value - required', async () => {
+        const languageSettingsSetup = new ServiceSetup().withCompletion();
+        languageSettingsSetup.languageSettings.disableDefaultProperties = true;
+        languageService.configure(languageSettingsSetup.languageSettings);
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            scripts: {
+              type: 'object',
+              properties: {
+                sample: {
+                  type: 'string',
+                  default: 'test',
+                },
+              },
+              required: ['sample'],
+            },
+          },
+        });
+        const content = '';
+        const result = await parseSetup(content, 0);
+        expect(result.items.length).to.be.equal(1);
+        expect(result.items[0]).to.deep.equal(
+          createExpectedCompletion('scripts', 'scripts:\n  sample: ${1:test}', 0, 0, 0, 0, 10, 2, {
+            documentation: '',
+          })
+        );
       });
 
       it('Autocomplete second key in middle of file', (done) => {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -400,6 +400,9 @@ describe('Auto Completion Tests', () => {
                   type: 'string',
                   default: 'test',
                 },
+                objectSample: {
+                  type: 'object',
+                },
               },
             },
           },
@@ -427,8 +430,11 @@ describe('Auto Completion Tests', () => {
                   type: 'string',
                   default: 'test',
                 },
+                objectSample: {
+                  type: 'object',
+                },
               },
-              required: ['sample'],
+              required: ['sample', 'objectSample'],
             },
           },
         });
@@ -436,7 +442,7 @@ describe('Auto Completion Tests', () => {
         const result = await parseSetup(content, 0);
         expect(result.items.length).to.be.equal(1);
         expect(result.items[0]).to.deep.equal(
-          createExpectedCompletion('scripts', 'scripts:\n  sample: ${1:test}', 0, 0, 0, 0, 10, 2, {
+          createExpectedCompletion('scripts', 'scripts:\n  sample: ${1:test}\n  objectSample:\n    $2', 0, 0, 0, 0, 10, 2, {
             documentation: '',
           })
         );

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -411,7 +411,7 @@ describe('Auto Completion Tests', () => {
         const result = await parseSetup(content, 0);
         expect(result.items.length).to.be.equal(1);
         expect(result.items[0]).to.deep.equal(
-          createExpectedCompletion('scripts', 'scripts:\n  $1', 0, 0, 0, 0, 10, 2, {
+          createExpectedCompletion('scripts', 'scripts:\n  ', 0, 0, 0, 0, 10, 2, {
             documentation: '',
           })
         );


### PR DESCRIPTION
### What does this PR do?
Add config to exclude not required default props from completion.
fix: required prop with default value or with const

The reason why users appreciated this feature is that users don't have to specify default properties. Only if the default value needs to be changed, it makes sense to add them (but not all of them automatically).

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
add unit tests