### PR TITLE
Add enable disable option on schema validation for file level

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The following settings are supported:
 - `yaml.hover`: Enable/disable hover
 - `yaml.completion`: Enable/disable autocompletion
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
+    `patterns`: Array of file paths/patterns
+    `enabled`: true/false the schemavvalidation on the provided file paths/patterns. Default is true
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org/json/)
 - `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
@@ -91,7 +93,9 @@ you can do
 
 ```
 yaml.schemas: {
-    "https://json.schemastore.org/composer": "/myYamlFile.yaml"
+    "https://json.schemastore.org/composer": {
+      "patterns": ["/myYamlFile.yaml"]
+    }
 }
 ```
 
@@ -116,8 +120,23 @@ e.g.
 
 ```json
 yaml.schemas: {
-    "https://json.schemastore.org/composer": "/*"
-}
+    "https://json.schemastore.org/composer": {
+      "patterns":["/*"]
+    }
+
+```
+
+### Disable the schema validation:
+
+e.g.
+
+```json
+yaml.schemas: {
+    "https://json.schemastore.org/composer": {
+      "patterns": ["/*"],
+      "enabled": false
+    }
+
 ```
 
 e.g.
@@ -132,7 +151,9 @@ e.g.
 
 ```json
 yaml.schemas: {
-    "https://json.schemastore.org/composer": "/*",
+    "https://json.schemastore.org/composer": {
+      "patterns": ["/*"]
+    },
     "kubernetes": "/myYamlFile.yaml"
 }
 ```
@@ -141,7 +162,10 @@ On Windows with full path:
 
 ```json
 yaml.schemas: {
-    "C:\\Users\\user\\Documents\\custom_schema.json": "someFilePattern.yaml",
+    "C:\\Users\\user\\Documents\\custom_schema.json": {
+      "patterns": ["someFilePattern.yaml"],
+      "enabled": false
+    },
 }
 ```
 
@@ -149,14 +173,19 @@ On Mac/Linux with full path:
 
 ```json
 yaml.schemas: {
-    "/home/user/custom_schema.json": "someFilePattern.yaml",
+    "/home/user/custom_schema.json": {
+      "patterns": ["someFilePattern.yaml"],
+      "enabled": false
+    },
 }
 ```
 
 Since `0.11.0` YAML Schemas can be used for validation:
 
 ```json
- "/home/user/custom_schema.yaml": "someFilePattern.yaml"
+ "/home/user/custom_schema.yaml": {
+   "patterns": ["someFilePattern.yaml"]
+ }
 ```
 
 A schema can be associated with multiple globs using a json array, e.g.
@@ -171,10 +200,18 @@ e.g.
 
 ```json
 "yaml.schemas": {
-    "http://json.schemastore.org/composer": ["/*"],
-    "file:///home/johnd/some-schema.json": ["some.yaml"],
-    "../relative/path/schema.json": ["/config*.yaml"],
-    "/Users/johnd/some-schema.json": ["some.yaml"],
+    "http://json.schemastore.org/composer": {
+      "patterns": ["/*"]
+    },
+    "file:///home/johnd/some-schema.json": {
+      "patterns": ["some.yaml"]
+    },
+    "../relative/path/schema.json": {
+      "patterns": ["/config*.yaml"]
+    },
+    "/Users/johnd/some-schema.json": {
+      "patterns": ["some.yaml"]
+    },
 }
 ```
 
@@ -190,7 +227,9 @@ e.g.
 
 ```json
 "yaml.schemas": {
-    "http://json.schemastore.org/composer": ["/*"],
+    "http://json.schemastore.org/composer": {
+      "patterns": ["/*"],
+    },
     "kubernetes": ["/myYamlFile.yaml"]
 }
 ```

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -109,6 +109,7 @@ export class SettingsHandler {
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
+    this.yamlSettings.yamlFilesShoudNotValidate = [];
 
     let tabSize = 2;
     if (settings.vscodeEditor) {
@@ -119,12 +120,20 @@ export class SettingsHandler {
     if (settings.yamlEditor && settings.yamlEditor['editor.tabSize']) {
       this.yamlSettings.indentation = ' '.repeat(tabSize);
     }
-
     for (const uri in this.yamlSettings.yamlConfigurationSettings) {
       const globPattern = this.yamlSettings.yamlConfigurationSettings[uri];
-
+      const files = globPattern.patterns
+        ? Array.isArray(globPattern.patterns)
+          ? globPattern.patterns
+          : [globPattern.patterns]
+        : Array.isArray(globPattern)
+        ? globPattern
+        : [globPattern];
+      if (globPattern.enabled !== undefined && globPattern.enabled === false) {
+        this.yamlSettings.yamlFilesShoudNotValidate.push(...files);
+      }
       const schemaObj = {
-        fileMatch: Array.isArray(globPattern) ? globPattern : [globPattern],
+        fileMatch: files,
         uri: checkSchemaURI(this.yamlSettings.workspaceFolders, this.yamlSettings.workspaceRoot, uri, this.telemetry),
       };
       this.yamlSettings.schemaConfigurationSettings.push(schemaObj);
@@ -237,6 +246,7 @@ export class SettingsHandler {
       disableAdditionalProperties: this.yamlSettings.disableAdditionalProperties,
       disableDefaultProperties: this.yamlSettings.disableDefaultProperties,
       yamlVersion: this.yamlSettings.yamlVersion,
+      yamlFilesShoudNotValidate: this.yamlSettings.yamlFilesShoudNotValidate,
     };
 
     if (this.yamlSettings.schemaAssociations) {

--- a/src/languageservice/parser/ast-converter.ts
+++ b/src/languageservice/parser/ast-converter.ts
@@ -42,7 +42,7 @@ export function convertAST(parent: ASTNode, node: YamlNode, doc: Document, lineC
   }
 
   if (!node) {
-    return;
+    return null;
   }
   if (isMap(node)) {
     return convertMap(node, parent, doc, lineCounter);

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1183,7 +1183,7 @@ function validate(
 
     if (Array.isArray(schema.required)) {
       for (const propertyName of schema.required) {
-        if (!seenKeys[propertyName]) {
+        if (seenKeys[propertyName] === undefined) {
           const keyNode = node.parent && node.parent.type === 'property' && node.parent.keyNode;
           const location = keyNode ? { offset: keyNode.offset, length: keyNode.length } : { offset: node.offset, length: 1 };
           validationResult.problems.push({

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -102,6 +102,11 @@ export interface LanguageSettings {
    * Default yaml lang version
    */
   yamlVersion?: YamlVersion;
+
+  /**
+   * list of files should not validate
+   */
+  yamlFilesShoudNotValidate?: string[];
 }
 
 export interface WorkspaceContextService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -41,6 +41,8 @@ export interface Settings {
 
 export interface JSONSchemaSettings {
   fileMatch?: string[];
+  patterns?: string;
+  enabled?: boolean;
   url?: string;
   schema?: JSONSchema;
 }
@@ -60,6 +62,7 @@ export class SettingsState {
     printWidth: 80,
     enable: true,
   } as CustomFormatterOptions;
+  yamlFilesShoudNotValidate: string[] = [];
   yamlShouldHover = true;
   yamlShouldCompletion = true;
   schemaStoreSettings = [];

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -453,6 +453,54 @@ describe('Validation Tests', () => {
     });
   });
 
+  describe('Null tests', () => {
+    it('Basic test on nodes with null', (done) => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          columns: {
+            type: 'object',
+            patternProperties: {
+              '^[a-zA-Z]+$': {
+                type: 'object',
+                properties: {
+                  int: {
+                    type: null,
+                  },
+                  long: {
+                    type: null,
+                  },
+                  id: {
+                    type: null,
+                  },
+                  unique: {
+                    type: null,
+                  },
+                },
+                oneOf: [
+                  {
+                    required: ['int'],
+                  },
+                  {
+                    required: ['long'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      const content = 'columns:\n  ColumnA: { int, id }\n  ColumnB: { long, unique }\n  ColumnC: { long, unique }';
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          assert.equal(result.length, 0);
+        })
+        .then(done, done);
+    });
+  });
+
   describe('Object tests', () => {
     it('Basic test on nodes with children', (done) => {
       languageService.addSchema(SCHEMA_ID, {

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -32,6 +32,7 @@ export function toFsPath(str: unknown): string {
 }
 
 export const TEST_URI = 'file://~/Desktop/vscode-k8s/test.yaml';
+export const DISABLE_TEST_URI = 'file://~/Desktop/vscode-k8s/testDisable.yaml';
 export const SCHEMA_ID = 'default_schema_id.yaml';
 
 export function setupTextDocument(content: string): TextDocument {
@@ -39,12 +40,14 @@ export function setupTextDocument(content: string): TextDocument {
   return TextDocument.create(TEST_URI, 'yaml', 0, content);
 }
 
-export function setupSchemaIDTextDocument(content: string, customSchemaID?: string): TextDocument {
+export function setupSchemaIDTextDocument(content: string, customSchemaID?: string, enableDisableOption?: boolean): TextDocument {
   yamlDocumentsCache.clear(); // clear cache
   if (customSchemaID) {
     return TextDocument.create(customSchemaID, 'yaml', 0, content);
   } else {
-    return TextDocument.create(SCHEMA_ID, 'yaml', 0, content);
+    return enableDisableOption
+      ? TextDocument.create(DISABLE_TEST_URI, 'yaml', 0, content)
+      : TextDocument.create(SCHEMA_ID, 'yaml', 0, content);
   }
 }
 
@@ -60,6 +63,7 @@ export interface TestLanguageServerSetup {
 
 export function setupLanguageService(languageSettings: LanguageSettings): TestLanguageServerSetup {
   const yamlSettings = new SettingsState();
+  languageSettings.yamlFilesShoudNotValidate = ['testDisable.yaml'];
   process.argv.push('--node-ipc');
   const connection = createConnection();
   const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promise<string> => {

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -23,9 +23,10 @@ describe('YAML Validation Tests', () => {
     yamlSettings = settings;
   });
 
-  function parseSetup(content: string, customSchemaID?: string): Promise<Diagnostic[]> {
-    const testTextDocument = setupSchemaIDTextDocument(content, customSchemaID);
+  function parseSetup(content: string, customSchemaID?: string, enableDisableOption?: boolean): Promise<Diagnostic[]> {
+    const testTextDocument = setupSchemaIDTextDocument(content, customSchemaID, enableDisableOption);
     yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
     return validationHandler.validateTextDocument(testTextDocument);
   }
@@ -90,6 +91,15 @@ some:
         createUnusedAnchorDiagnostic('Unused anchor "&aa"', 5, 0, 5, 3),
         createUnusedAnchorDiagnostic('Unused anchor "&e"', 8, 4, 8, 6),
       ]);
+    });
+  });
+
+  describe('Enable/Disable schema validation on Yaml File', () => {
+    it('Disable File', async () => {
+      const yaml = 'foo:\n\t- bar';
+      const result = await parseSetup(yaml, undefined, true);
+      expect(result).is.empty;
+      expect(result.length).to.be.equal(0);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

User can provide option on enable: true/false for schema validation on file path level

https://user-images.githubusercontent.com/93245779/159001884-74df1eeb-2f92-4c31-a73f-bbabd5a1e21e.mp4

### What issues does this PR fix or reference?

https://github.com/redhat-developer/vscode-yaml/issues/649

### Is it tested? How?
yes added UT
