### PR TITLE
fix/suggestion item title

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "build:libs": "yarn compile:umd && yarn compile:esm",
     "compile:umd": "tsc -p ./tsconfig.umd.json",
     "compile:esm": "tsc -p ./tsconfig.esm.json",
-    "check-dependencies": "node ./scripts/check-dependencies.js"
+    "check-dependencies": "node ./scripts/check-dependencies.js",
+    "pull-remote": "git pull https://github.com/redhat-developer/yaml-language-server.git main"
   },
   "nyc": {
     "extension": [

--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -14,6 +14,7 @@ export interface JSONSchema {
   url?: string;
   type?: string | string[];
   title?: string;
+  closestTitle?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: any;
   definitions?: { [name: string]: JSONSchema };

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -618,9 +618,8 @@ function validate(
   if (!schema.url) {
     schema.url = originalSchema.url;
   }
-  if (!schema.title) {
-    schema.title = originalSchema.title;
-  }
+
+  schema.closestTitle = schema.title || originalSchema.closestTitle;
 
   switch (node.type) {
     case 'object':
@@ -1074,6 +1073,7 @@ function validate(
             const subSchemaRef = itemSchema.oneOf[0];
             const subSchema = asSchema(subSchemaRef);
             subSchema.title = schema.title;
+            subSchema.closestTitle = schema.closestTitle;
             validate(item, subSchema, schema, itemValidationResult, matchingSchemas, options);
             validationResult.mergePropertyMatch(itemValidationResult);
             validationResult.mergeEnumValues(itemValidationResult);
@@ -1469,8 +1469,10 @@ function getSchemaSource(schema: JSONSchema, originalSchema: JSONSchema): string
     let label: string;
     if (schema.title) {
       label = schema.title;
-    } else if (originalSchema.title) {
-      label = originalSchema.title;
+    } else if (schema.closestTitle) {
+      label = schema.closestTitle;
+    } else if (originalSchema.closestTitle) {
+      label = originalSchema.closestTitle;
     } else {
       const uriString = schema.url ?? originalSchema.url;
       if (uriString) {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -46,6 +46,7 @@ const parentCompletionKind = CompletionItemKind.Class;
 
 interface ParentCompletionItemOptions {
   schemaType: string;
+  schemaDescription?: string;
   indent?: string;
   insertTexts?: string[];
 }
@@ -171,6 +172,7 @@ export class YamlCompletion {
             parentCompletion = {
               ...completionItem,
               label: schemaType,
+              documentation: completionItem.parent.schemaDescription,
               sortText: '_' + schemaType, // this parent completion goes first,
               kind: parentCompletionKind,
             };
@@ -645,6 +647,7 @@ export class YamlCompletion {
                       documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
                       parent: {
                         schemaType,
+                        schemaDescription: schema.schema.markdownDescription || schema.schema.description,
                         indent: identCompensation,
                       },
                     });

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -106,7 +106,7 @@ export class YAMLHover {
           enumValue: string | undefined = undefined;
         matchingSchemas.every((s) => {
           if (s.node === node && !s.inverted && s.schema) {
-            title = title || s.schema.title;
+            title = title || s.schema.title || s.schema.closestTitle;
             markdownDescription = markdownDescription || s.schema.markdownDescription || toMarkdown(s.schema.description);
             if (s.schema.enum) {
               const idx = s.schema.enum.indexOf(getNodeValue(node));

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -1,6 +1,9 @@
 import { JSONSchema } from '../jsonSchema';
 
 export function getSchemaTypeName(schema: JSONSchema): string {
+  if (schema.title) {
+    return schema.title;
+  }
   if (schema.$id) {
     const type = getSchemaRefTypeTitle(schema.$id);
     return type;
@@ -9,7 +12,7 @@ export function getSchemaTypeName(schema: JSONSchema): string {
     const type = getSchemaRefTypeTitle(schema.$ref || schema._$ref);
     return type;
   }
-  const typeStr = schema.title || (Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type); //object
+  const typeStr = schema.closestTitle || (Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type); //object
   return typeStr;
 }
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2541,6 +2541,7 @@ describe('Auto Completion Tests', () => {
       },
       required: ['type', 'options'],
       type: 'object',
+      description: 'Description1',
       title: 'Object1',
     };
     const obj2 = {
@@ -2585,7 +2586,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
+            value: 'Description1\n\n----\n\n```yaml\ntype: typeObj1\noptions:\n  label: \n```',
           },
           sortText: '_Object1',
         })
@@ -2631,7 +2632,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('Object1', 'type: typeObj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\n  type: typeObj1\n  options:\n    label: \n```',
+            value: 'Description1\n\n----\n\n```yaml\n  type: typeObj1\n  options:\n    label: \n```',
           },
           sortText: '_Object1',
         })
@@ -2670,7 +2671,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
+            value: 'Description1\n\n----\n\n```yaml\ntype: typeObj1\noptions:\n  label: \n```',
           },
           sortText: '_Object1',
         })
@@ -2690,7 +2691,7 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('Object1', 'options:\n  label: ', 1, 0, 1, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
-            value: '```yaml\noptions:\n  label: \n```',
+            value: 'Description1\n\n----\n\n```yaml\noptions:\n  label: \n```',
           },
           sortText: '_Object1',
         })

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2582,12 +2582,12 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('type', 'type: typeObj1', 0, 0, 0, 0, 10, 2, { documentation: '' })
       );
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
           },
-          sortText: '_obj1',
+          sortText: '_Object1',
         })
       );
       expect(result.items[2]).to.deep.equal(
@@ -2628,12 +2628,12 @@ describe('Auto Completion Tests', () => {
         createExpectedCompletion('type', 'type: typeObj1', 0, 2, 0, 2, 10, 2, { documentation: '' })
       );
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: typeObj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
+        createExpectedCompletion('Object1', 'type: typeObj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\n  type: typeObj1\n  options:\n    label: \n```',
           },
-          sortText: '_obj1',
+          sortText: '_Object1',
         })
       );
       expect(result.items[2]).to.deep.equal(
@@ -2667,12 +2667,12 @@ describe('Auto Completion Tests', () => {
 
       expect(result.items.length).equal(3);
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
+        createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\ntype: typeObj1\noptions:\n  label: \n```',
           },
-          sortText: '_obj1',
+          sortText: '_Object1',
         })
       );
     });
@@ -2687,12 +2687,12 @@ describe('Auto Completion Tests', () => {
 
       expect(result.items.length).equal(2);
       expect(result.items[1]).to.deep.equal(
-        createExpectedCompletion('obj1', 'options:\n  label: ', 1, 0, 1, 0, 7, 2, {
+        createExpectedCompletion('Object1', 'options:\n  label: ', 1, 0, 1, 0, 7, 2, {
           documentation: {
             kind: 'markdown',
             value: '```yaml\noptions:\n  label: \n```',
           },
-          sortText: '_obj1',
+          sortText: '_Object1',
         })
       );
     });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2541,6 +2541,7 @@ describe('Auto Completion Tests', () => {
       },
       required: ['type', 'options'],
       type: 'object',
+      title: 'Object1',
     };
     const obj2 = {
       properties: {


### PR DESCRIPTION
### What does this PR do?
 - The custom title of the suggestion item didn't work properly.
 - Add a description of the schema in 'object/parent' suggestion description. 

This PR fix logic of the `schema.title`.

I had a problem, that the previous `title` could be modified by title from parents. So `schema.title` could contain a title from its parent. And then I wasn't able to return the correct name of a suggestion item (display of the real title, name of the ref object, parent title).

So this PR adds a new `closestTitle` prop, that should cover previous functionality.

I went through all `schema.title` and tried to decide where to use `title` or `closesTitle`. Results of the UT are ok, but I will be better to check this from your side.

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
Modified one UT that covers this change