### PR TITLE
Remove getSchemas

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -80,12 +80,6 @@ export class SingleYAMLDocument extends JSONDocument {
   get warnings(): YAMLDocDiagnostic[] {
     return this.internalDocument.warnings.map(YAMLErrorToYamlDocDiagnostics);
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  public getSchemas(schema: any, doc: any, node: any): any[] {
-    const matchingSchemas = [];
-    doc.validate(schema, matchingSchemas, node.start);
-    return matchingSchemas;
-  }
 
   getNodeFromPosition(positionOffset: number, textBuffer: TextBuffer): [Node | undefined, boolean] {
     const position = textBuffer.getPosition(positionOffset);


### PR DESCRIPTION
Removes the getSchemas function from `SingleYAMLDocument` in favor of `getMatchingSchemas`.

### Is it tested? How?
Used the current test set. 