### PR TITLE
ensure YAML version is set always before parsing

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -246,7 +246,7 @@ export class YamlDocuments {
   /**
    * Get cached YAMLDocument
    * @param document TextDocument to parse
-   * @param customTags YAML custom tags
+   * @param parserOptions YAML parserOptions
    * @param addRootObject if true and document is empty add empty object {} to force schema usage
    * @returns the YAMLDocument
    */

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -31,7 +31,7 @@ export function parse(text: string, parserOptions: ParserOptions = defaultOption
   const options: ParseOptions & DocumentOptions & SchemaOptions = {
     strict: false,
     customTags: getCustomTags(parserOptions.customTags),
-    version: parserOptions.yamlVersion,
+    version: parserOptions.yamlVersion ?? defaultOptions.yamlVersion,
     keepSourceTokens: true,
   };
   const composer = new Composer(options);

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -234,6 +234,17 @@ objB:
       expect(isMap(result)).is.true;
       expect(((result as YAMLMap).items[0].key as Scalar).value).eqls('bar');
     });
+
+    it('should parse document when no yamlVersion is provided', () => {
+      const doc = setupTextDocument('foo: bar');
+
+      const opts = {
+        customTags: ['some'],
+        yamlVersion: undefined,
+      };
+      const yamlDoc = documents.getYamlDocument(doc, opts);
+      expect(yamlDoc).is.not.undefined;
+    });
   });
 });
 


### PR DESCRIPTION
Adds a fallback to default if yamlVersion is not set on the options. Adds a test and fixes API doc.

fixes #711 
