### PR TITLE
Expose only pullConfiguration as API

### DIFF
--- a/src/languageserver/handlers/notificationHandlers.ts
+++ b/src/languageserver/handlers/notificationHandlers.ts
@@ -45,10 +45,10 @@ export class NotificationHandlers {
    * Update the associations in the server
    */
   private schemaAssociationNotificationHandler(associations: Record<string, string[]> | SchemaConfiguration[]): void {
+    console.trace('schemaAssociationsHandler : ' + JSON.stringify(associations));
     this.yamlSettings.schemaAssociations = associations;
     this.yamlSettings.specificValidatorPaths = [];
-    this.settingsHandler.setSchemaStoreSettingsIfNotSet();
-    this.settingsHandler.updateConfiguration();
+    this.settingsHandler.pullConfiguration().catch((error) => console.log(error));
   }
 
   /**


### PR DESCRIPTION
Changes the `SettingsHandler` and exposes only `pullConfiguration` as API. This makes it easy to keep a consistent Settings list which would otherwise be affected by multiple events causing race conditions.

Also modifies the tests to test through `pullConfiguration`.

### What issues does this PR fix or reference?
fixes https://github.com/redhat-developer/vscode-yaml/issues/721

### Is it tested? How?
Added a new case to cover schema store and modified existing tests.
