### PR TITLE
fix: Array indent doesn't work properly inside another array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -735,7 +735,9 @@ export class YamlCompletion {
       if (propertySchema.properties) {
         return `${resultText}\n${this.getInsertTextForObject(propertySchema, separatorAfter, indent).insertText}`;
       } else if (propertySchema.items) {
-        return `${resultText}\n${indent}- ${this.getInsertTextForArray(propertySchema.items, separatorAfter).insertText}`;
+        return `${resultText}\n${indent}- ${
+          this.getInsertTextForArray(propertySchema.items, separatorAfter, 1, indent).insertText
+        }`;
       }
       if (nValueProposals === 0) {
         switch (type) {
@@ -802,7 +804,7 @@ export class YamlCompletion {
             break;
           case 'array':
             {
-              const arrayInsertResult = this.getInsertTextForArray(propertySchema.items, separatorAfter, insertIndex++);
+              const arrayInsertResult = this.getInsertTextForArray(propertySchema.items, separatorAfter, insertIndex++, indent);
               const arrayInsertLines = arrayInsertResult.insertText.split('\n');
               let arrayTemplate = arrayInsertResult.insertText;
               if (arrayInsertLines.length > 1) {
@@ -854,7 +856,7 @@ export class YamlCompletion {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getInsertTextForArray(schema: any, separatorAfter: string, insertIndex = 1): InsertText {
+  private getInsertTextForArray(schema: any, separatorAfter: string, insertIndex = 1, indent = this.indentation): InsertText {
     let insertText = '';
     if (!schema) {
       insertText = `$${insertIndex++}`;
@@ -882,7 +884,7 @@ export class YamlCompletion {
         break;
       case 'object':
         {
-          const objectInsertResult = this.getInsertTextForObject(schema, separatorAfter, `${this.indentation}  `, insertIndex++);
+          const objectInsertResult = this.getInsertTextForObject(schema, separatorAfter, `${indent}  `, insertIndex++);
           insertText = objectInsertResult.insertText.trimLeft();
           insertIndex = objectInsertResult.insertIndex;
         }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -676,7 +676,7 @@ export class YamlCompletion {
     key: string,
     propertySchema: JSONSchema,
     separatorAfter: string,
-    ident = this.indentation
+    indent = this.indentation
   ): string {
     const propertyText = this.getInsertTextForValue(key, '', 'string');
     const resultText = propertyText + ':';
@@ -733,11 +733,9 @@ export class YamlCompletion {
         nValueProposals += propertySchema.examples.length;
       }
       if (propertySchema.properties) {
-        return `${resultText}\n${this.getInsertTextForObject(propertySchema, separatorAfter, ident).insertText}`;
+        return `${resultText}\n${this.getInsertTextForObject(propertySchema, separatorAfter, indent).insertText}`;
       } else if (propertySchema.items) {
-        return `${resultText}\n${this.indentation}- ${
-          this.getInsertTextForArray(propertySchema.items, separatorAfter).insertText
-        }`;
+        return `${resultText}\n${indent}- ${this.getInsertTextForArray(propertySchema.items, separatorAfter).insertText}`;
       }
       if (nValueProposals === 0) {
         switch (type) {
@@ -748,10 +746,10 @@ export class YamlCompletion {
             value = ' $1';
             break;
           case 'object':
-            value = `\n${ident}`;
+            value = `\n${indent}`;
             break;
           case 'array':
-            value = `\n${ident}- `;
+            value = `\n${indent}- `;
             break;
           case 'number':
           case 'integer':

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -264,7 +264,7 @@ objB:
     );
   });
 
-  it('Autocomplete indent on array indent when parent is array', async () => {
+  it('Autocomplete indent on array when parent is array', async () => {
     languageService.addSchema(SCHEMA_ID, {
       type: 'object',
       properties: {
@@ -290,6 +290,41 @@ objB:
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
       createExpectedCompletion('objectWithArray', 'objectWithArray:\n    - ${1:""}', 1, 4, 1, 4, 10, 2, {
+        documentation: '',
+      })
+    );
+  });
+  it('Autocomplete indent on array object when parent is array', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        examples: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              objectWithArray: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['item', 'item2'],
+                  properties: {
+                    item: { type: 'string' },
+                    item2: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const content = 'examples:\n  - ';
+    const completion = await parseSetup(content, 1, 4);
+
+    expect(completion.items.length).equal(1);
+    expect(completion.items[0]).to.be.deep.equal(
+      createExpectedCompletion('objectWithArray', 'objectWithArray:\n    - item: $1\n      item2: $2', 1, 4, 1, 4, 10, 2, {
         documentation: '',
       })
     );

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -32,6 +32,13 @@ describe('Auto Completion Fix Tests', () => {
     yamlSettings = settings;
   });
 
+  /**
+   *
+   * @param content
+   * @param line starts with 0 index
+   * @param character starts with 1 index
+   * @returns
+   */
   function parseSetup(content: string, line: number, character: number): Promise<CompletionList> {
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
@@ -253,6 +260,37 @@ objB:
           kind: 'markdown',
           value: 'Create an item of an array\n ```\n- \n```',
         },
+      })
+    );
+  });
+
+  it('Autocomplete indent on array indent when parent is array', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        examples: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              objectWithArray: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const content = 'examples:\n  - ';
+    const completion = await parseSetup(content, 1, 4);
+
+    expect(completion.items.length).equal(1);
+    expect(completion.items[0]).to.be.deep.equal(
+      createExpectedCompletion('objectWithArray', 'objectWithArray:\n    - ${1:""}', 1, 4, 1, 4, 10, 2, {
+        documentation: '',
       })
     );
   });


### PR DESCRIPTION
### What does this PR do?
Array indent doesn't work properly inside another array.

https://user-images.githubusercontent.com/38421337/147991614-4871277e-3b79-4d7a-9a67-2158cba9afa6.mov

schema:
```json
{
  "definitions": {
    "arrayIndent": {
      "type": "object",
      "properties": {
        "examples": {
          "type": "array",
          "items": {
            "type": "object",
            "properties": {
              "objectWithArray": {
                "type": "array",
                "items": {
                  "type": "object",
                  "required": ["item", "item2"],
                  "properties": {
                    "item": { "type": "string" },
                    "item2": { "type": "string" }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "type": "object"
}

```
yaml
```yaml
arrayIndent:
  examples:
    - 
```

```yaml
arrayIndent:
  examples:
    - objectWithArray:
        - item: 
        item2: # there should be the same indent
```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
UT