### PR TITLE
schemas through files.association settings are enabled

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -43,6 +43,7 @@ export class SettingsHandler {
       { section: 'http' },
       { section: '[yaml]' },
       { section: 'editor' },
+      { section: 'files' },
     ]);
     const settings: Settings = {
       yaml: config[0],
@@ -52,6 +53,7 @@ export class SettingsHandler {
       },
       yamlEditor: config[2],
       vscodeEditor: config[3],
+      files: config[4],
     };
     await this.setConfiguration(settings);
   }
@@ -81,6 +83,13 @@ export class SettingsHandler {
         this.yamlSettings.schemaStoreEnabled = settings.yaml.schemaStore.enable;
         if (settings.yaml.schemaStore.url.length !== 0) {
           this.yamlSettings.schemaStoreUrl = settings.yaml.schemaStore.url;
+        }
+      }
+      if (settings.files?.associations) {
+        for (const [ext, languageId] of Object.entries(settings.files.associations)) {
+          if (languageId === 'yaml') {
+            this.yamlSettings.fileExtensions.push(ext);
+          }
         }
       }
       this.yamlSettings.yamlVersion = settings.yaml.yamlVersion ?? '1.2';
@@ -205,7 +214,11 @@ export class SettingsHandler {
         for (const fileMatch in schema.fileMatch) {
           const currFileMatch: string = schema.fileMatch[fileMatch];
           // If the schema is for files with a YAML extension, save the schema association
-          if (currFileMatch.indexOf('.yml') !== -1 || currFileMatch.indexOf('.yaml') !== -1) {
+          if (
+            this.yamlSettings.fileExtensions.findIndex((value) => {
+              return currFileMatch.indexOf(value) > -1;
+            }) > -1
+          ) {
             languageSettings.schemas.push({
               uri: schema.url,
               fileMatch: [currFileMatch],

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -40,6 +40,9 @@ export interface Settings {
   vscodeEditor: {
     detectIndentation: boolean;
   };
+  files: {
+    associations: Map<string, string>;
+  };
 }
 
 export interface JSONSchemaSettings {
@@ -97,6 +100,7 @@ export class SettingsState {
   yamlVersion: YamlVersion = '1.2';
   useSchemaSelectionRequests = false;
   hasWsChangeWatchedFileDynamicRegistration = false;
+  fileExtensions: string[] = ['.yml', '.yaml'];
 }
 
 export class TextDocumentTestManager extends TextDocuments<TextDocument> {


### PR DESCRIPTION
When a file is associated using `file.associations` setting with YAML language, any schemas that correspond to the association are enabled to be used from the schema store.


### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/747
and https://github.com/redhat-developer/vscode-yaml/issues/701

### Is it tested? How?
Adds 3 test cases
