### PR TITLE
fix: differentiate similar schemas on completion

### DIFF
--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2707,7 +2707,7 @@ describe('Auto Completion Tests', () => {
         })
       );
     });
-    it('Should agregate suggested text without duplicities in insertText', async () => {
+    it('Should not agregate suggested text from different schemas', async () => {
       const schema = {
         definitions: { obj1, obj2 },
         anyOf: [
@@ -2723,7 +2723,7 @@ describe('Auto Completion Tests', () => {
       const content = '';
       const result = await parseSetup(content, content.length);
 
-      expect(result.items.length).equal(3);
+      expect(result.items.length).equal(4);
       expect(result.items[1]).to.deep.equal(
         createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
           documentation: {
@@ -2733,6 +2733,7 @@ describe('Auto Completion Tests', () => {
           sortText: '_Object1',
         })
       );
+      expect(result.items[1]).to.deep.equal(result.items[3]);
     });
     it('Should suggest rest of the parent object', async () => {
       const schema = {


### PR DESCRIPTION
### What does this PR do?
If multiple schemas inside of `anyOf` have the same final calculated schema name, 'parent/skeleton' autocompletion merge properties from different schema into one completion item.
 
wrong merge of multiple subschemas:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/38421337/158634123-aefa5137-5133-420c-9650-d75709d28a7c.png">

after fix:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/38421337/158634353-01c08434-eab3-4156-89f5-6105b7afc081.png">

note that a fixed example is not ideal. Schema creator should add titles into the schemas for a proper fix.
```json
"leftElement": {
  "anyOf": [
    {
      "type": "object",
      "properties": { ... },
      "title": "Option 1"
    },
    {
      "type": "object",
      "properties": { ... },
      "title": "Option 2"
    },
   ...
  ]  
```

### What issues does this PR fix or reference?


### Is it tested? How?
modified Unit test
 - the previous unit test doesn't make much sense 