### PR TITLE
change completion that is invoked just after array symbol

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -71,6 +71,7 @@ export class YamlCompletion {
   private configuredIndentation: string | undefined;
   private yamlVersion: YamlVersion;
   private indentation: string;
+  private prefixIndentation = '';
   private supportsMarkdown: boolean | undefined;
   private disableDefaultProperties: boolean;
 
@@ -126,7 +127,8 @@ export class YamlCompletion {
 
     const currentWord = this.getCurrentWord(document, offset);
 
-    let overwriteRange = null;
+    this.prefixIndentation = '';
+    let overwriteRange: Range = null;
     if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);
       nodeStartPos.character += 1;
@@ -139,6 +141,9 @@ export class YamlCompletion {
         start.character -= 1;
       }
       overwriteRange = Range.create(start, document.positionAt(node.range[1]));
+    } else if (node && isScalar(node) && node.value === null && currentWord === '-') {
+      overwriteRange = Range.create(position, position);
+      this.prefixIndentation = ' ';
     } else {
       let overwriteStart = document.offsetAt(position) - currentWord.length;
       if (overwriteStart > 0 && document.getText()[overwriteStart - 1] === '"') {
@@ -217,6 +222,10 @@ export class YamlCompletion {
         if (isForParentCompletion) {
           addSuggestionForParent(completionItem);
           return;
+        }
+
+        if (this.prefixIndentation) {
+          this.updateCompletionText(completionItem, this.prefixIndentation + completionItem.insertText);
         }
 
         const existing = proposed[label];
@@ -408,6 +417,13 @@ export class YamlCompletion {
                     // eslint-disable-next-line no-self-assign
                     currentDoc.internalDocument = currentDoc.internalDocument;
                     node = map;
+                  } else if (lineContent.charAt(position.character - 1) === '-') {
+                    const map = this.createTempObjNode('', node, currentDoc);
+                    parent.delete(node);
+                    parent.add(map);
+                    // eslint-disable-next-line no-self-assign
+                    currentDoc.internalDocument = currentDoc.internalDocument;
+                    node = map;
                   } else {
                     node = parent;
                   }
@@ -547,9 +563,9 @@ export class YamlCompletion {
           insertText = insertText.substring(0, insertText.length - 2);
         }
 
-        completionItem.insertText = insertText;
+        completionItem.insertText = this.prefixIndentation + insertText;
         if (completionItem.textEdit) {
-          completionItem.textEdit.newText = insertText;
+          completionItem.textEdit.newText = completionItem.insertText;
         }
         // remove $x or use {$x:value} in documentation
         const mdText = insertText.replace(/\${[0-9]+[:|](.*)}/g, (s, arg) => arg).replace(/\$([0-9]+)/g, '');
@@ -628,6 +644,7 @@ export class YamlCompletion {
                       identCompensation = ' ' + sourceText.slice(indexOfSlash + 1, node.range[0]);
                     }
                   }
+                  identCompensation += this.prefixIndentation;
 
                   // if check that current node has last pair with "null" value and key witch match key from schema,
                   // and if schema has array definition it add completion item for array item creation

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -71,7 +71,7 @@ export class YamlCompletion {
   private configuredIndentation: string | undefined;
   private yamlVersion: YamlVersion;
   private indentation: string;
-  private prefixIndentation = '';
+  private arrayPrefixIndentation = '';
   private supportsMarkdown: boolean | undefined;
   private disableDefaultProperties: boolean;
 
@@ -127,7 +127,7 @@ export class YamlCompletion {
 
     const currentWord = this.getCurrentWord(document, offset);
 
-    this.prefixIndentation = '';
+    this.arrayPrefixIndentation = '';
     let overwriteRange: Range = null;
     if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);
@@ -143,7 +143,7 @@ export class YamlCompletion {
       overwriteRange = Range.create(start, document.positionAt(node.range[1]));
     } else if (node && isScalar(node) && node.value === null && currentWord === '-') {
       overwriteRange = Range.create(position, position);
-      this.prefixIndentation = ' ';
+      this.arrayPrefixIndentation = ' ';
     } else {
       let overwriteStart = document.offsetAt(position) - currentWord.length;
       if (overwriteStart > 0 && document.getText()[overwriteStart - 1] === '"') {
@@ -224,8 +224,8 @@ export class YamlCompletion {
           return;
         }
 
-        if (this.prefixIndentation) {
-          this.updateCompletionText(completionItem, this.prefixIndentation + completionItem.insertText);
+        if (this.arrayPrefixIndentation) {
+          this.updateCompletionText(completionItem, this.arrayPrefixIndentation + completionItem.insertText);
         }
 
         const existing = proposed[label];
@@ -563,7 +563,7 @@ export class YamlCompletion {
           insertText = insertText.substring(0, insertText.length - 2);
         }
 
-        completionItem.insertText = this.prefixIndentation + insertText;
+        completionItem.insertText = this.arrayPrefixIndentation + insertText;
         if (completionItem.textEdit) {
           completionItem.textEdit.newText = completionItem.insertText;
         }
@@ -644,7 +644,7 @@ export class YamlCompletion {
                       identCompensation = ' ' + sourceText.slice(indexOfSlash + 1, node.range[0]);
                     }
                   }
-                  identCompensation += this.prefixIndentation;
+                  identCompensation += this.arrayPrefixIndentation;
 
                   // if check that current node has last pair with "null" value and key witch match key from schema,
                   // and if schema has array definition it add completion item for array item creation

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1550,6 +1550,7 @@ describe('Auto Completion Tests', () => {
           rules: {
             type: 'array',
             items: {
+              title: 'rules item',
               type: 'object',
               properties: {
                 id: {
@@ -1607,9 +1608,10 @@ describe('Auto Completion Tests', () => {
       });
 
       const content = 'rules:\n    -\n';
-      const completion = await parseSetup(content, 11);
-      expect(completion.items[0].textEdit.newText).equal(
-        '- id: $1\n  nomination: $2\n  weight: $3\n  criteria:\n      - field: $4\n        operator: $5\n        operand: $6'
+      const completion = await parseSetup(content, 12);
+
+      expect(completion.items.find((i) => i.label === 'rules item').textEdit.newText).equal(
+        ' id: $1\n  nomination: $2\n  weight: ${3:0}\n  criteria:\n      - field: $4\n        operator: $5\n        operand: $6'
       );
     });
   });

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -981,8 +981,8 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- ', 1, 2, 1, 3, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
+              createExpectedCompletion('name', ' name: ', 1, 3, 1, 3, 10, 2, {
+                documentation: '',
               })
             );
           })
@@ -1299,7 +1299,7 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('Test', 'Test', 1, 2, 1, 3, 12, 2, {
+              createExpectedCompletion('Test', ' Test', 1, 3, 1, 3, 12, 2, {
                 documentation: undefined,
               })
             );
@@ -2446,8 +2446,9 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item)');
+          assert.equal(result.items.length, 2);
+          assert.equal(result.items[0].label, 'obj1');
+          assert.equal(result.items[0].insertText, ' obj1:\n    ');
         })
         .then(done, done);
     });
@@ -2472,8 +2473,9 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item)');
+          assert.equal(result.items.length, 2);
+          assert.equal(result.items[0].label, 'obj1');
+          assert.equal(result.items[0].insertText, ' obj1:\n    ');
         })
         .then(done, done);
     });
@@ -2501,8 +2503,9 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].label, '- (array item) obj1');
+          assert.equal(result.items.length, 4);
+          assert.equal(result.items[0].label, 'obj1');
+          assert.equal(result.items[0].insertText, ' obj1:\n    ');
         })
         .then(done, done);
     });
@@ -2527,8 +2530,9 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].label, '- (array item) obj1');
+          assert.equal(result.items.length, 4);
+          assert.equal(result.items[0].label, 'obj1');
+          assert.equal(result.items[0].insertText, ' obj1:\n    ');
         })
         .then(done, done);
     });


### PR DESCRIPTION
### What does this PR do?
unify how codecompletion is displayed in this two situations:
 - ` - #curstor`
 - ` -#curstor`

current implementation:

https://user-images.githubusercontent.com/38421337/161982187-22b1a7c8-3e16-498d-abf4-9c1810997e45.mov

after this update:

https://user-images.githubusercontent.com/38421337/161982355-9bbd70cb-4caf-4abe-8ab8-3511af1fa4ab.mov


### What issues does this PR fix or reference?
this PR extends:
https://github.com/redhat-developer/yaml-language-server/pull/696
https://github.com/redhat-developer/yaml-language-server/pull/697
but it's working separately 

### Is it tested? How?
modified existing unit tests
I also tested all 3 changes together. I didn't want to put it all together because it's quite different modifications. 