### PR TITLE
Fixed auto complete even parameters not in the specific order

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -798,7 +798,7 @@ function validate(
       const val = getNodeValue(node);
       let enumValueMatch = false;
       for (const e of schema.enum) {
-        if (equals(val, e)) {
+        if (equals(val, e) || (node.value && e.startsWith(val))) {
           enumValueMatch = true;
           break;
         }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -265,6 +265,34 @@ objB:
     );
   });
 
+  it('Array of enum autocomplete of irregular order', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        apiVersion: {
+          type: 'string',
+        },
+        metadata: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+        kind: {
+          type: 'string',
+          enum: ['Pod', 'PodTemplate'],
+        },
+      },
+    });
+    const content = 'kind: Po';
+    const completion = await parseSetup(content, 1, 9);
+    expect(completion.items.length).equal(2);
+    expect(completion.items[0].insertText).equal('Pod');
+    expect(completion.items[1].insertText).equal('PodTemplate');
+  });
+
   it('Autocomplete indent on array when parent is array', async () => {
     languageService.addSchema(SCHEMA_ID, {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
This PR checks the enum values that matches started characters of node value on auto suggestions

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/705

### Is it tested? How?

Yes. With existing UT.
![image](https://user-images.githubusercontent.com/93245779/170661337-6e634a42-2a89-493c-82dd-4e6ed3e90fc4.png)


