### PR TITLE
integrated the latest 0.5.6 request-light lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
     "mocha": "9.1.2",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",
@@ -92,7 +94,7 @@
       "out",
       "lib",
       "coverage/",
-      ".eslintrc.js", 
+      ".eslintrc.js",
       "scripts"
     ],
     "all": true

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier": "2.0.5"
   },
   "dependencies": {
-    "request-light": "^0.5.5",
+    "request-light": "^0.5.6",
     "vscode-json-languageservice": "^4.1.7",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",


### PR DESCRIPTION
### What does this PR do?

The latest version of request-lib version 0.5.6 integrated.  This version contains the proxy support

### What issues does this PR fix or reference?

https://github.com/redhat-developer/yaml-language-server/issues/588

### Is it tested? How?
Yes with test cases
