### PR TITLE
Handle case when schema not JS object

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -610,6 +610,11 @@ function validate(
     return;
   }
 
+  // schema should be an Object
+  if (typeof schema !== 'object') {
+    return;
+  }
+
   if (!schema.url) {
     schema.url = originalSchema.url;
   }

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -379,7 +379,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         const highestPrioSchemas = this.highestPrioritySchemas(schemas);
         const schemaHandle = super.createCombinedSchema(resource, highestPrioSchemas);
         return schemaHandle.getResolvedSchema().then((schema) => {
-          if (schema.schema && typeof schema.schema !== 'string') {
+          if (schema.schema && typeof schema.schema === 'object') {
             schema.schema.url = schemaHandle.url;
           }
 

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1560,6 +1560,15 @@ obj:
   });
 
   describe('Bug fixes', () => {
+    it('should handle "additionalItems" not schema or boolean', async () => {
+      const schema = 'Foo';
+      languageService.addSchema(SCHEMA_ID, schema as JSONSchema);
+      const content = `foo: bar`;
+      const result = await parseSetup(content);
+      expect(result).to.be.empty;
+      expect(telemetry.messages).to.be.empty;
+    });
+
     it('should handle bad schema refs', async () => {
       const schema = {
         type: 'object',

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1560,7 +1560,7 @@ obj:
   });
 
   describe('Bug fixes', () => {
-    it('should handle "additionalItems" not schema or boolean', async () => {
+    it('should handle not valid schema object', async () => {
       const schema = 'Foo';
       languageService.addSchema(SCHEMA_ID, schema as JSONSchema);
       const content = `foo: bar`;


### PR DESCRIPTION
### What does this PR do?
Add check if schema is `object` in validation function.

### What issues does this PR fix or reference?
Fix: https://github.com/redhat-developer/yaml-language-server/issues/652

### Is it tested? How?
with test
