### PR TITLE
fix: defaultSnippets insert text

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "build:libs": "yarn compile:umd && yarn compile:esm",
     "compile:umd": "tsc -p ./tsconfig.umd.json",
     "compile:esm": "tsc -p ./tsconfig.esm.json",
-    "check-dependencies": "node ./scripts/check-dependencies.js"
+    "check-dependencies": "node ./scripts/check-dependencies.js",
+    "pull-remote": "git pull https://github.com/redhat-developer/yaml-language-server.git main"
   },
   "nyc": {
     "extension": [

--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -71,6 +71,7 @@ export interface JSONSchema {
     markdownDescription?: string;
     type?: string;
     suggestionKind?: CompletionItemKind;
+    sortText?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     body?: any;
     bodyText?: string;

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1342,7 +1342,7 @@ export class YamlCompletion {
       }
       return value;
     };
-    return stringifyObject(value, '', replacer, settings, depth) + separatorAfter;
+    return stringifyObject(value, '', replacer, { ...settings, indentation: this.indentation }, depth) + separatorAfter;
   }
 
   private addBooleanValueCompletion(value: boolean, separatorAfter: string, collector: CompletionsCollector): void {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1318,6 +1318,7 @@ export class YamlCompletion {
         collector.add({
           kind: s.suggestionKind || this.getSuggestionKind(type),
           label,
+          sortText: s.sortText || s.label,
           documentation: this.fromMarkup(s.markdownDescription) || s.description,
           insertText,
           insertTextFormat: InsertTextFormat.Snippet,

--- a/src/languageservice/utils/json.ts
+++ b/src/languageservice/utils/json.ts
@@ -32,15 +32,15 @@ export function stringifyObject(
       let result = '';
       for (let i = 0; i < obj.length; i++) {
         let pseudoObj = obj[i];
+        if (typeof obj[i] !== 'object') {
+          result += '\n' + newIndent + '- ' + stringifyLiteral(obj[i]);
+          continue;
+        }
         if (!Array.isArray(obj[i])) {
           pseudoObj = preprendToObject(obj[i], consecutiveArrays);
         }
-        result += newIndent + stringifyObject(pseudoObj, indent, stringifyLiteral, settings, (depth += 1), consecutiveArrays);
-        if (i < obj.length - 1) {
-          result += '\n';
-        }
+        result += stringifyObject(pseudoObj, indent, stringifyLiteral, settings, (depth += 1), consecutiveArrays);
       }
-      result += indent;
       return result;
     } else {
       const keys = Object.keys(obj);
@@ -50,18 +50,23 @@ export function stringifyObject(
       let result = (depth === 0 && settings.newLineFirst) || depth > 0 ? '\n' : '';
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
+        const isObject = typeof obj[key] === 'object';
+        const colonDelimiter = isObject ? ':' : ': '; // add space only when value is primitive
+        const parentArrayCompensation = isObject && /^\s|-/.test(key) ? '  ' : ''; // add extra space if parent is an array
+        const objectIndent = newIndent + parentArrayCompensation;
 
         // The first child of an array needs to be treated specially, otherwise identations will be off
         if (depth === 0 && i === 0 && !settings.indentFirstObject) {
-          result += indent + key + ': ' + stringifyObject(obj[key], newIndent, stringifyLiteral, settings, (depth += 1), 0);
+          const value = stringifyObject(obj[key], objectIndent, stringifyLiteral, settings, (depth += 1), 0);
+          result += indent + key + colonDelimiter + value;
         } else {
-          result += newIndent + key + ': ' + stringifyObject(obj[key], newIndent, stringifyLiteral, settings, (depth += 1), 0);
+          const value = stringifyObject(obj[key], objectIndent, stringifyLiteral, settings, (depth += 1), 0);
+          result += newIndent + key + colonDelimiter + value;
         }
         if (i < keys.length - 1) {
           result += '\n';
         }
       }
-      result += indent;
       return result;
     }
   }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -551,7 +551,7 @@ describe('Auto Completion Tests', () => {
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
-            assert.equal(result.items[0].insertText, '\n  myOtherSample: ');
+            assert.equal(result.items[0].insertText, '\n  myOtherSample:');
             assert.equal((result.items[0].documentation as MarkupContent).value, 'snippet\n```yaml\nmyOtherSample:\n```\n');
           })
           .then(done, done);

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -116,6 +116,16 @@ describe('Default Snippet Tests', () => {
         })
         .then(done, done);
     });
+    it('Snippet custom sort', (done) => {
+      const content = 'arrayNestedObjectSnippet:\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.strictEqual(result.items.length, 1);
+          assert.strictEqual(result.items[0].sortText, 'custom');
+        })
+        .then(done, done);
+    });
 
     it('Snippet in object schema should autocomplete on next line ', (done) => {
       const content = 'object:\n  ';
@@ -199,7 +209,7 @@ describe('Default Snippet Tests', () => {
           // eslint-disable-next-line
           assert.equal(
             result.items[0].insertText,
-            '\n  name: $1\n  taskRef: \n    name: apply-manifests  \n  resources: \n    inputs:       \n      - name: source\n        resource: $3          \n  params:     \n    - name: manifest_dir\n      value: $2    '
+            '\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
           );
         })
         .then(done, done);
@@ -210,12 +220,12 @@ describe('Default Snippet Tests', () => {
       const completion = parseSetup(content, 3);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 11); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 14); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[4].label, 'longSnippet');
           // eslint-disable-next-line
           assert.equal(
             result.items[4].insertText,
-            'longSnippet:\n  name: $1\n  taskRef: \n    name: apply-manifests  \n  resources: \n    inputs:       \n      - name: source\n        resource: $3          \n  params:     \n    - name: manifest_dir\n      value: $2    '
+            'longSnippet:\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
           );
         })
         .then(done, done);
@@ -226,12 +236,8 @@ describe('Default Snippet Tests', () => {
       const completion = parseSetup(content, 11);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 11); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[5].label, 'arrayArraySnippet');
-          assert.equal(
-            result.items[5].insertText,
-            'arrayArraySnippet:\n  apple:         \n    - - name: source\n        resource: $3      '
-          );
+          assert.equal(result.items[5].insertText, 'arrayArraySnippet:\n  apple:\n    - - name: source\n        resource: $3');
         })
         .then(done, done);
     });
@@ -243,7 +249,7 @@ describe('Default Snippet Tests', () => {
         .then(function (result) {
           assert.equal(result.items.length, 1);
           assert.equal(result.items[0].label, 'Array Array Snippet');
-          assert.equal(result.items[0].insertText, '\n  apple:         \n    - - name: source\n        resource: $3      ');
+          assert.equal(result.items[0].insertText, '\n  apple:\n    - - name: source\n        resource: $3');
         })
         .then(done, done);
     });
@@ -255,7 +261,43 @@ describe('Default Snippet Tests', () => {
         .then(function (result) {
           assert.equal(result.items.length, 1);
           assert.equal(result.items[0].label, 'Array Array Snippet');
-          assert.equal(result.items[0].insertText, 'apple:     \n  - - name: source\n      resource: $3');
+          assert.equal(result.items[0].insertText, 'apple:\n  - - name: source\n      resource: $3');
+        })
+        .then(done, done);
+    });
+
+    it('Test array of strings', (done) => {
+      const content = 'arrayStringSnippet:\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(result.items[0].insertText, 'fruits:\n  - banana\n  - orange');
+        })
+        .then(done, done);
+    });
+
+    it('Test array nested object indented completion', (done) => {
+      const content = 'arrayNestedObjectSnippet:\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(
+            result.items[0].insertText,
+            'apple:\n  - name: source\n    resource:\n      prop1: value1\n      prop2: value2'
+          );
+        })
+        .then(done, done);
+    });
+
+    it('Test array of objects extra new line', (done) => {
+      const content = 'arrayObjectSnippet:\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(result.items[0].insertText, 'apple:\n  - name: source\n  - name: source2');
         })
         .then(done, done);
     });

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -99,6 +99,56 @@
         }
       ]
     },
+    "arrayStringSnippet": {
+      "type": "object",
+      "defaultSnippets": [
+        {
+          "label": "Array",
+          "body": {
+            "fruits": ["banana", "orange"]
+          }
+        }
+      ]
+    },
+    "arrayObjectSnippet": {
+      "type": "object",
+      "defaultSnippets": [
+        {
+          "label": "Array",
+          "body": {
+            "apple": [
+              {
+                "name": "source"
+              },
+              {
+                "name": "source2"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "arrayNestedObjectSnippet": {
+      "type": "object",
+      "defaultSnippets": [
+        {
+          "label": "Array Object Snippet",
+          "description": "Task",
+          "sortText": "custom",
+          "body": {
+            "apple": [
+              {
+                "name": "source",
+                "resource": {
+                  "prop1": "value1",
+                  "prop2": "value2"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
     "simpleBooleanString": {
       "type": "object",
       "defaultSnippets": [


### PR DESCRIPTION
### What does this PR do?
fix various snippets problems:
 - array of strings that was split into chars
 - remove extra line between objects inside array
 - indent from nested object inside array
 - remove extra spaces after property colon

add property `sortText` into defaultSnippets, so it's possible to sort snippets inside code-completion panel

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added unit tests and fixed existing