### PR TITLE
fix: update tests to use virtual caret

### DIFF
--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -45,7 +45,9 @@ describe('Auto Completion Tests', () => {
     if (typeof position === 'undefined') {
       position = content.indexOf('|:|');
       content = content.replace('|:|', '');
+      if (content.length) position--;
     }
+    // console.log('position:', position, '>' + content.substring(position) + '<');
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
@@ -192,7 +194,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'nam|:|e';
+        const content = 'name|:|';
         const completion = await parseSetup(content);
         assert.strictEqual(completion.items.length, 1);
         assert.deepStrictEqual(
@@ -353,8 +355,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sample';
-        const completion = parseSetup(content, 11);
+        const content = 'scripts:\n  s|:|ample';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -383,8 +385,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sam';
-        const completion = parseSetup(content, 11);
+        const content = 'scripts:\n  s|:|am';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -479,8 +481,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sample: test\n  myOther';
-        const completion = parseSetup(content, 31);
+        const content = 'scripts:\n  sample: test\n  myOthe|:|r';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -558,8 +560,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts: |:|';
-        const completion = parseSetup(content);
+        const content = 'scripts: ';
+        const completion = parseSetup(content, content.length);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -1180,8 +1182,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - name: test\n    e';
-        const completion = parseSetup(content, 27);
+        const content = 'authors:\n  - name: test\n    |:|e';
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -1688,8 +1690,8 @@ describe('Auto Completion Tests', () => {
           },
         },
       });
-      const content = 'fruit: App';
-      const completion = parseSetup(content, 9);
+      const content = 'fruit: App|:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -1955,8 +1957,8 @@ describe('Auto Completion Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n    sample: test\n    myOther';
-      const completion = await parseSetup(content, 34);
+      const content = 'scripts:\n    sample: test\n    myOth|:|er';
+      const completion = await parseSetup(content);
       assert.strictEqual(completion.items.length, 1);
       assert.deepStrictEqual(
         completion.items[0],
@@ -2118,8 +2120,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = '---\n- \n';
-      const completion = await parseSetup(content, 6);
+      const content = '---\n- \n|:|';
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0].label).eq('fooBar');
       expect(completion.items[0].insertText).eq('fooBar:\n    name: $1\n    aaa:\n      - $2');
@@ -2174,8 +2176,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'enum';
-      const completion = await parseSetup(content, 3);
+      const content = 'enum|:|';
+      const completion = await parseSetup(content);
 
       const enumItem = completion.items.find((i) => i.label === 'enum');
       expect(enumItem).to.not.undefined;
@@ -2197,7 +2199,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'fooBar: \n';
+      const content = 'fooBar: \n|:|';
       const completion = await parseSetup(content, 8);
 
       const testItem = completion.items.find((i) => i.label === 'test');

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -28,7 +28,14 @@ describe('Default Snippet Tests', () => {
   });
 
   describe('Snippet Tests', function () {
-    function parseSetup(content: string, position: number): Promise<CompletionList> {
+    function parseSetup(content: string, position?: number): Promise<CompletionList> {
+      if (typeof position === 'undefined') {
+        position = content.indexOf('|:|');
+        content = content.replace('|:|', '');
+        if (content.length) position--;
+      }
+      // console.log('position:', position, '>' + content.substring(position) + '<');
+
       const testTextDocument = setupSchemaIDTextDocument(content);
       yamlSettings.documents = new TextDocumentTestManager();
       (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -63,8 +70,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in array schema should autocomplete on same line as array', (done) => {
-      const content = 'array:  ';
-      const completion = parseSetup(content, 7);
+      const content = 'array:  |:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -156,8 +163,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in object schema should autocomplete on same line', (done) => {
-      const content = 'object:  ';
-      const completion = parseSetup(content, 8);
+      const content = 'object:  |:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -176,8 +183,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in string schema should autocomplete on same line', (done) => {
-      const content = 'string:  ';
-      const completion = parseSetup(content, 8);
+      const content = 'string:  |:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.notEqual(result.items.length, 0);
@@ -188,8 +195,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in boolean schema should autocomplete on same line', (done) => {
-      const content = 'boolean:  ';
-      const completion = parseSetup(content, 9);
+      const content = 'boolean:  |:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.notEqual(result.items.length, 0);
@@ -199,9 +206,9 @@ describe('Default Snippet Tests', () => {
         .then(done, done);
     });
 
-    it('Snippet in longSnipet schema should autocomplete on same line', (done) => {
-      const content = 'longSnippet:  ';
-      const completion = parseSetup(content, 13);
+    it('Snippet in longSnippet schema should autocomplete on same line', (done) => {
+      const content = 'longSnippet:  |:|';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -216,8 +223,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in short snippet schema should autocomplete on same line', (done) => {
-      const content = 'lon  ';
-      const completion = parseSetup(content, 3);
+      const content = 'lon |:| ';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 14); // This is just checking the total number of snippets in the defaultSnippets.json
@@ -232,8 +239,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test array of arrays on properties completion', (done) => {
-      const content = 'arrayArrayS  ';
-      const completion = parseSetup(content, 11);
+      const content = 'arrayArrayS |:| ';
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items[5].label, 'arrayArraySnippet');
@@ -327,8 +334,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('should preserve space after ":" with prefix', async () => {
-      const content = 'boolean: tr\n';
-      const result = await parseSetup(content, 9);
+      const content = 'boolean: t|:|r\n';
+      const result = await parseSetup(content);
 
       assert.notEqual(result.items.length, 0);
       assert.equal(result.items[0].label, 'My boolean item');

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -40,7 +40,14 @@ describe('Hover Tests', () => {
     languageService.deleteSchema(SCHEMA_ID);
   });
 
-  function parseSetup(content: string, position): Promise<Hover> {
+  function parseSetup(content: string, position?: number): Promise<Hover> {
+    if (typeof position === 'undefined') {
+      position = content.indexOf('|:|');
+      content = content.replace('|:|', '');
+      if (content.length) position--;
+    }
+    // console.log('position:', position, '>' + content.substring(position) + '<');
+
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -62,8 +69,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'cwd: test';
-      const hover = await parseSetup(content, 1);
+      const content = 'cw|:|d: test';
+      const hover = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(hover.contents), true);
       assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
@@ -84,8 +91,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'cwd: test';
-      const result = await parseSetup(content, 6);
+      const content = 'cwd: te|:|st';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -110,8 +117,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-      const result = await parseSetup(content, 15);
+      const content = 'scripts:\n  posti|:|nstall: test';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -136,8 +143,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-      const result = await parseSetup(content, 26);
+      const content = 'scripts:\n  postinstall: tes|:|t';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -163,9 +170,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-
-      const firstHover = await parseSetup(content, 3);
+      const content1 = 'scri|:|pts:\n  postinstall: test';
+      const firstHover = await parseSetup(content1);
 
       assert.strictEqual(MarkupContent.is(firstHover.contents), true);
       assert.strictEqual((firstHover.contents as MarkupContent).kind, 'markdown');
@@ -174,7 +180,8 @@ describe('Hover Tests', () => {
         `Contains custom hooks used to trigger other automated tools\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
 
-      const secondHover = await parseSetup(content, 15);
+      const content2 = 'scripts:\n  posti|:|nstall: test';
+      const secondHover = await parseSetup(content2);
 
       assert.strictEqual(MarkupContent.is(secondHover.contents), true);
       assert.strictEqual(
@@ -192,8 +199,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'analytics: true';
-      const result = await parseSetup(content, 3);
+      const content = 'anal|:|ytics: true';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -208,8 +215,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = '---\nanalytics: true\n...\n---\njson: test\n...';
-      const result = await parseSetup(content, 10);
+      const content = '---\nanalyti|:|cs: true\n...\n---\njson: test\n...';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -228,8 +235,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = '---\nanalytics: true\n...\n---\njson: test\n...';
-      const result = await parseSetup(content, 30);
+      const content = '---\nanalytics: true\n...\n---\njso|:|n: test\n...';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -243,8 +250,8 @@ describe('Hover Tests', () => {
         type: 'object',
         properties: {},
       });
-      const content = 'my_unknown_hover: test';
-      const result = await parseSetup(content, 1);
+      const content = 'my|:|_unknown_hover: test';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -255,8 +262,8 @@ describe('Hover Tests', () => {
         type: 'object',
         properties: {},
       });
-      const content = 'my_unknown_hover: test';
-      const result = await parseSetup(content, 21);
+      const content = 'my_unknown_hover: test|:|';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -280,8 +287,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'authors:\n  - name: Josh';
-      const result = await parseSetup(content, 14);
+      const content = 'authors:\n  - na|:|me: Josh';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -312,8 +319,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'authors:\n  - name: Josh\n  - email: jp';
-      const result = await parseSetup(content, 28);
+      const content = 'authors:\n  - name: Josh\n  - e|:|mail: jp';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -392,10 +399,10 @@ describe('Hover Tests', () => {
         },
       });
 
-      const content = `ignition:
+      const content1 = `ignition:
   proxy:
     no_proxy:
-      - 10.10.10.10
+      - 10.|:|10.10.10
       - service.local
 storage:
   raid:
@@ -404,14 +411,26 @@ storage:
         - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WX41A49H9FT4
         - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD`;
 
-      let result = await parseSetup(content, 43);
+      let result = await parseSetup(content1);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
         `#### no\\_proxy \\(list of strings\\):\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
 
-      result = await parseSetup(content, 160);
+      const content2 = `ignition:
+  proxy:
+    no_proxy:
+      - 10.10.10.10
+      - service.local
+storage:
+  raid:
+    - name: Raid
+      devices:
+        - /dev/disk/by-id/ata-WDC_WD1|:|0SPZX-80Z10T2_WD-WX41A49H9FT4
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD`;
+
+      result = await parseSetup(content2);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
@@ -429,8 +448,8 @@ storage:
           },
         },
       });
-      const content = 'childObject: \n';
-      const result = await parseSetup(content, 1);
+      const content = 'ch|:|ildObject: \n';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -451,8 +470,8 @@ storage:
           },
         },
       });
-      const content = 'animal:\n  cat';
-      const result = await parseSetup(content, 12);
+      const content = 'animal:\n  cat|:|';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -486,8 +505,8 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
           },
         },
       });
-      const content = 'childObject:\r\n  prop:\r\n  ';
-      const result = await parseSetup(content, 16);
+      const content = 'childObject:\r\n  p|:|rop:\r\n  ';
+      const result = await parseSetup(content);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
@@ -511,8 +530,8 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
   describe('Bug fixes', () => {
     it('should convert binary data correctly', async () => {
       const content =
-        'foo: [ !!binary R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs= ]\n';
-      const result = await parseSetup(content, 20);
+        'foo: [ !!binary R0lGO|:|DlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs= ]\n';
+      const result = await parseSetup(content);
       expect(telemetry.messages).to.be.empty;
       expect(result).to.be.null;
     });


### PR DESCRIPTION
### What does this PR do?
This is a follow-up to #722
* The previous PR introduced the concept of a _virtual caret_. However, I only updated a few tests in order to keep the noise low so the reviewer could easily see what was going on.
* This PR updates all relevant/remaining tests to use the new functionality. Note that some tests are not updated, for example when they specify an index that is out of range (see review comments)

### Is it tested? How?
Unit tests continue to pass.

I double-checked all `position` values one-by-one in this PR, by running `test.only()` for each edited test, and ensuring the old `position` matched the new. This was an onerous task, but the benefit is that we can be sure the old and new units are testing exactly the same thing. Please see the review notes for more detail.
