### PR TITLE
fix array completion in the middle of the empty text

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -316,7 +316,7 @@ export class YamlCompletion {
       let originalNode = node;
       if (node) {
         // when the array item value is null but the cursor is between '-' and null value (cursor is not at the end of the line)
-        if (isSeq(node) && node.items.length && isScalar(node.items[0])) {
+        if (isSeq(node) && node.items.length && isScalar(node.items[0]) && lineContent.includes('-')) {
           const nullNode = node.items[0];
           if (
             nullNode.value === null && // value is null

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2364,10 +2364,44 @@ describe('Auto Completion Tests', () => {
       });
 
       const content = 'test:\n  - and\n  - - ';
-      const completion = await parseSetup(content, 19);
+
+      const completion = await parseSetup(content, 20);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0]).eql(
-        createExpectedCompletion('and', 'and', 2, 4, 2, 5, 12, InsertTextFormat.Snippet, { documentation: undefined })
+        createExpectedCompletion('and', 'and', 2, 6, 2, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
+      );
+    });
+
+    it('should follow $ref in additionalItems: extra space after cursor', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            $ref: '#/definitions/Recur',
+          },
+        },
+        definitions: {
+          Recur: {
+            type: 'array',
+            items: [
+              {
+                type: 'string',
+                enum: ['and'],
+              },
+            ],
+            additionalItems: {
+              $ref: '#/definitions/Recur',
+            },
+          },
+        },
+      });
+
+      const content = 'test:\n  - and\n  - -   ';
+
+      const completion = await parseSetup(content, 20);
+      expect(completion.items).lengthOf(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('and', 'and', 2, 6, 2, 8, 12, InsertTextFormat.Snippet, { documentation: undefined })
       );
     });
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2541,6 +2541,19 @@ describe('Auto Completion Tests', () => {
         .then(done, done);
     });
 
+    it('Simple array object completion without "-" befor array empty item', (done) => {
+      const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'test_simpleArrayObject:\n  \n  -';
+      const completion = parseSetup(content, 'test_simpleArrayObject:\n  '.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(result.items[0].label, '- (array item)');
+        })
+        .then(done, done);
+    });
+
     it('Array anyOf two objects completion without "-" after array item', (done) => {
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       languageService.addSchema(SCHEMA_ID, schema);

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CompletionList, Position } from 'vscode-languageserver/node';
+import { CompletionList, Position, Range } from 'vscode-languageserver/node';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
@@ -469,6 +469,37 @@ objB:
       expect(completion.items[0].insertText).to.be.equal('obj1:\n  prop1: ');
       expect(completion.items[1].label).to.be.equal('obj1');
       expect(completion.items[1].insertText).to.be.equal('obj1:\n  prop2: ${1:value}');
+    });
+
+    it('should suggest object array when extra space is after cursor', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          arrayObj: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                item1: {
+                  type: 'string',
+                },
+                item2: {
+                  type: 'string',
+                },
+              },
+              required: ['item1', 'item2'],
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'arrayObj:\n  -   ';
+      const completion = await parseSetup(content, 1, 4);
+
+      expect(completion.items.length).equal(3);
+      expect(completion.items[1].textEdit).to.be.deep.equal({
+        newText: 'item1: $1\n  item2: $2',
+        range: Range.create(1, 4, 1, 6), // removes extra spaces after cursor
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
fix array completion when the cursor is in the middle of the empty text

before:

https://user-images.githubusercontent.com/38421337/161768169-198a26ce-d30b-48f7-bd42-5dcf724a6468.mov

after:

https://user-images.githubusercontent.com/38421337/161768203-082356fc-063a-4dab-9f2c-4687594bb28a.mov

schema for this test
```yaml
"arrayObj": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "item1": {
            "type": "string"
          },
          "item2": {
            "type": "string",
          }
        },
        "required": [
          "item1",
          "item2"
        ]
      }
    },
```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added UT, 
modified existing one