### PR TITLE
Add schema validation failure severity setting

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -41,6 +41,7 @@ export class SingleYAMLDocument extends JSONDocument {
     const copy = new SingleYAMLDocument(this.lineCounter);
     copy.isKubernetes = this.isKubernetes;
     copy.disableAdditionalProperties = this.disableAdditionalProperties;
+    copy.validationFailureSeverity = this.validationFailureSeverity;
     copy.currentDocIndex = this.currentDocIndex;
     copy._lineComments = this.lineComments.slice();
     // this will re-create root node

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { Diagnostic, Position } from 'vscode-languageserver';
+import { Diagnostic, DiagnosticSeverity, Position } from 'vscode-languageserver';
 import { LanguageSettings } from '../yamlLanguageService';
 import { YAMLDocument, YamlVersion } from '../parser/yamlParser07';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
@@ -43,6 +43,7 @@ export class YAMLValidation {
   private customTags: string[];
   private jsonValidation;
   private disableAdditionalProperties: boolean;
+  private validationFailureSeverity: DiagnosticSeverity;
   private yamlVersion: YamlVersion;
   private additionalValidation: AdditionalValidation;
 
@@ -57,6 +58,7 @@ export class YAMLValidation {
   public configure(settings: LanguageSettings): void {
     if (settings) {
       this.validationEnabled = settings.validate;
+      this.validationFailureSeverity = settings.validationFailureSeverity;
       this.customTags = settings.customTags;
       this.disableAdditionalProperties = settings.disableAdditionalProperties;
       this.yamlVersion = settings.yamlVersion;
@@ -81,6 +83,7 @@ export class YAMLValidation {
         currentYAMLDoc.isKubernetes = isKubernetes;
         currentYAMLDoc.currentDocIndex = index;
         currentYAMLDoc.disableAdditionalProperties = this.disableAdditionalProperties;
+        currentYAMLDoc.validationFailureSeverity = this.validationFailureSeverity;
 
         const validation = await this.jsonValidation.doValidation(textDocument, currentYAMLDoc);
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -22,6 +22,7 @@ import {
   DocumentLink,
   CodeLens,
   DefinitionLink,
+  DiagnosticSeverity,
 } from 'vscode-languageserver-types';
 import { JSONSchema } from './jsonSchema';
 import { YAMLDocumentSymbols } from './services/documentSymbols';
@@ -75,6 +76,7 @@ export interface SchemasSettings {
 
 export interface LanguageSettings {
   validate?: boolean; //Setting for whether we want to validate the schema
+  validationFailureSeverity?: DiagnosticSeverity; //Setting for the severity level of a schema validation failure
   hover?: boolean; //Setting for whether we want to have hover results
   completion?: boolean; //Setting for whether we want to have completion results
   format?: boolean; //Setting for whether we want to have the formatter or not


### PR DESCRIPTION
### What does this PR do?
This change adds a setting to language services which allows the severity of a schema validation failure to be specified. The intent of the change is to allow the monaco-yaml package to set the severity level, and that package is using language services directly for its validation.

This does not change the language server, though maybe that should be changed as well? In the ValidationHandler's validateTextDocument function, I see the severity level being converted there.

### What issues does this PR fix or reference?
#668 

### Is it tested? How?
Existing tests pass, as the severity defaults to Warning. Verified tests fail if set to a different value.
