### PR TITLE
Update K8S json schema version from 1.20.5 to 1.22.4

### DIFF
--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -6,7 +6,7 @@ import { isBoolean } from './objects';
 import { isRelativePath, relativeToAbsolutePath } from './paths';
 
 export const KUBERNETES_SCHEMA_URL =
-  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.20.5-standalone-strict/all.json';
+  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json';
 export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';
 
 export function checkSchemaURI(

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -21,7 +21,7 @@ describe('Auto Completion Fix Tests', () => {
 
   before(() => {
     languageSettingsSetup = new ServiceSetup().withCompletion().withSchemaFileMatch({
-      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.20.5-standalone-strict/all.json',
+      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json',
       fileMatch: [SCHEMA_ID],
     });
     const { languageService: langService, languageHandler: langHandler, yamlSettings: settings } = setupLanguageService(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -18,7 +18,7 @@ describe('Kubernetes Integration Tests', () => {
   let yamlSettings: SettingsState;
 
   before(() => {
-    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.20.5-standalone-strict/all.json';
+    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json';
     const fileMatch = ['*.yml', '*.yaml'];
     languageSettingsSetup = new ServiceSetup()
       .withHover()


### PR DESCRIPTION
### What does this PR do?

Update K8S json schema version

### What issues does this PR fix or reference?

The latest version is 2 minor version ahead of current, update it to prevent outdated validation.