### PR TITLE
Remove data from unused anchor diagnostics

### DIFF
--- a/src/languageservice/services/validation/unused-anchors.ts
+++ b/src/languageservice/services/validation/unused-anchors.ts
@@ -41,7 +41,6 @@ export class UnusedAnchorsValidator implements AdditionalValidator {
           );
           const warningDiagnostic = Diagnostic.create(range, `Unused anchor "${aToken.source}"`, DiagnosticSeverity.Hint, 0);
           warningDiagnostic.tags = [DiagnosticTag.Unnecessary];
-          warningDiagnostic.data = { name: aToken.source };
           result.push(warningDiagnostic);
         }
       }

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -172,13 +172,13 @@ export class YamlCodeActions {
     const buffer = new TextBuffer(document);
     for (const diag of diagnostics) {
       if (diag.message.startsWith('Unused anchor') && diag.source === YAML_SOURCE) {
-        const { name } = diag.data as { name: string };
         const range = Range.create(diag.range.start, diag.range.end);
+        const actual = buffer.getText(range);
         const lineContent = buffer.getLineContent(range.end.line);
         const lastWhitespaceChar = getFirstNonWhitespaceCharacterAfterOffset(lineContent, range.end.character);
         range.end.character = lastWhitespaceChar;
         const action = CodeAction.create(
-          `Delete unused anchor: ${name}`,
+          `Delete unused anchor: ${actual}`,
           createWorkspaceEdit(document.uri, [TextEdit.del(range)]),
           CodeActionKind.QuickFix
         );

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -37,7 +37,6 @@ export function createDiagnosticWithData(
 
 export function createUnusedAnchorDiagnostic(
   message: string,
-  name: string,
   startLine: number,
   startCharacter: number,
   endLine: number,
@@ -53,7 +52,6 @@ export function createUnusedAnchorDiagnostic(
     'YAML'
   );
   diagnostic.tags = [DiagnosticTag.Unnecessary];
-  diagnostic.data = { name };
   return diagnostic;
 }
 

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -158,7 +158,7 @@ describe('CodeActions Tests', () => {
   describe('Remove Unused Anchor', () => {
     it('should generate proper action', () => {
       const doc = setupTextDocument('foo: &bar bar\n');
-      const diagnostics = [createUnusedAnchorDiagnostic('Unused anchor "&bar"', '&bar', 0, 5, 0, 9)];
+      const diagnostics = [createUnusedAnchorDiagnostic('Unused anchor "&bar"', 0, 5, 0, 9)];
       const params: CodeActionParams = {
         context: CodeActionContext.create(diagnostics),
         range: undefined,
@@ -172,7 +172,7 @@ describe('CodeActions Tests', () => {
 
     it('should delete all whitespace after unused anchor', () => {
       const doc = setupTextDocument('foo: &bar   \tbar\n');
-      const diagnostics = [createUnusedAnchorDiagnostic('Unused anchor "&bar"', '&bar', 0, 5, 0, 9)];
+      const diagnostics = [createUnusedAnchorDiagnostic('Unused anchor "&bar"', 0, 5, 0, 9)];
       const params: CodeActionParams = {
         context: CodeActionContext.create(diagnostics),
         range: undefined,

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -61,7 +61,7 @@ describe('YAML Validation Tests', () => {
       const result = await parseSetup(yaml);
       expect(result).is.not.empty;
       expect(result.length).to.be.equal(1);
-      expect(result[0]).deep.equal(createUnusedAnchorDiagnostic('Unused anchor "&bar"', '&bar', 0, 5, 0, 9));
+      expect(result[0]).deep.equal(createUnusedAnchorDiagnostic('Unused anchor "&bar"', 0, 5, 0, 9));
     });
 
     it('should not report used anchor', async () => {
@@ -85,10 +85,10 @@ some:
       expect(result).is.not.empty;
       expect(result.length).to.be.equal(4);
       expect(result).to.include.deep.members([
-        createUnusedAnchorDiagnostic('Unused anchor "&bar"', '&bar', 0, 5, 0, 9),
-        createUnusedAnchorDiagnostic('Unused anchor "&a"', '&a', 4, 2, 4, 4),
-        createUnusedAnchorDiagnostic('Unused anchor "&aa"', '&aa', 5, 0, 5, 3),
-        createUnusedAnchorDiagnostic('Unused anchor "&e"', '&e', 8, 4, 8, 6),
+        createUnusedAnchorDiagnostic('Unused anchor "&bar"', 0, 5, 0, 9),
+        createUnusedAnchorDiagnostic('Unused anchor "&a"', 4, 2, 4, 4),
+        createUnusedAnchorDiagnostic('Unused anchor "&aa"', 5, 0, 5, 3),
+        createUnusedAnchorDiagnostic('Unused anchor "&e"', 8, 4, 8, 6),
       ]);
     });
   });


### PR DESCRIPTION
### What does this PR do?

The anchor name was added as custom data. It’s unnecessary, because the name of the anchor can be determined from other values in the place where it’s used.

### What issues does this PR fix or reference?

Because Monaco Editor marker data doesn’t support custom data, this blocks supports code actions in monaco-yaml.

### Is it tested? How?

Manually using monaco-yaml and using tests.