### PR TITLE
Lock vscode-json-languageservice@4.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "request-light": "^0.5.5",
-    "vscode-json-languageservice": "^4.1.7",
+    "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^7.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,10 +2515,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-json-languageservice@^4.1.7:
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.7.tgz#18244d62b115a5818c7526ef4339438b7175dfaa"
-  integrity sha512-cwG5TwZyHYthsk2aS3W1dVgVP6Vwn3o+zscwN58uMgZt/nKuyxd9vdEB1F58Ix+S5kSKAnkUCP6hvulcoImQQQ==
+vscode-json-languageservice@4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz#397a39238d496e3e08a544a8b93df2cd13347d0c"
+  integrity sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==
   dependencies:
     jsonc-parser "^3.0.0"
     vscode-languageserver-textdocument "^1.0.1"


### PR DESCRIPTION
### What does this PR do?

This is a around #585 by locking `vscode-json-languageservice` to version 4.1.8.

It’s a workaround, not a desirable fix.

### What issues does this PR fix or reference?

#585\
microsoft/vscode-json-languageservice#123

### Is it tested? How?

All steps are run from the project root using `vim` and the following configuration:

```viml
au User lsp_setup call lsp#register_server({
  \ 'name': 'yaml',
  \ 'cmd': {server_info->['node', 'out/server/src/server.js', '--stdio']},
  \ 'allowlist': ['yaml'],
\})

call plug#begin('~/.vim/plugged')

Plug 'prabirshrestha/vim-lsp'

call plug#end()
```

Clone and setup the project

```sh
git clone git@github.com:redhat-developer/yaml-language-server.git
yarn
yarn compile
yarn add vscode-json-languageservice@4.1.8
```

Create a file named `app-definition.yaml` with the following content. Use vim to edit it.

```yaml
name: 123
```

This correctly shows that `name` is invalid and some properties are missing.

Now close vim and run the following command:

```sh
yarn add vscode-json-languageservice@4.1.9
```

Now when editing the same file again, it shows an error saying the JSON schema can’t be resolved.
