### PR TITLE
fix: use virtual caret in tests

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -111,8 +111,9 @@ export class YamlCompletion {
     setKubernetesParserOption(doc.documents, isKubernetes);
 
     const offset = document.offsetAt(position);
+    const text = document.getText();
 
-    if (document.getText().charAt(offset - 1) === ':') {
+    if (text.charAt(offset - 1) === ':') {
       return Promise.resolve(result);
     }
 
@@ -138,7 +139,7 @@ export class YamlCompletion {
       overwriteRange = Range.create(nodeStartPos, nodeEndPos);
     } else if (node && isScalar(node) && node.value) {
       const start = document.positionAt(node.range[0]);
-      if (offset > 0 && start.character > 0 && document.getText().charAt(offset - 1) === '-') {
+      if (offset > 0 && start.character > 0 && text.charAt(offset - 1) === '-') {
         start.character -= 1;
       }
       overwriteRange = Range.create(start, document.positionAt(node.range[1]));
@@ -147,7 +148,7 @@ export class YamlCompletion {
       this.arrayPrefixIndentation = ' ';
     } else {
       let overwriteStart = document.offsetAt(position) - currentWord.length;
-      if (overwriteStart > 0 && document.getText()[overwriteStart - 1] === '"') {
+      if (overwriteStart > 0 && text[overwriteStart - 1] === '"') {
         overwriteStart--;
       }
       overwriteRange = Range.create(document.positionAt(overwriteStart), position);
@@ -495,7 +496,7 @@ export class YamlCompletion {
 
         this.addPropertyCompletions(schema, currentDoc, node, originalNode, '', collector, textBuffer, overwriteRange);
 
-        if (!schema && currentWord.length > 0 && document.getText().charAt(offset - currentWord.length - 1) !== '"') {
+        if (!schema && currentWord.length > 0 && text.charAt(offset - currentWord.length - 1) !== '"') {
           collector.add({
             kind: CompletionItemKind.Property,
             label: currentWord,

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -34,7 +34,19 @@ describe('Auto Completion Tests', () => {
     yamlSettings = settings;
   });
 
-  function parseSetup(content: string, position: number): Promise<CompletionList> {
+  /**
+   * Generates a completion list for the given document and caret (cursor) position.
+   * @param content The content of the document.
+   * @param position The position of the caret in the document.
+   * Alternatively, can be omitted if the caret is located in the content using the symbol `|:|`.
+   * @returns A list of valid completions.
+   */
+  function parseSetup(content: string, position?: number): Promise<CompletionList> {
+    if (typeof position === 'undefined') {
+      position = content.indexOf('|:|');
+      content = content.replace('|:|', '');
+    }
+
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -60,8 +72,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = '';
-        const completion = parseSetup(content, 0);
+        const content = '|:|';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -84,8 +96,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'na';
-        const completion = parseSetup(content, 2);
+        const content = 'na|:|';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -180,8 +192,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'name';
-        const completion = await parseSetup(content, 3);
+        const content = 'nam|:|e';
+        const completion = await parseSetup(content);
         assert.strictEqual(completion.items.length, 1);
         assert.deepStrictEqual(
           completion.items[0],
@@ -546,8 +558,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts: ';
-        const completion = parseSetup(content, content.length);
+        const content = 'scripts: |:|';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);


### PR DESCRIPTION
### What does this PR do?
_It improves core test infrastructure:_

While helping to fix several autocomplete bugs (eg #724) in the language server, it was difficult to understand where the "cursor" was placed in sample `content` within the `tests`. 

The existing code uses the following method signature, whereby the caller has to do the math on the `position` parameter to establish where the caret is placed:
```typescript
// Method
function parseSetup(content: string, position: number): ...

// Caller
const content = 'hello world this is great';
const completion = parseSetup(content, 10); // <---- Can you easily tell where the cursor is?
`
```
While this works, it is difficult to maintain since it's not easy to understand the test by just looking at the `content` (& without doing math)

This PR introduces the notion of a _virtual caret_, which is specified in the `content` itself.
The token `|:|` is chosen to be easily noticed, and not conflict with 'real' yaml

```typescript
// Method
function parseSetup(content: string, position?: number): ... // position optional if caret specified

// Caller
const content = 'hello worl|:|d this is great'; // Note embedded caret token `|:|` representing cursor pos
const completion = parseSetup(content); // Zero calories
`
```

### What issues does this PR fix or reference?
Tests are simpler to write and maintain since the cursor's position is explicit in the content.

### Is it tested? How?
The changed method is back-compatible, _so all existing tests continue to pass_.
However, I have updated one example `test` of each interesting scenario:
- When the caret is a _prefix_, eg `|:|abc`
- When the caret is a _postfix_, eg `abc|:|`
- When the caret is an _infix_, eg `ab|:|c`

If this PR is approved, I will update the other tests accordingly. I updated just a few tests for now to keep the noise down and the changes easy to identify.

cc @p-spacek