### PR TITLE
Add: show examples on hover.

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -102,8 +102,10 @@ export class YAMLHover {
 
         let title: string | undefined = undefined;
         let markdownDescription: string | undefined = undefined;
-        let markdownEnumValueDescription: string | undefined = undefined,
-          enumValue: string | undefined = undefined;
+        let markdownEnumValueDescription: string | undefined = undefined;
+        let enumValue: string | undefined = undefined;
+        const markdownExamples: string[] = [];
+
         matchingSchemas.every((s) => {
           if (s.node === node && !s.inverted && s.schema) {
             title = title || s.schema.title;
@@ -121,6 +123,11 @@ export class YAMLHover {
                   enumValue = JSON.stringify(enumValue);
                 }
               }
+            }
+            if (s.schema.examples) {
+              s.schema.examples.forEach((example) => {
+                markdownExamples.push(JSON.stringify(example));
+              });
             }
           }
           return true;
@@ -141,7 +148,16 @@ export class YAMLHover {
           }
           result += `\`${toMarkdownCodeBlock(enumValue)}\`: ${markdownEnumValueDescription}`;
         }
-
+        if (markdownExamples.length !== 0) {
+          if (result.length > 0) {
+            result += '\n\n';
+          }
+          result += 'Examples: [\n\n';
+          markdownExamples.forEach((example) => {
+            result += `\`\`\`${example}\`\`\`\n\n`;
+          });
+          result += ']';
+        }
         if (result.length > 0 && schema.schema.url) {
           result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;
         }

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -152,11 +152,10 @@ export class YAMLHover {
           if (result.length > 0) {
             result += '\n\n';
           }
-          result += 'Examples: [\n\n';
+          result += 'Examples:';
           markdownExamples.forEach((example) => {
-            result += `\`\`\`${example}\`\`\`\n\n`;
+            result += `\n\n\`\`\`${example}\`\`\``;
           });
-          result += ']';
         }
         if (result.length > 0 && schema.schema.url) {
           result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -426,6 +426,39 @@ storage:
       );
     });
 
+    it('Hover works on examples', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            type: 'string',
+            description: 'should return this description',
+            enum: ['cat', 'dog'],
+            examples: ['cat', 'dog'],
+          },
+        },
+      });
+      const content = 'animal:\n  cat';
+      const result = await parseSetup(content, 12);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Examples: [
+
+\`\`\`"cat"\`\`\`
+
+\`\`\`"dog"\`\`\`
+
+]
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('Hover on property next value on null', async () => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -447,13 +447,11 @@ storage:
         (result.contents as MarkupContent).value,
         `should return this description
 
-Examples: [
+Examples:
 
 \`\`\`"cat"\`\`\`
 
 \`\`\`"dog"\`\`\`
-
-]
 
 Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );


### PR DESCRIPTION
### What does this PR do?
If "examples" is defined in the schema, display it on the hover.

I think it useful to show what kind of input is expected for a string in user format.

### Is it tested? How?
A test was added.
