### PR TITLE
updated maxMatch value based on oneOf size

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -681,9 +681,13 @@ function validate(
       }
     }
 
-    const testAlternatives = (alternatives: JSONSchemaRef[], maxOneMatch: boolean): number => {
+    const testAlternatives = (alternatives: JSONSchemaRef[], oneOfMatch: boolean): number => {
       const matches = [];
-
+      let maxMatch = 1;
+      if (oneOfMatch) {
+        //there may be chances that node value matches all the schemas which provided under oneOf
+        maxMatch = alternatives.length;
+      }
       // remember the best match that is used for error messages
       let bestMatch: {
         schema: JSONSchema;
@@ -707,11 +711,11 @@ function validate(
         } else if (isKubernetes) {
           bestMatch = alternativeComparison(subValidationResult, bestMatch, subSchema, subMatchingSchemas);
         } else {
-          bestMatch = genericComparison(maxOneMatch, subValidationResult, bestMatch, subSchema, subMatchingSchemas);
+          bestMatch = genericComparison(oneOfMatch, subValidationResult, bestMatch, subSchema, subMatchingSchemas);
         }
       }
 
-      if (matches.length > 1 && maxOneMatch) {
+      if (matches.length > maxMatch && oneOfMatch) {
         validationResult.problems.push({
           location: { offset: node.offset, length: 1 },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -683,6 +683,10 @@ function validate(
 
     const testAlternatives = (alternatives: JSONSchemaRef[], minOneMatch: boolean): number => {
       const matches = [];
+      let minMatch = 1;
+      if (minOneMatch) {
+        minMatch = alternatives.length;
+      }
       // remember the best match that is used for error messages
       let bestMatch: {
         schema: JSONSchema;
@@ -710,7 +714,7 @@ function validate(
         }
       }
 
-      if (matches.length < 1 && minOneMatch) {
+      if (matches.length > minMatch && minOneMatch) {
         validationResult.problems.push({
           location: { offset: node.offset, length: 1 },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -681,13 +681,8 @@ function validate(
       }
     }
 
-    const testAlternatives = (alternatives: JSONSchemaRef[], oneOfMatch: boolean): number => {
+    const testAlternatives = (alternatives: JSONSchemaRef[], minOneMatch: boolean): number => {
       const matches = [];
-      let maxMatch = 1;
-      if (oneOfMatch) {
-        //there may be chances that node value matches all the schemas which provided under oneOf
-        maxMatch = alternatives.length;
-      }
       // remember the best match that is used for error messages
       let bestMatch: {
         schema: JSONSchema;
@@ -711,15 +706,15 @@ function validate(
         } else if (isKubernetes) {
           bestMatch = alternativeComparison(subValidationResult, bestMatch, subSchema, subMatchingSchemas);
         } else {
-          bestMatch = genericComparison(oneOfMatch, subValidationResult, bestMatch, subSchema, subMatchingSchemas);
+          bestMatch = genericComparison(minOneMatch, subValidationResult, bestMatch, subSchema, subMatchingSchemas);
         }
       }
 
-      if (matches.length > maxMatch && oneOfMatch) {
+      if (matches.length < 1 && minOneMatch) {
         validationResult.problems.push({
           location: { offset: node.offset, length: 1 },
           severity: DiagnosticSeverity.Warning,
-          message: localize('oneOfWarning', 'Matches multiple schemas when only one must validate.'),
+          message: localize('oneOfWarning', 'Minimum one schema should validate.'),
           source: getSchemaSource(schema, originalSchema),
           schemaUri: getSchemaUri(schema, originalSchema),
         });

--- a/test/jsonParser.test.ts
+++ b/test/jsonParser.test.ts
@@ -1864,6 +1864,32 @@ describe('JSON Parser', () => {
     assert.strictEqual(semanticErrors[0].message, 'Value is not accepted. Valid values: "a", "b", "c", "d".');
   });
 
+  it('value matches more than one schema in oneOf', function () {
+    const schema: JsonSchema.JSONSchema = {
+      type: 'object',
+      properties: {
+        repository: {
+          oneOf: [
+            {
+              type: 'string',
+              format: 'uri',
+            },
+            {
+              type: 'string',
+              pattern: '^@',
+            },
+          ],
+        },
+      },
+    };
+
+    const { textDoc, jsonDoc } = toDocument('{"repository":"@bitnami"}');
+    assert.strictEqual(jsonDoc.syntaxErrors.length, 0);
+
+    const semanticErrors = jsonDoc.validate(textDoc, schema);
+    assert.strictEqual(semanticErrors.length, 0);
+  });
+
   it('validate API', async function () {
     const { textDoc, jsonDoc } = toDocument('{ "pages": [  "pages/index", "pages/log", ] }');
 


### PR DESCRIPTION
### What does this PR do?

This PR updated the maxMatch value based on the oneOf size. Because there may be a chances that node value matches all the schema which provided under oneOf 

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/586

### Is it tested? How?
Yes with test cases.
