### PR TITLE
fix: object with additional properties completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -892,6 +892,8 @@ export class YamlCompletion {
             if (propertySchema) {
               this.addSchemaValueCompletions(propertySchema, separatorAfter, collector, types);
             }
+          } else if (s.schema.additionalProperties) {
+            this.addSchemaValueCompletions(s.schema.additionalProperties, separatorAfter, collector, types);
           }
         }
       }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -519,4 +519,23 @@ objB:
       });
     });
   });
+  it('should suggest from additionalProperties', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      additionalProperties: {
+        anyOf: [
+          {
+            type: 'string',
+            const: 'test1',
+          },
+        ],
+      },
+    };
+    languageService.addSchema(SCHEMA_ID, schema);
+    const content = 'value: ';
+    const completion = await parseSetup(content, 0, content.length);
+
+    expect(completion.items.length).equal(1);
+    expect(completion.items[0].insertText).to.be.equal('test1');
+  });
 });


### PR DESCRIPTION
### What does this PR do?
add support for completion for an object that has a definition in `additionalProperties`


```
{
  type: 'object',
  additionalProperties: {
    anyOf: [
      {
        type: 'string',
        const: 'test1',
      },
    ],
  },
};
```

typescript that produces this schema:
```ts
Record<string, 'test1' | InterfaceXYZ>
```
### What issues does this PR fix or reference?
no ref

### Is it tested? How?
add UnitTest