### PR TITLE
Fix folding for multiline strings

### DIFF
--- a/src/languageservice/services/yamlFolding.ts
+++ b/src/languageservice/services/yamlFolding.ts
@@ -19,20 +19,31 @@ export function getFoldingRanges(document: TextDocument, context: FoldingRangesC
       result.push(createNormalizedFolding(document, ymlDoc.root));
     }
     ymlDoc.visit((node) => {
-      if (
-        (node.type === 'property' && node.valueNode.type === 'array') ||
-        (node.type === 'object' && node.parent?.type === 'array')
-      ) {
+      if (node.type === 'object' && node.parent?.type === 'array') {
         result.push(createNormalizedFolding(document, node));
       }
-      if (node.type === 'property' && node.valueNode.type === 'object') {
-        result.push(createNormalizedFolding(document, node));
+      if (node.type === 'property' && node.valueNode) {
+        switch (node.valueNode.type) {
+          case 'array':
+          case 'object':
+            result.push(createNormalizedFolding(document, node));
+            break;
+          case 'string': {
+            // check if it is a multi-line string
+            const nodePosn = document.positionAt(node.offset);
+            const valuePosn = document.positionAt(node.valueNode.offset + node.valueNode.length);
+            if (nodePosn.line !== valuePosn.line) {
+              result.push(createNormalizedFolding(document, node));
+            }
+            break;
+          }
+          default:
+            return true;
+        }
       }
-
       return true;
     });
   }
-
   const rangeLimit = context && context.rangeLimit;
   if (typeof rangeLimit !== 'number' || result.length <= rangeLimit) {
     return result;

--- a/test/yamlFolding.test.ts
+++ b/test/yamlFolding.test.ts
@@ -58,11 +58,24 @@ describe('YAML Folding', () => {
   });
 
   it('should not include comments on folding ranges', () => {
-    const yaml = `# a comment\nname: jack\n# age comment\nage: 22\n  - date: october`;
+    const yaml = `# a comment\nname: jack\n# age comment\nage:\n  - october`;
     const doc = setupTextDocument(yaml);
     const ranges = getFoldingRanges(doc, context);
     expect(ranges.length).to.equal(1);
-    expect(ranges[0]).to.be.eql(FoldingRange.create(3, 4, 0, 17));
+    expect(ranges[0]).to.be.eql(FoldingRange.create(3, 4, 0, 11));
+  });
+
+  it('should provide folding ranges for multiline string', () => {
+    const yaml = `
+    foo: 
+          bar:
+    aaa:
+          bbb
+          zzz
+    `;
+    const doc = setupTextDocument(yaml);
+    const ranges = getFoldingRanges(doc, context);
+    expect(ranges).to.deep.include.members([FoldingRange.create(1, 2, 4, 14), FoldingRange.create(3, 5, 4, 13)]);
   });
 
   it('should provide folding ranges for mapping in array', () => {


### PR DESCRIPTION
Adds folding for multiline strings. Refactors the property folding logic. Adds a test for multiline strings.
### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/737

### Is it tested? How?
Added unit test for multiline string folding