### PR TITLE
fix: merge simple property completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -195,35 +195,48 @@ export class YamlCompletion {
         if (!isString(label)) {
           label = String(label);
         }
+
+        label = label.replace(/[\n]/g, '↵');
+        if (label.length > 60) {
+          const shortendedLabel = label.substr(0, 57).trim() + '...';
+          if (!proposed[shortendedLabel]) {
+            label = shortendedLabel;
+          }
+        }
+
+        // trim $1 from end of completion
+        if (completionItem.insertText.endsWith('$1') && !isForParentCompletion) {
+          completionItem.insertText = completionItem.insertText.substr(0, completionItem.insertText.length - 2);
+        }
+        if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
+          completionItem.textEdit = TextEdit.replace(overwriteRange, completionItem.insertText);
+        }
+
+        completionItem.label = label;
+
+        if (isForParentCompletion) {
+          addSuggestionForParent(completionItem);
+          return;
+        }
+
         const existing = proposed[label];
-        if (!existing || isForParentCompletion) {
-          label = label.replace(/[\n]/g, '↵');
-          if (label.length > 60) {
-            const shortendedLabel = label.substr(0, 57).trim() + '...';
-            if (!proposed[shortendedLabel]) {
-              label = shortendedLabel;
-            }
-          }
-
-          // trim $1 from end of completion
-          if (completionItem.insertText.endsWith('$1') && !isForParentCompletion) {
-            completionItem.insertText = completionItem.insertText.substr(0, completionItem.insertText.length - 2);
-          }
-          if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {
-            completionItem.textEdit = TextEdit.replace(overwriteRange, completionItem.insertText);
-          }
-
-          completionItem.label = label;
-
-          if (isForParentCompletion) {
-            addSuggestionForParent(completionItem);
-          }
-
-          if (!existing) {
+        const isInsertTextDifferent =
+          existing?.label !== existingProposeItem && existing?.insertText !== completionItem.insertText;
+        if (!existing) {
+          proposed[label] = completionItem;
+          result.items.push(completionItem);
+        } else if (isInsertTextDifferent) {
+          // try to merge simple insert values
+          const mergedText = this.mergeSimpleInsertTexts(label, existing.insertText, completionItem.insertText);
+          if (mergedText) {
+            this.updateCompletionText(existing, mergedText);
+          } else {
+            // add to result when it wasn't able to merge (even if the item is already there but with a different value)
             proposed[label] = completionItem;
             result.items.push(completionItem);
           }
-        } else if (!existing.documentation && completionItem.documentation) {
+        }
+        if (existing && !existing.documentation && completionItem.documentation) {
           existing.documentation = completionItem.documentation;
         }
       },
@@ -459,6 +472,45 @@ export class YamlCompletion {
     this.finalizeParentCompletion(result);
 
     return result;
+  }
+
+  updateCompletionText(completionItem: CompletionItem, text: string): void {
+    completionItem.insertText = text;
+    if (completionItem.textEdit) {
+      completionItem.textEdit.newText = text;
+    }
+  }
+
+  mergeSimpleInsertTexts(label: string, existingText: string, addingText: string): string | undefined {
+    const containsNewLineAfterColon = (value: string): boolean => {
+      return value.includes('\n');
+    };
+    if (containsNewLineAfterColon(existingText) || containsNewLineAfterColon(addingText)) {
+      return undefined;
+    }
+    const existingValues = this.getValuesFromInsertText(existingText);
+    const addingValues = this.getValuesFromInsertText(addingText);
+
+    const newValues = Array.prototype.concat(existingValues, addingValues);
+    if (!newValues.length) {
+      return undefined;
+    } else if (newValues.length === 1) {
+      return `${label}: \${1:${newValues[0]}}`;
+    } else {
+      return `${label}: \${1|${newValues.join(',')}|}`;
+    }
+  }
+
+  getValuesFromInsertText(insertText: string): string[] {
+    const value = insertText.substring(insertText.indexOf(':') + 1).trim();
+    if (!value) {
+      return [];
+    }
+    const valueMath = value.match(/^\${1[|:]([^|]*)+\|?}$/); // ${1|one,two,three|}  or  ${1:one}
+    if (valueMath) {
+      return valueMath[1].split(',');
+    }
+    return [value];
   }
 
   private finalizeParentCompletion(result: CompletionList): void {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2635,9 +2635,9 @@ describe('Auto Completion Tests', () => {
       const content = '';
       const result = await parseSetup(content, content.length);
 
-      expect(result.items.length).equal(4);
+      expect(result.items.length).equal(5);
       expect(result.items[0]).to.deep.equal(
-        createExpectedCompletion('type', 'type: typeObj1', 0, 0, 0, 0, 10, 2, { documentation: '' })
+        createExpectedCompletion('type', 'type: ${1|typeObj1,typeObj2|}', 0, 0, 0, 0, 10, 2, { documentation: '' })
       );
       expect(result.items[1]).to.deep.equal(
         createExpectedCompletion('Object1', 'type: typeObj1\noptions:\n  label: ', 0, 0, 0, 0, 7, 2, {
@@ -2660,6 +2660,9 @@ describe('Auto Completion Tests', () => {
           sortText: '_obj2',
         })
       );
+      expect(result.items[4]).to.deep.equal(
+        createExpectedCompletion('options', 'options:\n  description: ', 0, 0, 0, 0, 10, 2, { documentation: '' })
+      );
     });
 
     it('Should suggest complete object skeleton - array', async () => {
@@ -2681,9 +2684,9 @@ describe('Auto Completion Tests', () => {
       const content = '- ';
       const result = await parseSetup(content, content.length);
 
-      expect(result.items.length).equal(4);
+      expect(result.items.length).equal(5);
       expect(result.items[0]).to.deep.equal(
-        createExpectedCompletion('type', 'type: typeObj1', 0, 2, 0, 2, 10, 2, { documentation: '' })
+        createExpectedCompletion('type', 'type: ${1|typeObj1,typeObj2|}', 0, 2, 0, 2, 10, 2, { documentation: '' })
       );
       expect(result.items[1]).to.deep.equal(
         createExpectedCompletion('Object1', 'type: typeObj1\n  options:\n    label: ', 0, 2, 0, 2, 7, 2, {
@@ -2705,6 +2708,9 @@ describe('Auto Completion Tests', () => {
           },
           sortText: '_obj2',
         })
+      );
+      expect(result.items[4]).to.deep.equal(
+        createExpectedCompletion('options', 'options:\n    description: ', 0, 2, 0, 2, 10, 2, { documentation: '' })
       );
     });
     it('Should not agregate suggested text from different schemas', async () => {


### PR DESCRIPTION
### What does this PR do?
try to merge simple property completion from anyOf objects.
It's used syntax for choice in snippets: `${1|one,two,three|}` https://code.visualstudio.com/docs/editor/userdefinedsnippets#_choice

original:

https://user-images.githubusercontent.com/38421337/159483927-2ed0e8db-4407-4d5d-82aa-cf6daae38148.mov

after this PR:

https://user-images.githubusercontent.com/38421337/159483906-2efef386-a673-4189-9d82-e58fed23d0b6.mov


schema
```json
{
  "anyOf": [
    {
      "properties": {
        "prop": {
          "const": "const value"
        }
      }
    },
    {
      "properties": {
        "prop": {
          "const": "const value2"
        }
      }
    },
    {
      "properties": {
        "prop": {
          "type": "boolean",
          "default": false
        }
      }
    },
    {
      "properties": {
        "prop": {
          "type": "null"
        }
      }
    }
  ]
}

```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
modified existing and add new