### PR TITLE
fix: completion invoke when next line has an indented comment

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -137,7 +137,7 @@ export class SingleYAMLDocument extends JSONDocument {
       if (!range) {
         return;
       }
-      const diff = range[2] - offset;
+      const diff = range[1] - offset;
       if (maxOffset <= range[0] && diff <= 0 && Math.abs(diff) <= offsetDiff) {
         offsetDiff = Math.abs(diff);
         maxOffset = range[0];

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -554,7 +554,7 @@ objB:
             },
           },
         },
-      }
+      },
     };
 
     it('completion should handle indented comment on new line', async () => {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -540,29 +540,43 @@ objB:
   });
   
   describe('should suggest property before indented comment', () => {
-    it('Completion should handle indented comment on new line', async () => {
-      languageService.addSchema(SCHEMA_ID, {
-        type: 'object',
-        properties: {
-          example: {
-            type: 'object',
-            properties: {
-              prop1: {
-                type: 'string',
-              },
-              prop2: {
-                type: 'string',
-              },
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        example: {
+          type: 'object',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+            prop2: {
+              type: 'string',
             },
           },
         },
-      });
+      }
+    };
+
+    it('completion should handle indented comment on new line', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
       const content = 'example:\n  prop1: "test"\n  \n    #comment';
       const completion = await parseSetup(content, 2, 2);
       expect(completion.items.length).equal(1);
       expect(completion.items[0]).to.be.deep.equal(
-      createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
-          documentation: '',
+        createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
+          documentation: ''
+        })
+      );
+    });
+
+    it('completion should handle comment at same indent level on new line', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'example:\n  prop1: "test"\n  \n  #comment';
+      const completion = await parseSetup(content, 2, 2);
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).to.be.deep.equal(
+        createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
+          documentation: ''
         })
       );
     });

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -551,6 +551,9 @@ objB:
             prop2: {
               type: 'string',
             },
+            prop3: {
+              type: 'string',
+            },
           },
         },
       },
@@ -560,7 +563,7 @@ objB:
       languageService.addSchema(SCHEMA_ID, schema);
       const content = 'example:\n  prop1: "test"\n  \n    #comment';
       const completion = await parseSetup(content, 2, 2);
-      expect(completion.items.length).equal(1);
+      expect(completion.items.length).equal(2);
       expect(completion.items[0]).to.be.deep.equal(
         createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
           documentation: '',
@@ -571,6 +574,18 @@ objB:
     it('completion should handle comment at same indent level on new line', async () => {
       languageService.addSchema(SCHEMA_ID, schema);
       const content = 'example:\n  prop1: "test"\n  \n  #comment';
+      const completion = await parseSetup(content, 2, 2);
+      expect(completion.items.length).equal(2);
+      expect(completion.items[0]).to.be.deep.equal(
+        createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
+          documentation: '',
+        })
+      );
+    });
+
+    it('completion should handle suggestion without comment on next line', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'example:\n  prop1: "test"\n  \n  prop3: "test"';
       const completion = await parseSetup(content, 2, 2);
       expect(completion.items.length).equal(1);
       expect(completion.items[0]).to.be.deep.equal(

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CompletionList, Position, Range } from 'vscode-languageserver-types';
+import { CompletionItemKind, CompletionList, InsertTextFormat, Position, Range } from 'vscode-languageserver-types';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
@@ -537,5 +537,34 @@ objB:
 
     expect(completion.items.length).equal(1);
     expect(completion.items[0].insertText).to.be.equal('test1');
+  });
+  
+  describe('should suggest property before indented comment', () => {
+    it('Completion should handle indented comment on new line', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          example: {
+            type: 'object',
+            properties: {
+              prop1: {
+                type: 'string',
+              },
+              prop2: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      });
+      const content = 'example:\n  prop1: "test"\n  \n    #comment';
+      const completion = await parseSetup(content, 2, 2);
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).to.be.deep.equal(
+      createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
+          documentation: '',
+        })
+      );
+    });
   });
 });

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -538,7 +538,6 @@ objB:
     expect(completion.items.length).equal(1);
     expect(completion.items[0].insertText).to.be.equal('test1');
   });
-  
   describe('should suggest property before indented comment', () => {
     const schema: JSONSchema = {
       type: 'object',
@@ -564,7 +563,7 @@ objB:
       expect(completion.items.length).equal(1);
       expect(completion.items[0]).to.be.deep.equal(
         createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
-          documentation: ''
+          documentation: '',
         })
       );
     });
@@ -576,7 +575,7 @@ objB:
       expect(completion.items.length).equal(1);
       expect(completion.items[0]).to.be.deep.equal(
         createExpectedCompletion('prop2', 'prop2: ', 2, 2, 2, 2, CompletionItemKind.Property, InsertTextFormat.Snippet, {
-          documentation: ''
+          documentation: '',
         })
       );
     });


### PR DESCRIPTION
### What does this PR do?
fix: completion invoke when next line has an indented comment

The change for this was to evaluate `range[1]` (value-end) rather than `range[2]` (node-end, which may contain trivia such as comments) when trying to find the closest node.

```yaml
example:
  prop1: "test"
  # cursor here
    #comment
```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added unit tests
