### PR TITLE
Add nova-yaml to extension readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ This repository only contains the server implementation. Here are some known cli
 - [LSP-yaml](https://packagecontrol.io/packages/LSP-yaml) for Sublime Text
 - [monaco-yaml](https://monaco-yaml.js.org) for Monaco editor
 - [Vim-EasyComplete](https://github.com/jayli/vim-easycomplete) for Vim/NeoVim
+- [nova-yaml](https://github.com/robb-j/nova-yaml/) for Nova
 
 ## Developer Support
 


### PR DESCRIPTION
### What does this PR do?

Add's a link to nova-yaml to the extension readme

### What issues does this PR fix or reference?

n/a

### Is it tested? How?

It's just a readme change
