### PR TITLE
fix: array indent on different index position

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -452,7 +452,7 @@ export class YamlCompletion {
 
                 if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema['doNotSuggest']) {
                   let identCompensation = '';
-                  if (nodeParent && isSeq(nodeParent) && node.items.length <= 1) {
+                  if (nodeParent && isSeq(nodeParent) && node.items.length <= 1 && !hasOnlyWhitespace) {
                     // because there is a slash '-' to prevent the properties generated to have the correct
                     // indent
                     const sourceText = textBuffer.getText();

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -256,4 +256,58 @@ objB:
       })
     );
   });
+  describe('array indent on different index position', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        objectWithArray: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['item', 'item2'],
+            properties: {
+              item: { type: 'string' },
+              item2: {
+                type: 'object',
+                required: ['prop1', 'prop2'],
+                properties: {
+                  prop1: { type: 'string' },
+                  prop2: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    it('array indent on the first item', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'objectWithArray:\n  - ';
+      const completion = await parseSetup(content, 1, 4);
+
+      expect(completion.items.length).equal(2);
+      expect(completion.items[0]).to.be.deep.equal(
+        createExpectedCompletion('item', 'item: ', 1, 4, 1, 4, 10, 2, {
+          documentation: '',
+        })
+      );
+      expect(completion.items[1]).to.be.deep.equal(
+        createExpectedCompletion('item2', 'item2:\n    prop1: $1\n    prop2: $2', 1, 4, 1, 4, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+    it('array indent on the second item', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'objectWithArray:\n  - item: first line\n    ';
+      const completion = await parseSetup(content, 2, 4);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).to.be.deep.equal(
+        createExpectedCompletion('item2', 'item2:\n  prop1: $1\n  prop2: $2', 2, 4, 2, 4, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
https://user-images.githubusercontent.com/38421337/148134131-4fc930d4-4c39-41f8-99a9-599fd104cfd4.mov

note: in the video `examples: \n -` is extra and doesn't have an effect to the bug behavior.

```yaml
objectWithArray:
  - item: first item
    item2:
        prop1: extra indent
        prop2: 
```


### What issues does this PR fix or reference?
no ref

### Is it tested? How?
UTs for the 1st and 2nd item