### PR TITLE
feat: extend array documentation on completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -472,17 +472,20 @@ export class YamlCompletion {
                     if (Array.isArray(propertySchema.items)) {
                       this.addSchemaValueCompletions(propertySchema.items[0], separatorAfter, collector, {});
                     } else if (typeof propertySchema.items === 'object' && propertySchema.items.type === 'object') {
+                      const insertText = `- ${this.getInsertTextForObject(
+                        propertySchema.items,
+                        separatorAfter,
+                        '  '
+                      ).insertText.trimLeft()}`;
+                      const documentation = this.getDocumentationWithMarkdownText(
+                        `Create an item of an array${propertySchema.description ? ' (' + propertySchema.description + ')' : ''}`,
+                        insertText
+                      );
                       collector.add({
                         kind: this.getSuggestionKind(propertySchema.items.type),
                         label: '- (array item)',
-                        documentation: `Create an item of an array${
-                          propertySchema.description === undefined ? '' : '(' + propertySchema.description + ')'
-                        }`,
-                        insertText: `- ${this.getInsertTextForObject(
-                          propertySchema.items,
-                          separatorAfter,
-                          '  '
-                        ).insertText.trimLeft()}`,
+                        documentation,
+                        insertText,
                         insertTextFormat: InsertTextFormat.Snippet,
                       });
                     }
@@ -599,13 +602,16 @@ export class YamlCompletion {
                   this.addSchemaValueCompletions(s.schema.items[index], separatorAfter, collector, types);
                 }
               } else if (typeof s.schema.items === 'object' && s.schema.items.type === 'object') {
+                const insertText = `- ${this.getInsertTextForObject(s.schema.items, separatorAfter, '  ').insertText.trimLeft()}`;
+                const documentation = this.getDocumentationWithMarkdownText(
+                  `Create an item of an array${s.schema.description ? ' (' + s.schema.description + ')' : ''}`,
+                  insertText
+                );
                 collector.add({
                   kind: this.getSuggestionKind(s.schema.items.type),
                   label: '- (array item)',
-                  documentation: `Create an item of an array${
-                    s.schema.description === undefined ? '' : '(' + s.schema.description + ')'
-                  }`,
-                  insertText: `- ${this.getInsertTextForObject(s.schema.items, separatorAfter, '  ').insertText.trimLeft()}`,
+                  documentation,
+                  insertText,
                   insertTextFormat: InsertTextFormat.Snippet,
                 });
 
@@ -1302,8 +1308,7 @@ function convertToStringValue(value: string): string {
     return `"${value}"`;
   }
 
-  // eslint-disable-next-line prettier/prettier, no-useless-escape
-  if (value.indexOf('\"') !== -1) {
+  if (value.indexOf('"') !== -1) {
     value = value.replace(doubleQuotesEscapeRegExp, '"');
   }
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -155,8 +155,7 @@ describe('Auto Completion Tests', () => {
           properties: {
             name: {
               type: 'string',
-              // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -177,8 +176,7 @@ describe('Auto Completion Tests', () => {
           properties: {
             name: {
               type: 'string',
-              // eslint-disable-next-line prettier/prettier, no-useless-escape
-              default: '\"yaml\"',
+              default: '"yaml"',
             },
           },
         });
@@ -898,7 +896,7 @@ describe('Auto Completion Tests', () => {
             assert.deepEqual(
               result.items[0],
               createExpectedCompletion('- (array item)', '- $1', 1, 2, 1, 3, 9, 2, {
-                documentation: 'Create an item of an array',
+                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
               })
             );
           })
@@ -933,7 +931,7 @@ describe('Auto Completion Tests', () => {
             assert.deepEqual(
               result.items[0],
               createExpectedCompletion('- (array item)', '- $1', 2, 2, 2, 2, 9, 2, {
-                documentation: 'Create an item of an array',
+                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
               })
             );
           })
@@ -968,7 +966,7 @@ describe('Auto Completion Tests', () => {
             assert.deepEqual(
               result.items[0],
               createExpectedCompletion('- (array item)', '- $1', 1, 0, 1, 0, 9, 2, {
-                documentation: 'Create an item of an array',
+                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
               })
             );
           })
@@ -1189,7 +1187,7 @@ describe('Auto Completion Tests', () => {
             assert.deepEqual(
               result.items[0],
               createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 4, 9, 2, {
-                documentation: 'Create an item of an array',
+                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- name: test\n```' },
               })
             );
           })


### PR DESCRIPTION
### What does this PR do?
extends array documentation on completion
before:
![image](https://user-images.githubusercontent.com/38421337/144401985-c80da24b-f576-41ab-9bca-5b8f63d6c862.png)

after:
![image](https://user-images.githubusercontent.com/38421337/144402121-2c07285a-cf70-42b0-83ba-287dadc7d008.png)

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
modified UT