### PR TITLE
Select parent skeleton first before other properties are suggested

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following settings are supported:
 - `http.proxyStrictSSL`: If true the proxy server certificate should be verified against the list of supplied CAs. Default is false.
 - `[yaml].editor.formatOnType`: Enable/disable on type indent and auto formatting array
 - `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text
+- `yaml.selectParentSkeletonFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.\nWhen yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
 
 ##### Adding custom tags
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following settings are supported:
 - `http.proxyStrictSSL`: If true the proxy server certificate should be verified against the list of supplied CAs. Default is false.
 - `[yaml].editor.formatOnType`: Enable/disable on type indent and auto formatting array
 - `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text
-- `yaml.selectParentSkeletonFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.\nWhen yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
+- `yaml.suggest.parentSkeletonSelectedFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.\nWhen yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
 
 ##### Adding custom tags
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -105,7 +105,10 @@ export class SettingsHandler {
       }
       this.yamlSettings.disableAdditionalProperties = settings.yaml.disableAdditionalProperties;
       this.yamlSettings.disableDefaultProperties = settings.yaml.disableDefaultProperties;
-      this.yamlSettings.selectParentSkeletonFirst = settings.yaml.selectParentSkeletonFirst;
+
+      if (settings.yaml.suggest) {
+        this.yamlSettings.suggest.parentSkeletonSelectedFirst = settings.yaml.suggest.parentSkeletonSelectedFirst;
+      }
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -233,7 +236,7 @@ export class SettingsHandler {
       indentation: this.yamlSettings.indentation,
       disableAdditionalProperties: this.yamlSettings.disableAdditionalProperties,
       disableDefaultProperties: this.yamlSettings.disableDefaultProperties,
-      selectParentSkeletonFirst: this.yamlSettings.selectParentSkeletonFirst,
+      parentSkeletonSelectedFirst: this.yamlSettings.suggest.parentSkeletonSelectedFirst,
       yamlVersion: this.yamlSettings.yamlVersion,
     };
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -106,6 +106,7 @@ export class SettingsHandler {
       }
       this.yamlSettings.disableAdditionalProperties = settings.yaml.disableAdditionalProperties;
       this.yamlSettings.disableDefaultProperties = settings.yaml.disableDefaultProperties;
+      this.yamlSettings.selectParentSkeletonFirst = settings.yaml.selectParentSkeletonFirst;
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -236,6 +237,7 @@ export class SettingsHandler {
       indentation: this.yamlSettings.indentation,
       disableAdditionalProperties: this.yamlSettings.disableAdditionalProperties,
       disableDefaultProperties: this.yamlSettings.disableDefaultProperties,
+      selectParentSkeletonFirst: this.yamlSettings.selectParentSkeletonFirst,
       yamlVersion: this.yamlSettings.yamlVersion,
     };
 

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -73,7 +73,7 @@ export class YamlCompletion {
   private indentation: string;
   private supportsMarkdown: boolean | undefined;
   private disableDefaultProperties: boolean;
-  private selectParentSkeletonFirst: boolean;
+  private parentSkeletonSelectedFirst: boolean;
 
   constructor(
     private schemaService: YAMLSchemaService,
@@ -90,7 +90,7 @@ export class YamlCompletion {
     this.yamlVersion = languageSettings.yamlVersion;
     this.configuredIndentation = languageSettings.indentation;
     this.disableDefaultProperties = languageSettings.disableDefaultProperties;
-    this.selectParentSkeletonFirst = languageSettings.selectParentSkeletonFirst;
+    this.parentSkeletonSelectedFirst = languageSettings.parentSkeletonSelectedFirst;
   }
 
   async doComplete(document: TextDocument, position: Position, isKubernetes = false): Promise<CompletionList> {
@@ -591,8 +591,6 @@ export class YamlCompletion {
     const lineContent = textBuffer.getLineContent(overwriteRange.start.line);
     const hasOnlyWhitespace = lineContent.trim().length === 0;
     const hasColon = lineContent.indexOf(':') !== -1;
-    const isNodeNull =
-      (isScalar(originalNode) && originalNode.value === null) || (isMap(originalNode) && originalNode.items.length === 0);
     const nodeParent = doc.getParent(node);
     const matchOriginal = matchingSchemas.find((it) => it.node.internalNode === originalNode && it.schema.properties);
     for (const schema of matchingSchemas) {
@@ -679,8 +677,11 @@ export class YamlCompletion {
                       identCompensation + this.indentation
                     );
                   }
+                  const isNodeNull =
+                    (isScalar(originalNode) && originalNode.value === null) ||
+                    (isMap(originalNode) && originalNode.items.length === 0);
                   const existsParentCompletion = schema.schema.required?.length > 0;
-                  if (!this.selectParentSkeletonFirst || !isNodeNull || !existsParentCompletion) {
+                  if (!this.parentSkeletonSelectedFirst || !isNodeNull || !existsParentCompletion) {
                     collector.add({
                       kind: CompletionItemKind.Property,
                       label: key,

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -102,7 +102,7 @@ export interface LanguageSettings {
    * If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.
    * When yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
    */
-  selectParentSkeletonFirst?: boolean;
+  parentSkeletonSelectedFirst?: boolean;
 
   /**
    * Default yaml lang version

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -99,6 +99,12 @@ export interface LanguageSettings {
   disableDefaultProperties?: boolean;
 
   /**
+   * If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.
+   * When yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
+   */
+  selectParentSkeletonFirst?: boolean;
+
+  /**
    * Default yaml lang version
    */
   yamlVersion?: YamlVersion;

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -22,6 +22,7 @@ export interface Settings {
     };
     disableDefaultProperties: boolean;
     disableAdditionalProperties: boolean;
+    selectParentSkeletonFirst: boolean;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
   };
@@ -69,6 +70,7 @@ export class SettingsState {
   indentation: string | undefined = undefined;
   disableAdditionalProperties = false;
   disableDefaultProperties = false;
+  selectParentSkeletonFirst = false;
   maxItemsComputed = 5000;
 
   // File validation helpers

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -22,7 +22,9 @@ export interface Settings {
     };
     disableDefaultProperties: boolean;
     disableAdditionalProperties: boolean;
-    selectParentSkeletonFirst: boolean;
+    suggest: {
+      parentSkeletonSelectedFirst: boolean;
+    };
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
   };
@@ -70,7 +72,9 @@ export class SettingsState {
   indentation: string | undefined = undefined;
   disableAdditionalProperties = false;
   disableDefaultProperties = false;
-  selectParentSkeletonFirst = false;
+  suggest = {
+    parentSkeletonSelectedFirst: false,
+  };
   maxItemsComputed = 5000;
 
   // File validation helpers

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2789,5 +2789,108 @@ describe('Auto Completion Tests', () => {
         })
       );
     });
+    describe('Select parent skeleton first', () => {
+      beforeEach(() => {
+        const languageSettingsSetup = new ServiceSetup().withCompletion();
+        languageSettingsSetup.languageSettings.selectParentSkeletonFirst = true;
+        languageService.configure(languageSettingsSetup.languageSettings);
+      });
+      it('Should suggest complete object skeleton', async () => {
+        const schema = {
+          definitions: { obj1, obj2 },
+          anyOf: [
+            {
+              $ref: '#/definitions/obj1',
+            },
+            {
+              $ref: '#/definitions/obj2',
+            },
+          ],
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = '';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['Object1', 'obj2']);
+      });
+      it('Should suggest complete object skeleton - nested', async () => {
+        const schema = {
+          definitions: { obj1, obj2 },
+          properties: {
+            name: {
+              anyOf: [
+                {
+                  $ref: '#/definitions/obj1',
+                },
+                {
+                  $ref: '#/definitions/obj2',
+                },
+              ],
+            },
+          },
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'name:\n  ';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['Object1', 'obj2']);
+      });
+      it('Should suggest complete object skeleton - array', async () => {
+        const schema = {
+          definitions: { obj1, obj2 },
+          items: {
+            anyOf: [
+              {
+                $ref: '#/definitions/obj1',
+              },
+              {
+                $ref: '#/definitions/obj2',
+              },
+            ],
+          },
+          type: 'array',
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = '- ';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['Object1', 'obj2']);
+      });
+      it('Should suggest rest of the parent object', async () => {
+        const schema = {
+          definitions: { obj1 },
+          $ref: '#/definitions/obj1',
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'type: typeObj1\n';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['options', 'Object1']);
+      });
+      it('Should suggest all feature when user is typing', async () => {
+        const schema = {
+          definitions: { obj1 },
+          $ref: '#/definitions/obj1',
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'ty';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['type', 'options', 'Object1']);
+      });
+      it('Should suggest all properties in empty yaml with now required props', async () => {
+        const schema = {
+          properties: {
+            fruit: {},
+            vegetable: {},
+          },
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = '';
+        const result = await parseSetup(content, content.length);
+
+        expect(result.items.map((i) => i.label)).to.have.members(['fruit', 'vegetable']);
+      });
+    });
   });
 });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2798,7 +2798,7 @@ describe('Auto Completion Tests', () => {
     describe('Select parent skeleton first', () => {
       beforeEach(() => {
         const languageSettingsSetup = new ServiceSetup().withCompletion();
-        languageSettingsSetup.languageSettings.selectParentSkeletonFirst = true;
+        languageSettingsSetup.languageSettings.parentSkeletonSelectedFirst = true;
         languageService.configure(languageSettingsSetup.languageSettings);
       });
       it('Should suggest complete object skeleton', async () => {


### PR DESCRIPTION
### What does this PR do?
This functionality helps a less technical person not to get lost on completion when there are complicated schemas and many properties that can be used (see the last screen - there are too many options so the user should select the parent/skeleton first and don't have to care about all possible properties).

It little bit extends 'parent/skeleton' object completion.

This PR adds`yaml.selectParentSkeletonFirst`. If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.
When yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.

Not sure if it's useful for your users but it can help others (less technical creators).

### examples

suggest only skeletons because object is empty:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/38421337/161216850-299a15c9-d8fc-42c4-baaa-4d1c03db3007.png">

whit disabled property `yaml.selectParentSkeletonFirst` (default)
<img width="225" alt="image" src="https://user-images.githubusercontent.com/38421337/161217869-b6071b5b-3406-4897-a523-c65347fa33f9.png">


properties are suggested as usual when the user tries to write it:
![image](https://user-images.githubusercontent.com/38421337/161217112-2f241c64-855b-4b91-85bb-c2c8a939a976.png)

when the object is not empty, standard completion is displayed
<img width="285" alt="image" src="https://user-images.githubusercontent.com/38421337/161217294-144e72ff-9681-4b05-9d78-bf7b640b6511.png">

Note that I haven't created PR for yaml client yet. I can create it when you check this one.