### PR TITLE
Add diagnostic and code action for unused anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^5.0.0",
     "vscode-uri": "^3.0.2",
-    "yaml": "2.0.0-9"
+    "yaml": "2.0.0-10"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^5.0.0",
     "vscode-uri": "^3.0.2",
-    "yaml": "2.0.0-8"
+    "yaml": "2.0.0-9"
   },
   "devDependencies": {
     "@types/chai": "^4.2.12",

--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -53,9 +53,12 @@ export class ValidationHandler {
       .doValidation(textDocument, isKubernetesAssociatedDocument(textDocument, this.yamlSettings.specificValidatorPaths))
       .then((diagnosticResults) => {
         const diagnostics = [];
-        for (const diagnosticItem in diagnosticResults) {
-          diagnosticResults[diagnosticItem].severity = 1; //Convert all warnings to errors
-          diagnostics.push(diagnosticResults[diagnosticItem]);
+        for (const diagnosticItem of diagnosticResults) {
+          // Convert all warnings to errors
+          if (diagnosticItem.severity === 2) {
+            diagnosticItem.severity = 1;
+          }
+          diagnostics.push(diagnosticItem);
         }
 
         const removeDuplicatesDiagnostics = removeDuplicatesObj(diagnostics);

--- a/src/languageservice/jsonASTTypes.ts
+++ b/src/languageservice/jsonASTTypes.ts
@@ -3,7 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Node } from 'yaml';
+import { Node, Pair } from 'yaml';
+
+export type YamlNode = Node | Pair;
 
 export type ASTNode =
   | ObjectASTNode
@@ -21,7 +23,7 @@ export interface BaseASTNode {
   readonly length: number;
   readonly children?: ASTNode[];
   readonly value?: string | boolean | number | null;
-  readonly internalNode: Node;
+  readonly internalNode: YamlNode;
   location: string;
   getNodeFromOffsetEndInclusive(offset: number): ASTNode;
 }

--- a/src/languageservice/parser/ast-converter.ts
+++ b/src/languageservice/parser/ast-converter.ts
@@ -19,7 +19,7 @@ import {
   Document,
   LineCounter,
 } from 'yaml';
-import { ASTNode } from '../jsonASTTypes';
+import { ASTNode, YamlNode } from '../jsonASTTypes';
 import {
   NullASTNodeImpl,
   PropertyASTNodeImpl,
@@ -35,7 +35,7 @@ type NodeRange = [number, number, number];
 const maxRefCount = 1000;
 let refDepth = 0;
 
-export function convertAST(parent: ASTNode, node: Node, doc: Document, lineCounter: LineCounter): ASTNode {
+export function convertAST(parent: ASTNode, node: YamlNode, doc: Document, lineCounter: LineCounter): ASTNode {
   if (!parent) {
     // first invocation
     refDepth = 0;

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -16,6 +16,7 @@ import {
   StringASTNode,
   NullASTNode,
   PropertyASTNode,
+  YamlNode,
 } from '../jsonASTTypes';
 import { ErrorCode } from 'vscode-json-languageservice';
 import * as nls from 'vscode-nls';
@@ -24,7 +25,7 @@ import { DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic } from 'vscode-languageserver';
 import { isArrayEqual } from '../utils/arrUtils';
-import { Node } from 'yaml';
+import { Node, Pair } from 'yaml';
 import { safeCreateUnicodeRegExp } from '../utils/strings';
 
 const localize = nls.loadMessageBundle();
@@ -89,9 +90,9 @@ export abstract class ASTNodeImpl {
   public length: number;
   public readonly parent: ASTNode;
   public location: string;
-  readonly internalNode: Node;
+  readonly internalNode: YamlNode;
 
-  constructor(parent: ASTNode, internalNode: Node, offset: number, length?: number) {
+  constructor(parent: ASTNode, internalNode: YamlNode, offset: number, length?: number) {
     this.offset = offset;
     this.length = length;
     this.parent = parent;
@@ -204,7 +205,7 @@ export class PropertyASTNodeImpl extends ASTNodeImpl implements PropertyASTNode 
   public valueNode: ASTNode;
   public colonOffset: number;
 
-  constructor(parent: ObjectASTNode, internalNode: Node, offset: number, length?: number) {
+  constructor(parent: ObjectASTNode, internalNode: Pair, offset: number, length?: number) {
     super(parent, internalNode, offset, length);
     this.colonOffset = -1;
   }

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -6,7 +6,7 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { JSONDocument } from './jsonParser07';
 import { Document, isNode, isPair, isScalar, LineCounter, visit, YAMLError } from 'yaml';
-import { ASTNode } from '../jsonASTTypes';
+import { ASTNode, YamlNode } from '../jsonASTTypes';
 import { defaultOptions, parse as parseYAML, ParserOptions } from './yamlParser07';
 import { ErrorCode } from 'vscode-json-languageservice';
 import { Node } from 'yaml';
@@ -87,7 +87,7 @@ export class SingleYAMLDocument extends JSONDocument {
     return matchingSchemas;
   }
 
-  getNodeFromPosition(positionOffset: number, textBuffer: TextBuffer): [Node | undefined, boolean] {
+  getNodeFromPosition(positionOffset: number, textBuffer: TextBuffer): [YamlNode | undefined, boolean] {
     const position = textBuffer.getPosition(positionOffset);
     const lineContent = textBuffer.getLineContent(position.line);
     if (lineContent.trim().length === 0) {
@@ -114,10 +114,10 @@ export class SingleYAMLDocument extends JSONDocument {
     return [closestNode, false];
   }
 
-  findClosestNode(offset: number, textBuffer: TextBuffer): Node {
+  findClosestNode(offset: number, textBuffer: TextBuffer): YamlNode {
     let offsetDiff = this.internalDocument.range[2];
     let maxOffset = this.internalDocument.range[0];
-    let closestNode: Node;
+    let closestNode: YamlNode;
     visit(this.internalDocument, (key, node: Node) => {
       if (!node) {
         return;
@@ -149,11 +149,11 @@ export class SingleYAMLDocument extends JSONDocument {
     return closestNode;
   }
 
-  private getProperParentByIndentation(indentation: number, node: Node, textBuffer: TextBuffer): Node {
+  private getProperParentByIndentation(indentation: number, node: YamlNode, textBuffer: TextBuffer): YamlNode {
     if (!node) {
       return this.internalDocument.contents as Node;
     }
-    if (node.range) {
+    if (isNode(node) && node.range) {
       const position = textBuffer.getPosition(node.range[0]);
       if (position.character > indentation && position.character > 0) {
         const parent = this.getParent(node);
@@ -175,7 +175,7 @@ export class SingleYAMLDocument extends JSONDocument {
     return node;
   }
 
-  getParent(node: Node): Node | undefined {
+  getParent(node: YamlNode): YamlNode | undefined {
     return getParent(this.internalDocument, node);
   }
 }

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -30,6 +30,7 @@ export function parse(text: string, parserOptions: ParserOptions = defaultOption
     strict: false,
     customTags: getCustomTags(parserOptions.customTags),
     version: parserOptions.yamlVersion,
+    keepSourceTokens: true,
   };
   const composer = new Composer(options);
   const lineCounter = new LineCounter();

--- a/src/languageservice/services/validation/types.ts
+++ b/src/languageservice/services/validation/types.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic } from 'vscode-languageserver-types';
+import { SingleYAMLDocument } from '../../parser/yaml-documents';
+
+export interface AdditionalValidator {
+  validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[];
+}

--- a/src/languageservice/services/validation/unused-anchors.ts
+++ b/src/languageservice/services/validation/unused-anchors.ts
@@ -41,7 +41,7 @@ export class UnusedAnchorsValidator implements AdditionalValidator {
           );
           const warningDiagnostic = Diagnostic.create(range, `Unused anchor "${aToken.source}"`, DiagnosticSeverity.Hint, 0);
           warningDiagnostic.tags = [DiagnosticTag.Unnecessary];
-          warningDiagnostic.data = { range, name: aToken.source };
+          warningDiagnostic.data = { name: aToken.source };
           result.push(warningDiagnostic);
         }
       }

--- a/src/languageservice/services/validation/unused-anchors.ts
+++ b/src/languageservice/services/validation/unused-anchors.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic, DiagnosticSeverity, DiagnosticTag, Range } from 'vscode-languageserver-types';
+import { isAlias, isCollection, isNode, isScalar, Node, Scalar, visit, YAMLMap, YAMLSeq, CST, Pair } from 'yaml';
+import { YamlNode } from '../../jsonASTTypes';
+import { SingleYAMLDocument } from '../../parser/yaml-documents';
+import { AdditionalValidator } from './types';
+import { isCollectionItem } from '../../../languageservice/utils/astUtils';
+
+export class UnusedAnchorsValidator implements AdditionalValidator {
+  validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[] {
+    const result = [];
+    const anchors = new Set<Scalar | YAMLMap | YAMLSeq>();
+    const usedAnchors = new Set<Node>();
+    const anchorParent = new Map<Scalar | YAMLMap | YAMLSeq, Node | Pair>();
+
+    visit(yamlDoc.internalDocument, (key, node, path) => {
+      if (!isNode(node)) {
+        return;
+      }
+      if ((isCollection(node) || isScalar(node)) && node.anchor) {
+        anchors.add(node);
+        anchorParent.set(node, path[path.length - 1] as Node);
+      }
+      if (isAlias(node)) {
+        usedAnchors.add(node.resolve(yamlDoc.internalDocument));
+      }
+    });
+
+    for (const anchor of anchors) {
+      if (!usedAnchors.has(anchor)) {
+        const aToken = this.getAnchorNode(anchorParent.get(anchor));
+        if (aToken) {
+          const range = Range.create(
+            document.positionAt(aToken.offset),
+            document.positionAt(aToken.offset + aToken.source.length)
+          );
+          const warningDiagnostic = Diagnostic.create(range, `Unused anchor "${aToken.source}"`, DiagnosticSeverity.Hint, 0);
+          warningDiagnostic.tags = [DiagnosticTag.Unnecessary];
+          warningDiagnostic.data = { range, name: aToken.source };
+          result.push(warningDiagnostic);
+        }
+      }
+    }
+
+    return result;
+  }
+  private getAnchorNode(parentNode: YamlNode): CST.SourceToken | undefined {
+    if (parentNode && parentNode.srcToken) {
+      const token = parentNode.srcToken;
+      if (isCollectionItem(token)) {
+        return getAnchorFromCollectionItem(token);
+      } else if (CST.isCollection(token)) {
+        for (const t of token.items) {
+          const anchor = getAnchorFromCollectionItem(t);
+          if (anchor) {
+            return anchor;
+          }
+        }
+      }
+    }
+    return undefined;
+  }
+}
+function getAnchorFromCollectionItem(token: CST.CollectionItem): CST.SourceToken | undefined {
+  for (const t of token.start) {
+    if (t.type === 'anchor') {
+      return t;
+    }
+  }
+  if (token.sep && Array.isArray(token.sep)) {
+    for (const t of token.sep) {
+      if (t.type === 'anchor') {
+        return t;
+      }
+    }
+  }
+}

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { TextBuffer } from '../utils/textBuffer';
 import { LanguageSettings } from '../yamlLanguageService';
 import { YAML_SOURCE } from '../parser/jsonParser07';
-import { getLastWhitespaceAfterChar } from '../utils/strings';
+import { getFirstNonWhitespaceCharacterAfterOffset } from '../utils/strings';
 
 interface YamlDiagnosticData {
   schemaUri: string[];
@@ -171,9 +171,10 @@ export class YamlCodeActions {
     const buffer = new TextBuffer(document);
     for (const diag of diagnostics) {
       if (diag.message.startsWith('Unused anchor') && diag.source === YAML_SOURCE) {
-        const { range, name } = diag.data as { range: Range; name: string };
+        const { name } = diag.data as { name: string };
+        const range = Range.create(diag.range.start, diag.range.end);
         const lineContent = buffer.getLineContent(range.end.line);
-        const lastWhitespaceChar = getLastWhitespaceAfterChar(lineContent, range.end.character);
+        const lastWhitespaceChar = getFirstNonWhitespaceCharacterAfterOffset(lineContent, range.end.character);
         range.end.character = lastWhitespaceChar;
         const action = CodeAction.create(
           `Delete unused anchor: ${name}`,

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -36,6 +36,7 @@ import { isInComment, isMapContainsEmptyPair } from '../utils/astUtils';
 import { indexOf } from '../utils/astUtils';
 import { isModeline } from './modelineUtil';
 import { getSchemaTypeName } from '../utils/schemaUtils';
+import { YamlNode } from '../jsonASTTypes';
 
 const localize = nls.loadMessageBundle();
 
@@ -222,7 +223,7 @@ export class YamlCompletion {
         return result;
       }
 
-      let currentProperty: Node = null;
+      let currentProperty: YamlNode = null;
 
       if (!node) {
         if (!currentDoc.internalDocument.contents || isScalar(currentDoc.internalDocument.contents)) {
@@ -411,7 +412,7 @@ export class YamlCompletion {
     schema: ResolvedSchema,
     doc: SingleYAMLDocument,
     node: YAMLMap,
-    originalNode: Node,
+    originalNode: YamlNode,
     separatorAfter: string,
     collector: CompletionsCollector,
     textBuffer: TextBuffer,
@@ -568,7 +569,7 @@ export class YamlCompletion {
   private getValueCompletions(
     schema: ResolvedSchema,
     doc: SingleYAMLDocument,
-    node: Node,
+    node: YamlNode,
     offset: number,
     document: TextDocument,
     collector: CompletionsCollector,

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -17,6 +17,8 @@ import { YAML_SOURCE } from '../parser/jsonParser07';
 import { TextBuffer } from '../utils/textBuffer';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
+import { AdditionalValidator } from './validation/types';
+import { UnusedAnchorsValidator } from './validation/unused-anchors';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -41,12 +43,14 @@ export class YAMLValidation {
   private jsonValidation;
   private disableAdditionalProperties: boolean;
   private yamlVersion: YamlVersion;
+  private additionalValidation: AdditionalValidation;
 
   private MATCHES_MULTIPLE = 'Matches multiple schemas when only one must validate.';
 
-  public constructor(schemaService: YAMLSchemaService) {
+  constructor(schemaService: YAMLSchemaService) {
     this.validationEnabled = true;
     this.jsonValidation = new JSONValidation(schemaService, Promise);
+    this.additionalValidation = new AdditionalValidation();
   }
 
   public configure(settings: LanguageSettings): void {
@@ -89,6 +93,7 @@ export class YAMLValidation {
         }
 
         validationResult.push(...validation);
+        validationResult.push(...this.additionalValidation.validate(textDocument, currentYAMLDoc));
         index++;
       }
     } catch (err) {
@@ -136,5 +141,20 @@ export class YAMLValidation {
     }
 
     return duplicateMessagesRemoved;
+  }
+}
+
+class AdditionalValidation {
+  private validators: AdditionalValidator[] = [];
+  constructor() {
+    this.validators.push(new UnusedAnchorsValidator());
+  }
+  validate(document: TextDocument, yarnDoc: SingleYAMLDocument): Diagnostic[] {
+    const result = [];
+
+    for (const validator of this.validators) {
+      result.push(...validator.validate(document, yarnDoc));
+    }
+    return result;
   }
 }

--- a/src/languageservice/utils/astUtils.ts
+++ b/src/languageservice/utils/astUtils.ts
@@ -6,10 +6,11 @@
 import { Document, isDocument, isScalar, Node, visit, YAMLMap, YAMLSeq } from 'yaml';
 import { CollectionItem, SourceToken, Token } from 'yaml/dist/parse/cst';
 import { VisitPath } from 'yaml/dist/parse/cst-visit';
+import { YamlNode } from '../jsonASTTypes';
 
 type Visitor = (item: SourceToken, path: VisitPath) => number | symbol | Visitor | void;
 
-export function getParent(doc: Document, nodeToFind: Node): Node | undefined {
+export function getParent(doc: Document, nodeToFind: YamlNode): YamlNode | undefined {
   let parentNode: Node;
   visit(doc, (_, node: Node, path) => {
     if (node === nodeToFind) {
@@ -37,7 +38,7 @@ export function isMapContainsEmptyPair(map: YAMLMap): boolean {
   return false;
 }
 
-export function indexOf(seq: YAMLSeq, item: Node): number | undefined {
+export function indexOf(seq: YAMLSeq, item: YamlNode): number | undefined {
   for (const [i, obj] of seq.items.entries()) {
     if (item === obj) {
       return i;
@@ -79,7 +80,7 @@ export function isInComment(tokens: Token[], offset: number): boolean {
   return inComment;
 }
 
-function isCollectionItem(token: unknown): token is CollectionItem {
+export function isCollectionItem(token: unknown): token is CollectionItem {
   return token['start'] !== undefined;
 }
 

--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -75,3 +75,16 @@ export function safeCreateUnicodeRegExp(pattern: string): RegExp {
     return new RegExp(pattern);
   }
 }
+
+export function getLastWhitespaceAfterChar(str: string, offset: number): number {
+  offset++;
+  for (let i = offset; i < str.length; i++) {
+    const char = str.charAt(i);
+    if (char === ' ' || char === '\t') {
+      offset++;
+    } else {
+      return offset;
+    }
+  }
+  return offset;
+}

--- a/src/languageservice/utils/strings.ts
+++ b/src/languageservice/utils/strings.ts
@@ -76,7 +76,7 @@ export function safeCreateUnicodeRegExp(pattern: string): RegExp {
   }
 }
 
-export function getLastWhitespaceAfterChar(str: string, offset: number): number {
+export function getFirstNonWhitespaceCharacterAfterOffset(str: string, offset: number): number {
   offset++;
   for (let i = offset; i < str.length; i++) {
     const char = str.charAt(i);

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DocumentSymbol, SymbolKind, InsertTextFormat, Range } from 'vscode-languageserver-types';
+import { DocumentSymbol, SymbolKind, InsertTextFormat, Range, DiagnosticTag } from 'vscode-languageserver-types';
 import { CompletionItem, CompletionItemKind, SymbolInformation, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { ErrorCode } from 'vscode-json-languageservice';
 
@@ -32,6 +32,28 @@ export function createDiagnosticWithData(
 ): Diagnostic {
   const diagnostic: Diagnostic = createExpectedError(message, startLine, startCharacter, endLine, endCharacter, severity, source);
   diagnostic.data = { schemaUri: typeof schemaUri === 'string' ? [schemaUri] : schemaUri };
+  return diagnostic;
+}
+
+export function createUnusedAnchorDiagnostic(
+  message: string,
+  name: string,
+  startLine: number,
+  startCharacter: number,
+  endLine: number,
+  endCharacter: number
+): Diagnostic {
+  const diagnostic = createExpectedError(
+    message,
+    startLine,
+    startCharacter,
+    endLine,
+    endCharacter,
+    DiagnosticSeverity.Hint,
+    'YAML'
+  );
+  diagnostic.tags = [DiagnosticTag.Unnecessary];
+  diagnostic.data = { range: Range.create(startLine, startCharacter, endLine, endCharacter), name };
   return diagnostic;
 }
 

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -53,7 +53,7 @@ export function createUnusedAnchorDiagnostic(
     'YAML'
   );
   diagnostic.tags = [DiagnosticTag.Unnecessary];
-  diagnostic.data = { range: Range.create(startLine, startCharacter, endLine, endCharacter), name };
+  diagnostic.data = { name };
   return diagnostic;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,10 +2636,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.0.0-8:
-  version "2.0.0-8"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-8.tgz#226365f0d804ba7fb8cc2b527a00a7a4a3d8ea5f"
-  integrity sha512-QaYgJZMfWD6fKN/EYMk6w1oLWPCr1xj9QaPSZW5qkDb3y8nGCXhy2Ono+AF4F+CSL/vGcqswcAT0BaS//pgD2A==
+yaml@2.0.0-9:
+  version "2.0.0-9"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-9.tgz#0099f0645d1ffa686a2c5141b6da340f545d3634"
+  integrity sha512-Bf2KowHjyVkIIiGMt7+fbhmlvKOaE8DWuD07bnL4+FQ9sPmEl/5IzGpBpoxPqOaHuyasBjJhyXDcISpJWfhCGw==
 
 yargs-parser@20.2.4:
   version "20.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,10 +2636,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.0.0-9:
-  version "2.0.0-9"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-9.tgz#0099f0645d1ffa686a2c5141b6da340f545d3634"
-  integrity sha512-Bf2KowHjyVkIIiGMt7+fbhmlvKOaE8DWuD07bnL4+FQ9sPmEl/5IzGpBpoxPqOaHuyasBjJhyXDcISpJWfhCGw==
+yaml@2.0.0-10:
+  version "2.0.0-10"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-10.tgz#d5b59e2d14b8683313a534f2bbc648e211a2753e"
+  integrity sha512-FHV8s5ODFFQXX/enJEU2EkanNl1UDBUz8oa4k5Qo/sR+Iq7VmhCDkRMb0/mjJCNeAWQ31W8WV6PYStDE4d9EIw==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
### What does this PR do?
It add diagnostic report for unused anchors, also it add code action which delete unused anchor.
This PR also updates the `yaml` parser to `2.0.0-9` to be able to use `CST` `scrToken` from  `Node`.

Demo:

https://user-images.githubusercontent.com/929743/146509097-9444b434-53d1-4d11-9a7c-f4c426f51726.mov



### What issues does this PR fix or reference?
Resolve: https://github.com/redhat-developer/yaml-language-server/issues/587

### Is it tested? How?
with test
