### PR TITLE
Update yamlCompletion.ts

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -194,7 +194,7 @@ export class YamlCompletion {
 
         const isForParentCompletion = !!completionItem.parent;
         let label = completionItem.label;
-        if (!label) {
+        if (label === null || label === undefined) {
           // we receive not valid CompletionItem as `label` is mandatory field, so just ignore it
           console.warn(`Ignoring CompletionItem without label: ${JSON.stringify(completionItem)}`);
           return;


### PR DESCRIPTION
### What does this PR do?
When filtering items, items with `label` as a logical value type are left

### Is it tested? How?
none