### PR TITLE
Re-enable folding ranges

### DIFF
--- a/src/languageservice/services/yamlFolding.ts
+++ b/src/languageservice/services/yamlFolding.ts
@@ -15,15 +15,18 @@ export function getFoldingRanges(document: TextDocument, context: FoldingRangesC
   const result: FoldingRange[] = [];
   const doc = yamlDocumentsCache.getYamlDocument(document);
   for (const ymlDoc of doc.documents) {
+    if (doc.documents.length > 1) {
+      result.push(createNormalizedFolding(document, ymlDoc.root));
+    }
     ymlDoc.visit((node) => {
       if (
         (node.type === 'property' && node.valueNode.type === 'array') ||
         (node.type === 'object' && node.parent?.type === 'array')
       ) {
-        result.push(creteNormalizedFolding(document, node));
+        result.push(createNormalizedFolding(document, node));
       }
       if (node.type === 'property' && node.valueNode.type === 'object') {
-        result.push(creteNormalizedFolding(document, node));
+        result.push(createNormalizedFolding(document, node));
       }
 
       return true;
@@ -41,7 +44,7 @@ export function getFoldingRanges(document: TextDocument, context: FoldingRangesC
   return result.slice(0, context.rangeLimit);
 }
 
-function creteNormalizedFolding(document: TextDocument, node: ASTNode): FoldingRange {
+function createNormalizedFolding(document: TextDocument, node: ASTNode): FoldingRange {
   const startPos = document.positionAt(node.offset);
   let endPos = document.positionAt(node.offset + node.length);
   const textFragment = document.getText(Range.create(startPos, endPos));

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -109,8 +109,7 @@ export class YAMLServerInit {
         documentRangeFormattingProvider: false,
         definitionProvider: true,
         documentLinkProvider: {},
-        // disabled until we not get parser which parse comments as separate nodes
-        foldingRangeProvider: false,
+        foldingRangeProvider: true,
         codeActionProvider: true,
         codeLensProvider: {
           resolveProvider: false,

--- a/test/yamlFolding.test.ts
+++ b/test/yamlFolding.test.ts
@@ -48,6 +48,23 @@ describe('YAML Folding', () => {
     expect(ranges[0]).to.be.eql(FoldingRange.create(2, 3, 4, 11));
   });
 
+  it('should provide folding ranges for multiple documents', () => {
+    const yaml = `---\nname: jack\nage: 22\n---\ncwd: test\n`;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges.length).to.equal(2);
+    expect(ranges[0]).to.be.eql(FoldingRange.create(1, 2, 0, 7));
+    expect(ranges[1]).to.be.eql(FoldingRange.create(4, 4, 0, 9));
+  });
+
+  it('should not include comments on folding ranges', () => {
+    const yaml = `# a comment\nname: jack\n# age comment\nage: 22\n  - date: october`;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges.length).to.equal(1);
+    expect(ranges[0]).to.be.eql(FoldingRange.create(3, 4, 0, 17));
+  });
+
   it('should provide folding ranges for mapping in array', () => {
     const yaml = `
     foo: bar


### PR DESCRIPTION
### What does this PR do?
Enables folding ranges. Adds the ability to fold documents when there is more than one document. Adds tests for making sure comments are not part of a region.

### What issues does this PR fix or reference?

fixes https://github.com/redhat-developer/vscode-yaml/issues/413
fixes https://github.com/redhat-developer/vscode-yaml/issues/561

### Is it tested? How?

2 new tests are added to cover the case.