### PR TITLE
fix: suggest prop of the object -based on not completed prop name

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -370,7 +370,7 @@ export class YamlCompletion {
                           currentDoc.internalDocument = currentDoc.internalDocument;
                         }
                       } else {
-                        currentDoc.internalDocument.set(parent.key, map);
+                        parent.value = map;
                         // eslint-disable-next-line no-self-assign
                         currentDoc.internalDocument = currentDoc.internalDocument;
                       }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -364,6 +364,7 @@ export class YamlCompletion {
                   if (parent.value === node) {
                     if (lineContent.trim().length > 0 && lineContent.indexOf(':') < 0) {
                       const map = this.createTempObjNode(currentWord, node, currentDoc);
+                      const parentParent = currentDoc.getParent(parent);
                       if (isSeq(currentDoc.internalDocument.contents)) {
                         const index = indexOf(currentDoc.internalDocument.contents, parent);
                         if (typeof index === 'number') {
@@ -371,8 +372,12 @@ export class YamlCompletion {
                           // eslint-disable-next-line no-self-assign
                           currentDoc.internalDocument = currentDoc.internalDocument;
                         }
+                      } else if (parentParent && (isMap(parentParent) || isSeq(parentParent))) {
+                        parentParent.set(parent.key, map);
+                        // eslint-disable-next-line no-self-assign
+                        currentDoc.internalDocument = currentDoc.internalDocument;
                       } else {
-                        parent.value = map;
+                        currentDoc.internalDocument.set(parent.key, map);
                         // eslint-disable-next-line no-self-assign
                         currentDoc.internalDocument = currentDoc.internalDocument;
                       }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -566,4 +566,52 @@ objB:
     expect(completion.items.length).equal(1);
     expect(completion.items[0].insertText).to.be.equal('test1');
   });
+
+  describe('should suggest prop of the object (based on not completed prop name)', () => {
+    const schema: JSONSchema = {
+      definitions: {
+        Obj: {
+          anyOf: [
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                prop1: { type: 'string' },
+              },
+              required: ['prop1'],
+            },
+          ],
+        },
+      },
+      properties: {
+        test1: {
+          properties: {
+            nested: { $ref: '#/definitions/Obj' },
+          },
+        },
+        test2: { $ref: '#/definitions/Obj' },
+      },
+    };
+    const content = `
+test2: 
+  pr
+test1:
+  nested: 
+    pr
+`;
+    it('nested object', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const completion = await parseSetup(content, 5, 6);
+
+      expect(completion.items.length).equal(2);
+      expect(completion.items[0].label).to.be.equal('prop1');
+    });
+    it('root object', async () => {
+      languageService.addSchema(SCHEMA_ID, schema);
+      const completion = await parseSetup(content, 2, 4);
+
+      expect(completion.items.length).equal(2);
+      expect(completion.items[0].label).to.be.equal('prop1');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
fix completion when property name is expected in nested object
```yaml
test2: 
  pr # 1 worked ok here
test1:
  nested: 
    pr # 2 didn't work, this PR fixes this
```

this PR fixes the # 2nd scenario and add UT for the # 1st example

note that I am not sure if there could be more issues in other places where the root is modifying (`currentDoc.internalDocument.set`) instead of modifying `parent`. 
It seems that this part of the code is not under the UTs, so if I try to comment all `currentDoc.internalDocument.set...` all tests will pass. So I am afraid and won't change others because not sure what yaml is behind.


### What issues does this PR fix or reference?
no ref

### Is it tested? How?
add UT for both examples