### PR TITLE
Schema validation should check the object's oneOf if it has instead of the object type

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -602,7 +602,8 @@ function validate(
   originalSchema: JSONSchema,
   validationResult: ValidationResult,
   matchingSchemas: ISchemaCollector,
-  options: Options
+  options: Options,
+  isAdditionalPropertiesCheck?: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
   const { isKubernetes } = options;
@@ -646,6 +647,16 @@ function validate(
       return node.type === type || (type === 'integer' && node.type === 'number' && node.isInteger);
     }
 
+    function matchesSchemaType(schema: JSONSchema): boolean {
+      /* when schema type is object and it contains oneOf then needs to validate that particular types
+        reference issue 692
+      */
+      if (schema.type === 'object' && typeof schema.additionalProperties === 'object' && schema.additionalProperties.oneOf) {
+        return true;
+      }
+      return node.type === schema.type || (schema.type === 'integer' && node.type === 'number' && node.isInteger);
+    }
+
     if (Array.isArray(schema.type)) {
       if (!schema.type.some(matchesType)) {
         validationResult.problems.push({
@@ -659,7 +670,7 @@ function validate(
         });
       }
     } else if (schema.type) {
-      if (!matchesType(schema.type)) {
+      if (!matchesSchemaType(schema)) {
         //get more specific name than just object
         const schemaType = schema.type === 'object' ? getSchemaTypeName(schema) : schema.type;
         validationResult.problems.push({
@@ -677,6 +688,13 @@ function validate(
       for (const subSchemaRef of schema.allOf) {
         validate(node, asSchema(subSchemaRef), schema, validationResult, matchingSchemas, options);
       }
+    }
+    if (schema.additionalProperties && typeof schema.additionalProperties === 'object' && schema.additionalProperties.oneOf) {
+      const propertyValidationResult = new ValidationResult(isKubernetes);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      validate(node, <any>schema.additionalProperties, schema, propertyValidationResult, matchingSchemas, options, true);
+      validationResult.mergePropertyMatch(propertyValidationResult);
+      validationResult.mergeEnumValues(propertyValidationResult);
     }
     const notSchema = asSchema(schema.not);
     if (notSchema) {
@@ -727,7 +745,14 @@ function validate(
         } else if (isKubernetes) {
           bestMatch = alternativeComparison(subValidationResult, bestMatch, subSchema, subMatchingSchemas);
         } else {
-          bestMatch = genericComparison(maxOneMatch, subValidationResult, bestMatch, subSchema, subMatchingSchemas);
+          bestMatch = genericComparison(
+            maxOneMatch,
+            subValidationResult,
+            bestMatch,
+            subSchema,
+            subMatchingSchemas,
+            isAdditionalPropertiesCheck
+          );
         }
       }
 
@@ -1429,7 +1454,8 @@ function validate(
       matchingSchemas: ISchemaCollector;
     },
     subSchema,
-    subMatchingSchemas
+    subMatchingSchemas,
+    isAdditionalPropertiesCheck?: boolean
   ): {
     schema: JSONSchema;
     validationResult: ValidationResult;
@@ -1442,7 +1468,7 @@ function validate(
       bestMatch.validationResult.propertiesValueMatches += subValidationResult.propertiesValueMatches;
     } else {
       const compareResult = subValidationResult.compareGeneric(bestMatch.validationResult);
-      if (compareResult > 0) {
+      if (compareResult > 0 || isAdditionalPropertiesCheck) {
         // our node is the best matching so far
         bestMatch = {
           schema: subSchema,

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -651,10 +651,12 @@ function validate(
       /* when schema type is object and it contains oneOf then needs to validate that particular types
         reference issue 692
       */
-      if (schema.type === 'object' && typeof schema.additionalProperties === 'object' && schema.additionalProperties.oneOf) {
+      const type = Array.isArray(schema.type) ? undefined : schema.type;
+      if (type === 'object' && typeof schema.additionalProperties === 'object' && schema.additionalProperties.oneOf) {
         return true;
+      } else if (type) {
+        return matchesType(type);
       }
-      return node.type === schema.type || (schema.type === 'integer' && node.type === 'number' && node.isInteger);
     }
 
     if (Array.isArray(schema.type)) {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1557,18 +1557,58 @@ obj:
         expect(result.length).to.eq(0);
       });
     });
+
+    it('schema should validate additionalProp oneOf', async () => {
+      const schema = {
+        type: 'object',
+        definitions: {
+          expressionSyntax: {
+            type: 'string',
+            pattern: '^\\$\\{\\{\\s*fromJSON\\(.*\\)\\s*\\}\\}$',
+          },
+        },
+        properties: {
+          env: {
+            type: 'object',
+            additionalProperties: {
+              oneOf: [
+                {
+                  type: 'object',
+                  additionalProperties: {
+                    oneOf: [
+                      {
+                        type: 'string',
+                      },
+                      {
+                        type: 'number',
+                      },
+                      {
+                        type: 'boolean',
+                      },
+                    ],
+                  },
+                  minProperties: 1,
+                },
+                {
+                  $ref: '#/definitions/expressionSyntax',
+                },
+              ],
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = `env: matrix.env`;
+      const result = await parseSetup(content);
+      expect(result.length).to.eq(1);
+      assert.deepStrictEqual(
+        result[0].message,
+        'String does not match the pattern of "^\\$\\{\\{\\s*fromJSON\\(.*\\)\\s*\\}\\}$".'
+      );
+    });
   });
 
   describe('Bug fixes', () => {
-    it('should handle not valid schema object', async () => {
-      const schema = 'Foo';
-      languageService.addSchema(SCHEMA_ID, schema as JSONSchema);
-      const content = `foo: bar`;
-      const result = await parseSetup(content);
-      expect(result).to.be.empty;
-      expect(telemetry.messages).to.be.empty;
-    });
-
     it('should handle bad schema refs', async () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?

The PR will check the oneOf array and do the type check against the schemas mentioned over it if the particular schema object has, instead of directly check the schema object type.

### What issues does this PR fix or reference?

https://github.com/redhat-developer/vscode-yaml/issues/692

### Is it tested? How?
Yes with UT
