### PR TITLE
fix: update tests to use virtual caret

### DIFF
--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -42,10 +42,12 @@ describe('Auto Completion Tests', () => {
    * @returns A list of valid completions.
    */
   function parseSetup(content: string, position?: number): Promise<CompletionList> {
+    // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
     if (typeof position === 'undefined') {
-      position = content.indexOf('|:|');
-      content = content.replace('|:|', '');
+      position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+      content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
     }
+    // console.log('position:', position, content, '>' + content.substring(position) + '<');
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
@@ -72,8 +74,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = '|:|';
-        const completion = parseSetup(content);
+        const content = '';
+        const completion = parseSetup(content, 0);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -96,8 +98,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'na|:|';
-        const completion = parseSetup(content);
+        const content = 'na'; // len: 2
+        const completion = parseSetup(content, 2);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -121,7 +123,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'name';
+        const content = 'name'; // len: 4
         const completion = parseSetup(content, 10);
         completion
           .then(function (result) {
@@ -146,7 +148,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'name: ';
+        const content = 'name: '; // len: 6
         const completion = parseSetup(content, 12);
         completion
           .then(function (result) {
@@ -171,7 +173,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'name: ';
+        const content = 'name: '; // len: 6
         const completion = await parseSetup(content, 6);
         assert.strictEqual(completion.items.length, 1);
         assert.deepStrictEqual(
@@ -192,8 +194,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'nam|:|e';
-        const completion = await parseSetup(content);
+        const content = 'nam|e|'; // len: 4
+        const completion = await parseSetup(content); // 3
         assert.strictEqual(completion.items.length, 1);
         assert.deepStrictEqual(
           completion.items[0],
@@ -213,7 +215,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'name: ya';
+        const content = 'name: ya'; // len: 8
         const completion = parseSetup(content, 15);
         completion
           .then(function (result) {
@@ -237,7 +239,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'yaml: ';
+        const content = 'yaml: '; // len: 6
         const completion = parseSetup(content, 11);
         completion
           .then(function (result) {
@@ -267,7 +269,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'yaml: fal';
+        const content = 'yaml: fal'; // len: 9
         const completion = parseSetup(content, 11);
         completion
           .then(function (result) {
@@ -298,7 +300,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'timeout: ';
+        const content = 'timeout: '; // len: 9
         const completion = parseSetup(content, 9);
         completion
           .then(function (result) {
@@ -323,7 +325,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'timeout: 6';
+        const content = 'timeout: 6'; // len: 10
         const completion = parseSetup(content, 10);
         completion
           .then(function (result) {
@@ -353,8 +355,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sample';
-        const completion = parseSetup(content, 11);
+        const content = 'scripts:\n  |s|ample'; // len: 17, pos: 11
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -383,8 +385,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sam';
-        const completion = parseSetup(content, 11);
+        const content = 'scripts:\n  |s|am'; // len: 14, pos: 11
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -479,8 +481,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sample: test\n  myOther';
-        const completion = parseSetup(content, 31);
+        const content = 'scripts:\n  sample: test\n  myOth|e|r'; // len: 33, pos: 31
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -504,7 +506,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'timeout:';
+        const content = 'timeout:'; // len: 8
         const completion = parseSetup(content, 9);
         completion
           .then(function (result) {
@@ -532,7 +534,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts:\n  sample:';
+        const content = 'scripts:\n  sample:'; // len: 18
         const completion = parseSetup(content, 21);
         completion
           .then(function (result) {
@@ -558,8 +560,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts: |:|';
-        const completion = parseSetup(content);
+        const content = 'scripts: ';
+        const completion = parseSetup(content, content.length);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -579,7 +581,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = '---\ntimeout: 10\n...\n---\n...';
+        const content = '---\ntimeout: 10\n...\n---\n...'; // len: 27
         const completion = parseSetup(content, 28);
         completion
           .then(function (result) {
@@ -604,8 +606,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = '---\ntimeout: 10\n...\n---\ntime \n...';
-        const completion = parseSetup(content, 26);
+        const content = '---\ntimeout: 10\n...\n---\nti|m|e \n...'; // len: 33, pos: 26
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -628,7 +630,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'time: ';
+        const content = 'time: '; // len: 6
         const completion = parseSetup(content, 6);
         completion
           .then(function (result) {
@@ -647,7 +649,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'scripts: ';
+        const content = 'scripts: '; // len: 9
         const completion = parseSetup(content, 9);
         completion
           .then(function (result) {
@@ -691,7 +693,7 @@ describe('Auto Completion Tests', () => {
           ],
         };
         languageService.addSchema(SCHEMA_ID, schema);
-        const content = 'kind: ';
+        const content = 'kind: '; // len: 6
         const validator = parseSetup(content, 6);
         validator
           .then(function (result) {
@@ -950,8 +952,8 @@ describe('Auto Completion Tests', () => {
       it('Should insert empty array item', (done) => {
         const schema = require(path.join(__dirname, './fixtures/testStringArray.json'));
         languageService.addSchema(SCHEMA_ID, schema);
-        const content = 'fooBa';
-        const completion = parseSetup(content, content.lastIndexOf('Ba') + 2);
+        const content = 'fooBa'; // len: 5
+        const completion = parseSetup(content, content.lastIndexOf('Ba') + 2); // pos: 3+2
         completion
           .then(function (result) {
             assert.strictEqual('fooBar:\n  - ${1:""}', result.items[0].insertText);
@@ -976,7 +978,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - ';
+        const content = 'authors:\n  - '; // len: 13
         const completion = parseSetup(content, 14);
         completion
           .then(function (result) {
@@ -1008,7 +1010,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  -';
+        const content = 'authors:\n  -'; // len: 12
         const completion = parseSetup(content, 13);
         completion
           .then(function (result) {
@@ -1043,7 +1045,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - name: test\n  ';
+        const content = 'authors:\n  - name: test\n  '; // len: 26
         const completion = parseSetup(content, 26);
         completion
           .then(function (result) {
@@ -1078,7 +1080,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n';
+        const content = 'authors:\n'; // len: 9
         const completion = parseSetup(content, 9);
         completion
           .then(function (result) {
@@ -1110,7 +1112,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - n';
+        const content = 'authors:\n  - n'; // len: 14
         const completion = parseSetup(content, 14);
         completion
           .then(function (result) {
@@ -1145,7 +1147,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - name: test\n    ';
+        const content = 'authors:\n  - name: test\n    '; // len: 28
         const completion = parseSetup(content, 32);
         completion
           .then(function (result) {
@@ -1180,8 +1182,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - name: test\n    e';
-        const completion = parseSetup(content, 27);
+        const content = 'authors:\n  - name: test\n   | |e'; // len: 29, pos: 27
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -1218,7 +1220,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'authors:\n  - name: test\n';
+        const content = 'authors:\n  - name: test\n'; // len: 24
         const completion = parseSetup(content, 24);
         completion
           .then(function (result) {
@@ -1260,8 +1262,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'archive:\n  exclude:\n    - name: test\n\n';
-        const completion = parseSetup(content, content.length - 1); //don't test on the last row
+        const content = 'archive:\n  exclude:\n    - name: test\n|\n|'; // len: 38, pos: 37
+        const completion = parseSetup(content); //don't test on the last row
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -1299,8 +1301,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'archive:\n  exclude:\n    - nam\n     ';
-        const completion = parseSetup(content, content.length - 1);
+        const content = 'archive:\n  exclude:\n    - nam\n    | |'; // len: 35, pos: 34
+        const completion = parseSetup(content);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 1);
@@ -1326,7 +1328,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'references:\n  -';
+        const content = 'references:\n  -'; // len: 15
         const completion = parseSetup(content, 29);
         completion
           .then(function (result) {
@@ -1353,7 +1355,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'references:\n  - ';
+        const content = 'references:\n  - '; // len: 16
         const completion = parseSetup(content, 30);
         completion
           .then(function (result) {
@@ -1380,7 +1382,7 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'references:\n  - T';
+        const content = 'references:\n  - T'; // len: 17
         const completion = parseSetup(content, 31);
         completion
           .then(function (result) {
@@ -1430,7 +1432,7 @@ describe('Auto Completion Tests', () => {
           },
         });
 
-        const content = 'metadata:\n    ownerReferences';
+        const content = 'metadata:\n    ownerReferences'; // len: 29
         const completion = await parseSetup(content, 29);
         expect(completion.items[0]).deep.eq(
           createExpectedCompletion(
@@ -1483,7 +1485,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'metadata:\n  ownerReferences';
+      const content = 'metadata:\n  ownerReferences'; // len: 27
       const completion = await parseSetup(content, 27);
       expect(completion.items[0]).deep.eq(
         createExpectedCompletion(
@@ -1535,8 +1537,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'metadata:\n   ownerReferences';
-      const completion = await parseSetup(content, 27);
+      const content = 'metadata:\n   ownerReference|s|'; // len: 28, pos: 27
+      const completion = await parseSetup(content);
       expect(completion.items[0]).deep.eq(
         createExpectedCompletion(
           'ownerReferences',
@@ -1641,8 +1643,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'rules:\n    -\n';
-      const completion = await parseSetup(content, 12);
+      const content = 'rules:\n    -|\n|'; // len: 13, pos: 12
+      const completion = await parseSetup(content);
 
       expect(completion.items.find((i) => i.label === 'rules item').textEdit.newText).equal(
         ' id: $1\n  nomination: $2\n  weight: ${3:0}\n  criteria:\n      - field: $4\n        operator: $5\n        operand: $6'
@@ -1662,7 +1664,7 @@ describe('Auto Completion Tests', () => {
           },
         },
       });
-      const content = 'foodItems: ';
+      const content = 'foodItems: '; // len: 11
       const completion = parseSetup(content, 12);
       completion
         .then(function (result) {
@@ -1688,8 +1690,8 @@ describe('Auto Completion Tests', () => {
           },
         },
       });
-      const content = 'fruit: App';
-      const completion = parseSetup(content, 9);
+      const content = 'fruit: Ap|p|'; // len: 10, pos: 9
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -1751,8 +1753,8 @@ describe('Auto Completion Tests', () => {
     it('Indent should be considered with position relative to slash', (done) => {
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'install:\n  - he';
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2);
+      const content = 'install:\n  - he'; // len: 15
+      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 13+2
       completion
         .then(function (result) {
           assert.equal(result.items.length, 2);
@@ -1769,8 +1771,8 @@ describe('Auto Completion Tests', () => {
     it('Large indent should be considered with position relative to slash', (done) => {
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'install:\n -            he';
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2);
+      const content = 'install:\n -            he'; // len: 25
+      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 23+2
       completion
         .then(function (result) {
           assert.equal(result.items.length, 2);
@@ -1787,8 +1789,8 @@ describe('Auto Completion Tests', () => {
     it('Tab indent should be considered with position relative to slash', (done) => {
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'install:\n -\t             he';
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2);
+      const content = 'install:\n -\t             he'; // len: 27
+      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 25+2
       completion
         .then(function (result) {
           assert.equal(result.items.length, 2);
@@ -1827,9 +1829,9 @@ describe('Auto Completion Tests', () => {
     });
 
     it('Provide completion from schema declared in file with several documents', async () => {
-      const documentContent1 = `# yaml-language-server: $schema=${uri} anothermodeline=value\n- `;
-      const content = `${documentContent1}\n---\n- `;
-      const result = await parseSetup(content, documentContent1.length);
+      const documentContent1 = `# yaml-language-server: $schema=${uri} anothermodeline=value\n- `; // 149
+      const content = `${documentContent1}|\n|---\n- `; // len: 156, pos: 149
+      const result = await parseSetup(content);
       assert.equal(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
 
       const resultDoc2 = await parseSetup(content, content.length);
@@ -1840,16 +1842,15 @@ describe('Auto Completion Tests', () => {
       const documentContent = `# yaml-language-server: $schema=${path.join(
         __dirname,
         './fixtures/testArrayMaxProperties.json'
-      )} anothermodeline=value\n- `;
-      const content = `${documentContent}\n---\n- `;
-      const result = await parseSetup(content, documentContent.length);
+      )} anothermodeline=value\n- `; // len: 142
+      const content = `${documentContent}|\n|---\n- `; // len: 149, pos: 142
+      const result = await parseSetup(content);
       assert.strictEqual(result.items.length, 3, `Expecting 3 items in completion but found ${result.items.length}`);
     });
 
     it('should handle relative path', async () => {
-      const documentContent = `# yaml-language-server: $schema=./fixtures/testArrayMaxProperties.json anothermodeline=value\n- `;
+      const documentContent = `# yaml-language-server: $schema=./fixtures/testArrayMaxProperties.json anothermodeline=value\n- `; // 95
       const content = `${documentContent}\n---\n- `;
-
       const testTextDocument = setupSchemaIDTextDocument(content, path.join(__dirname, 'test.yaml'));
       yamlSettings.documents = new TextDocumentTestManager();
       (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -1955,8 +1956,8 @@ describe('Auto Completion Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n    sample: test\n    myOther';
-      const completion = await parseSetup(content, 34);
+      const content = 'scripts:\n    sample: test\n    myOt|h|er'; // len: 37, pos: 34
+      const completion = await parseSetup(content);
       assert.strictEqual(completion.items.length, 1);
       assert.deepStrictEqual(
         completion.items[0],
@@ -2014,7 +2015,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'components:\n  - id: jsakdh\n    setti';
+      const content = 'components:\n  - id: jsakdh\n    setti'; // len: 36
       const completion = await parseSetup(content, 36);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0].textEdit.newText).to.equal(
@@ -2035,7 +2036,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'env: ';
+      const content = 'env: '; // len: 5
       const completion = parseSetup(content, 5);
       completion
         .then(function (result) {
@@ -2067,7 +2068,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'env: ';
+      const content = 'env: '; // len: 5
       const completion = parseSetup(content, 5);
       completion
         .then(function (result) {
@@ -2118,8 +2119,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = '---\n- \n';
-      const completion = await parseSetup(content, 6);
+      const content = '---\n- |\n|'; // len: 7, pos: 6
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0].label).eq('fooBar');
       expect(completion.items[0].insertText).eq('fooBar:\n    name: $1\n    aaa:\n      - $2');
@@ -2152,7 +2153,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = '- prop1: value\n  object:\n  - env_prop1: value\n  ';
+      const content = '- prop1: value\n  object:\n  - env_prop1: value\n  '; // len: 48
       const completion = await parseSetup(content, 49);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0].label).eq('prop2');
@@ -2174,8 +2175,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'enum';
-      const completion = await parseSetup(content, 3);
+      const content = 'enu|m|'; // len: 4, pos: 3
+      const completion = await parseSetup(content);
 
       const enumItem = completion.items.find((i) => i.label === 'enum');
       expect(enumItem).to.not.undefined;
@@ -2197,8 +2198,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'fooBar: \n';
-      const completion = await parseSetup(content, 8);
+      const content = 'fooBar: |\n|'; // len: 9, pos: 8
+      const completion = await parseSetup(content);
 
       const testItem = completion.items.find((i) => i.label === 'test');
       expect(testItem).to.not.undefined;
@@ -2227,8 +2228,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'fooBar: \n';
-      const completion = await parseSetup(content, 8);
+      const content = 'fooBar: |\n|'; // len: 9, pos: 8
+      const completion = await parseSetup(content);
 
       expect(completion.items).length(1);
     });
@@ -2239,8 +2240,8 @@ describe('Auto Completion Tests', () => {
         properties: { A: { type: 'string', enum: ['a1', 'a2'] }, B: { type: 'string', enum: ['b1', 'b2'] } },
       });
 
-      const content = '{A: , B: b1}';
-      const completion = await parseSetup(content, 4);
+      const content = '{A: |,| B: b1}'; // len: 12, pos: 4
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('a1', 'a1', 0, 4, 0, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
@@ -2260,8 +2261,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'kind: \n';
-      const completion = await parseSetup(content, 6);
+      const content = 'kind: |\n|'; // len: 7, pos: 6
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('project', 'project', 0, 6, 0, 6, 12, InsertTextFormat.Snippet, { documentation: undefined })
@@ -2299,8 +2300,8 @@ describe('Auto Completion Tests', () => {
         ],
       });
 
-      const content = ' \n\n\n';
-      const completion = await parseSetup(content, 3);
+      const content = ' \n\n|\n|'; // len: 4, pos: 3
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind: ', 2, 0, 2, 0, 10, InsertTextFormat.Snippet, { documentation: '' })
@@ -2321,8 +2322,8 @@ describe('Auto Completion Tests', () => {
         required: ['kind'],
       });
 
-      const content = 'kind: 111\n';
-      const completion = await parseSetup(content, 3);
+      const content = 'kin|d|: 111\n'; // len: 10, pos: 3
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind', 0, 0, 0, 4, 10, InsertTextFormat.Snippet, { documentation: '' })
@@ -2340,8 +2341,8 @@ describe('Auto Completion Tests', () => {
         required: ['kind'],
       });
 
-      const content = 'ki: 111\n';
-      const completion = await parseSetup(content, 1);
+      const content = 'k|i|: 111\n'; // len: 8, pos: 1
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind', 0, 0, 0, 2, 10, InsertTextFormat.Snippet, { documentation: '' })
@@ -2362,8 +2363,8 @@ describe('Auto Completion Tests', () => {
         required: ['kind'],
       });
 
-      const content = 'kin';
-      const completion = await parseSetup(content, 1);
+      const content = 'k|i|n'; // len: 3, pos: 1
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
         createExpectedCompletion('kind', 'kind: ', 0, 0, 0, 3, 10, InsertTextFormat.Snippet, {
@@ -2399,7 +2400,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'test:\n  - and\n  - - ';
+      const content = 'test:\n  - and\n  - - '; // len: 20
 
       const completion = await parseSetup(content, 20);
       expect(completion.items).lengthOf(1);
@@ -2432,9 +2433,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'test:\n  - and\n  - -   ';
-
-      const completion = await parseSetup(content, 20);
+      const content = 'test:\n  - and\n  - - | | '; // len: 22, pos: 20
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0]).eql(
         createExpectedCompletion('and', 'and', 2, 6, 2, 8, 12, InsertTextFormat.Snippet, { documentation: undefined })
@@ -2465,8 +2465,8 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'test:\n  - and\n  - []';
-      const completion = await parseSetup(content, 18);
+      const content = 'test:\n  - and\n  - |[|]'; // len: 20, pos: 18
+      const completion = await parseSetup(content);
       expect(completion.items).lengthOf(1);
       expect(completion.items[0]).eql(
         createExpectedCompletion('and', 'and', 2, 4, 2, 4, 12, InsertTextFormat.Snippet, { documentation: undefined })
@@ -2496,7 +2496,7 @@ describe('Auto Completion Tests', () => {
         },
       });
 
-      const content = 'version: ';
+      const content = 'version: '; // len: 9
       const completion = await parseSetup(content, 9);
       expect(completion.items).lengthOf(2);
       expect(completion.items[0]).eql(
@@ -2583,8 +2583,8 @@ describe('Auto Completion Tests', () => {
     it('Simple array object completion without "-" befor array empty item', (done) => {
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'test_simpleArrayObject:\n  \n  -';
-      const completion = parseSetup(content, 'test_simpleArrayObject:\n  '.length);
+      const content = 'test_simpleArrayObject:\n  |\n|  -'; // len: 30, pos: 26
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument, toFsPath } from './utils/testHelper';
+import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument, toFsPath } from './utils/testHelper';
 import assert = require('assert');
 import path = require('path');
 import { createExpectedCompletion } from './utils/verifyError';
@@ -43,12 +43,9 @@ describe('Auto Completion Tests', () => {
    * @returns A list of valid completions.
    */
   function parseSetup(content: string, position?: number): Promise<CompletionList> {
-    // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
     if (typeof position === 'undefined') {
-      position = content.search(/\|[^]\|/); // | -> any char including newline -> |
-      content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+      ({ content, position } = caretPosition(content));
     }
-    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -194,8 +194,8 @@ describe('Auto Completion Tests', () => {
             },
           },
         });
-        const content = 'nam|e|'; // len: 4
-        const completion = await parseSetup(content); // 3
+        const content = 'nam|e|'; // len: 4, pos: 3
+        const completion = await parseSetup(content);
         assert.strictEqual(completion.items.length, 1);
         assert.deepStrictEqual(
           completion.items[0],

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -38,7 +38,8 @@ describe('Auto Completion Tests', () => {
    * Generates a completion list for the given document and caret (cursor) position.
    * @param content The content of the document.
    * @param position The position of the caret in the document.
-   * Alternatively, can be omitted if the caret is located in the content using the symbol `|:|`.
+   * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.
+   * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
    * @returns A list of valid completions.
    */
   function parseSetup(content: string, position?: number): Promise<CompletionList> {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -43,12 +43,12 @@ describe('Auto Completion Tests', () => {
    * @returns A list of valid completions.
    */
   function parseSetup(content: string, position?: number): Promise<CompletionList> {
-    // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+    // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
     if (typeof position === 'undefined') {
       position = content.search(/\|[^]\|/); // | -> any char including newline -> |
       content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
     }
-    // console.log('position:', position, content, '>' + content.substring(position) + '<');
+    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -8,7 +8,7 @@ import { LanguageHandlers } from '../src/languageserver/handlers/languageHandler
 import { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
 import { expect } from 'chai';
 import { createExpectedCompletion } from './utils/verifyError';
 import * as path from 'path';
@@ -53,17 +53,14 @@ describe('Auto Completion Fix Tests', () => {
   /**
    * Generates a completion list for the given document and caret (cursor) position.
    * @param content The content of the document.
-   * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.
+   * The caret is located in the content using `|` bookends.
    * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
    * @returns A list of valid completions.
    */
   function parseCaret(content: string): Promise<CompletionList> {
-    // console.log(`was: len: ${content.length}, content: "${content}"`);
-    const position = content.search(/\|[^]\|/); // | -> any char including newline -> |
-    content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
-    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
+    const { position, content: content2 } = caretPosition(content);
 
-    const testTextDocument = setupSchemaIDTextDocument(content);
+    const testTextDocument = setupSchemaIDTextDocument(content2);
     yamlSettings.documents = new TextDocumentTestManager();
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
     return languageHandler.completionHandler({

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -59,7 +59,7 @@ describe('Auto Completion Fix Tests', () => {
    */
   function parseCaret(content: string): Promise<CompletionList> {
     // console.log(`was: len: ${content.length}, content: "${content}"`);
-    let position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+    const position = content.search(/\|[^]\|/); // | -> any char including newline -> |
     content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
     // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -34,11 +34,11 @@ describe('Auto Completion Fix Tests', () => {
   });
 
   /**
-   *
-   * @param content
+   * Generates a completion list for the given document and caret (cursor) position.
+   * @param content The content of the document.
    * @param line starts with 0 index
    * @param character starts with 1 index
-   * @returns
+   * @returns A list of valid completions.
    */
   function parseSetup(content: string, line: number, character: number): Promise<CompletionList> {
     const testTextDocument = setupSchemaIDTextDocument(content);
@@ -46,6 +46,28 @@ describe('Auto Completion Fix Tests', () => {
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
     return languageHandler.completionHandler({
       position: Position.create(line, character),
+      textDocument: testTextDocument,
+    });
+  }
+
+  /**
+   * Generates a completion list for the given document and caret (cursor) position.
+   * @param content The content of the document.
+   * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.
+   * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
+   * @returns A list of valid completions.
+   */
+  function parseCaret(content: string): Promise<CompletionList> {
+    // console.log(`was: len: ${content.length}, content: "${content}"`);
+    let position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+    content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
+
+    const testTextDocument = setupSchemaIDTextDocument(content);
+    yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+    return languageHandler.completionHandler({
+      position: testTextDocument.positionAt(position),
       textDocument: testTextDocument,
     });
   }
@@ -72,8 +94,8 @@ describe('Auto Completion Fix Tests', () => {
         },
       },
     });
-    const content = '- from:\n    ';
-    const completion = await parseSetup(content, 1, 3);
+    const content = '- from:\n   | |'; // len: 12, pos: 11
+    const completion = await parseCaret(content);
     expect(completion.items).lengthOf(1);
     expect(completion.items[0]).eql(
       createExpectedCompletion('foo', 'foo: ', 1, 3, 1, 3, 10, 2, {
@@ -99,7 +121,7 @@ describe('Auto Completion Fix Tests', () => {
         },
       },
     });
-    const content = '- ';
+    const content = '- '; // len: 2
     const completion = await parseSetup(content, 0, 2);
     expect(completion.items).lengthOf(1);
     expect(completion.items[0]).eql(
@@ -119,19 +141,19 @@ spec:
     - name: test
       
       image: alpine
-    `;
+    `; // len: 90
     const completion = await parseSetup(content, 7, 6);
     expect(completion.items).length.greaterThan(1);
   });
 
   it('should show completion on array item on first line', async () => {
-    const content = '-d';
+    const content = '-d'; // len: 2
     const completion = await parseSetup(content, 0, 1);
     expect(completion.items).is.empty;
   });
 
   it('should complete without error on map inside array', async () => {
-    const content = '- foo\n- bar:\n    so';
+    const content = '- foo\n- bar:\n    so'; // len: 19
     const completion = await parseSetup(content, 2, 6);
     expect(completion.items).is.empty;
   });
@@ -146,7 +168,7 @@ spec:
 objB:
   size: midle
   name: nameB2  
-`;
+`; // len: 67
     const completion = await parseSetup(content, 2, 4);
     expect(completion.items).is.not.empty;
   });
@@ -159,7 +181,7 @@ objB:
   Selector:
     query:
       - 
-`;
+`; // len: 42
     const completion = await parseSetup(content, 3, 8);
     expect(completion.items).length(5);
     expect(completion.items.map((it) => it.label)).to.have.members(['NOT', 'attribute', 'operation', 'value', 'FUNC_item']);
@@ -188,7 +210,7 @@ objB:
         },
       },
     });
-    const content = 'example:\n  sample:\n    ';
+    const content = 'example:\n  sample:\n    '; // len: 23
     const completion = await parseSetup(content + '\na: test', 2, 4);
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
@@ -220,8 +242,8 @@ objB:
         },
       },
     });
-    const content = 'example:\n  sample:\n    \n    prop2: value2';
-    const completion = await parseSetup(content, 2, 4);
+    const content = 'example:\n  sample:\n    |\n|    prop2: value2'; // len: 41, pos: 23
+    const completion = await parseCaret(content);
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
       createExpectedCompletion('prop1', 'prop1: ', 2, 4, 2, 4, 10, 2, {
@@ -252,8 +274,8 @@ objB:
         },
       },
     });
-    const content = 'examples:\n  \n  - sample:\n      prop1: value1';
-    const completion = await parseSetup(content, 1, 2);
+    const content = 'examples:\n  |\n|  - sample:\n      prop1: value1'; // len: 44, pos: 12
+    const completion = await parseCaret(content);
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
       createExpectedCompletion('- (array item)', '- ', 1, 2, 1, 2, 9, 2, {
@@ -286,7 +308,7 @@ objB:
         },
       },
     });
-    const content = 'kind: Po';
+    const content = 'kind: Po'; // len: 8
     const completion = await parseSetup(content, 1, 9);
     expect(completion.items.length).equal(2);
     expect(completion.items[0].insertText).equal('Pod');
@@ -313,7 +335,7 @@ objB:
         },
       },
     });
-    const content = 'examples:\n  - ';
+    const content = 'examples:\n  - '; // len: 14
     const completion = await parseSetup(content, 1, 4);
 
     expect(completion.items.length).equal(1);
@@ -348,7 +370,7 @@ objB:
         },
       },
     });
-    const content = 'examples:\n  - ';
+    const content = 'examples:\n  - '; // len: 14
     const completion = await parseSetup(content, 1, 4);
 
     expect(completion.items.length).equal(1);
@@ -384,7 +406,7 @@ objB:
     };
     it('array indent on the first item', async () => {
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'objectWithArray:\n  - ';
+      const content = 'objectWithArray:\n  - '; // len: 21
       const completion = await parseSetup(content, 1, 4);
 
       expect(completion.items.length).equal(3);
@@ -401,7 +423,7 @@ objB:
     });
     it('array indent on the second item', async () => {
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'objectWithArray:\n  - item: first line\n    ';
+      const content = 'objectWithArray:\n  - item: first line\n    '; // len: 42
       const completion = await parseSetup(content, 2, 4);
 
       expect(completion.items.length).equal(2);
@@ -508,12 +530,12 @@ objB:
         },
       };
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'prop:   ';
-      const completion = await parseSetup(content, 0, 6);
+      const content = 'prop: | | '; // len: 8, pos: 6
+      const completion = await parseCaret(content);
 
       expect(completion.items.length).equal(1);
       expect(completion.items[0].label).to.be.equal('const');
-      expect(completion.items[0].textEdit).to.be.deep.equal({ newText: 'const', range: Range.create(0, 6, 0, content.length) });
+      expect(completion.items[0].textEdit).to.be.deep.equal({ newText: 'const', range: Range.create(0, 6, 0, 8) });
     });
 
     it('should suggest object array when extra space is after cursor', async () => {
@@ -537,8 +559,8 @@ objB:
         },
       };
       languageService.addSchema(SCHEMA_ID, schema);
-      const content = 'arrayObj:\n  -   ';
-      const completion = await parseSetup(content, 1, 4);
+      const content = 'arrayObj:\n  - | | '; // len: 16, pos: 14
+      const completion = await parseCaret(content);
 
       expect(completion.items.length).equal(3);
       expect(completion.items[1].textEdit).to.be.deep.equal({

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -28,7 +28,15 @@ describe('Default Snippet Tests', () => {
   });
 
   describe('Snippet Tests', function () {
-    function parseSetup(content: string, position: number): Promise<CompletionList> {
+    function parseSetup(content: string, position?: number): Promise<CompletionList> {
+      // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+      if (typeof position === 'undefined') {
+        position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+        content =
+          content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+      }
+      // console.log('position:', position, content, '>' + content.substring(position) + '<');
+
       const testTextDocument = setupSchemaIDTextDocument(content);
       yamlSettings.documents = new TextDocumentTestManager();
       (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -39,7 +47,7 @@ describe('Default Snippet Tests', () => {
     }
 
     it('Snippet in array schema should autocomplete with -', (done) => {
-      const content = 'array:\n  - ';
+      const content = 'array:\n  - '; // len: 11
       const completion = parseSetup(content, 11);
       completion
         .then(function (result) {
@@ -51,7 +59,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in array schema should autocomplete with - if none is present', (done) => {
-      const content = 'array:\n  ';
+      const content = 'array:\n  '; // len: 9
       const completion = parseSetup(content, 9);
       completion
         .then(function (result) {
@@ -63,8 +71,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in array schema should autocomplete on same line as array', (done) => {
-      const content = 'array:  ';
-      const completion = parseSetup(content, 7);
+      const content = 'array: | |'; // len: 8, pos: 7
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -128,7 +136,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in object schema should autocomplete on next line ', (done) => {
-      const content = 'object:\n  ';
+      const content = 'object:\n  '; // len: 10
       const completion = parseSetup(content, 11);
       completion
         .then(function (result) {
@@ -142,7 +150,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in object schema should autocomplete on next line with depth', (done) => {
-      const content = 'object:\n  key:\n    ';
+      const content = 'object:\n  key:\n    '; // len: 19
       const completion = parseSetup(content, 20);
       completion
         .then(function (result) {
@@ -156,7 +164,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in object schema should autocomplete on same line', (done) => {
-      const content = 'object:  ';
+      const content = 'object:  '; // len: 9
       const completion = parseSetup(content, 8);
       completion
         .then(function (result) {
@@ -176,8 +184,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in string schema should autocomplete on same line', (done) => {
-      const content = 'string:  ';
-      const completion = parseSetup(content, 8);
+      const content = 'string: | |'; // len: 9, pos: 8
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.notEqual(result.items.length, 0);
@@ -188,8 +196,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in boolean schema should autocomplete on same line', (done) => {
-      const content = 'boolean:  ';
-      const completion = parseSetup(content, 9);
+      const content = 'boolean: | |'; // len: 10, pos: 9
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.notEqual(result.items.length, 0);
@@ -200,8 +208,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in longSnipet schema should autocomplete on same line', (done) => {
-      const content = 'longSnippet:  ';
-      const completion = parseSetup(content, 13);
+      const content = 'longSnippet: | |'; // len: 14, pos: 13
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
@@ -216,8 +224,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Snippet in short snippet schema should autocomplete on same line', (done) => {
-      const content = 'lon  ';
-      const completion = parseSetup(content, 3);
+      const content = 'lon| | '; // len: 5, pos: 3
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items.length, 14); // This is just checking the total number of snippets in the defaultSnippets.json
@@ -232,8 +240,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test array of arrays on properties completion', (done) => {
-      const content = 'arrayArrayS  ';
-      const completion = parseSetup(content, 11);
+      const content = 'arrayArrayS| | '; // len: 13, pos: 11
+      const completion = parseSetup(content);
       completion
         .then(function (result) {
           assert.equal(result.items[5].label, 'arrayArraySnippet');
@@ -243,7 +251,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test array of arrays on value completion', (done) => {
-      const content = 'arrayArraySnippet: ';
+      const content = 'arrayArraySnippet: '; // len: 19
       const completion = parseSetup(content, 20);
       completion
         .then(function (result) {
@@ -255,7 +263,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test array of arrays on indented completion', (done) => {
-      const content = 'arrayArraySnippet:\n  ';
+      const content = 'arrayArraySnippet:\n  '; // len: 21
       const completion = parseSetup(content, 21);
       completion
         .then(function (result) {
@@ -303,7 +311,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test string with boolean in string should insert string', (done) => {
-      const content = 'simpleBooleanString: ';
+      const content = 'simpleBooleanString: '; // len: 21
       const completion = parseSetup(content, 21);
       completion
         .then(function (result) {
@@ -315,7 +323,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('Test string with boolean NOT in string should insert boolean', (done) => {
-      const content = 'simpleBoolean: ';
+      const content = 'simpleBoolean: '; // len: 15
       const completion = parseSetup(content, 15);
       completion
         .then(function (result) {
@@ -327,8 +335,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('should preserve space after ":" with prefix', async () => {
-      const content = 'boolean: tr\n';
-      const result = await parseSetup(content, 9);
+      const content = 'boolean: |t|r\n'; // len: 12, pos: 9
+      const result = await parseSetup(content);
 
       assert.notEqual(result.items.length, 0);
       assert.equal(result.items[0].label, 'My boolean item');
@@ -341,7 +349,7 @@ describe('Default Snippet Tests', () => {
     });
 
     it('should preserve space after ":"', async () => {
-      const content = 'boolean: ';
+      const content = 'boolean: '; // len: 9
       const result = await parseSetup(content, 9);
 
       assert.notEqual(result.items.length, 0);
@@ -355,8 +363,8 @@ describe('Default Snippet Tests', () => {
     });
 
     it('should add space before value on root node', async () => {
-      const content = 'name\n';
-      const result = await parseSetup(content, 4);
+      const content = 'name|\n|'; // len: 5, pos: 4
+      const result = await parseSetup(content);
       const item = result.items.find((i) => i.label === 'name');
       expect(item).is.not.undefined;
       expect(item.textEdit.newText).to.be.equal('name: some');

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { toFsPath, setupSchemaIDTextDocument, setupLanguageService } from './utils/testHelper';
+import { toFsPath, setupSchemaIDTextDocument, setupLanguageService, caretPosition } from './utils/testHelper';
 import assert = require('assert');
 import path = require('path');
 import { ServiceSetup } from './utils/serviceSetup';
@@ -37,13 +37,9 @@ describe('Default Snippet Tests', () => {
      * @returns A list of valid completions.
      */
     function parseSetup(content: string, position?: number): Promise<CompletionList> {
-      // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
       if (typeof position === 'undefined') {
-        position = content.search(/\|[^]\|/); // | -> any char including newline -> |
-        content =
-          content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+        ({ content, position } = caretPosition(content));
       }
-      // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
       const testTextDocument = setupSchemaIDTextDocument(content);
       yamlSettings.documents = new TextDocumentTestManager();

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -28,6 +28,14 @@ describe('Default Snippet Tests', () => {
   });
 
   describe('Snippet Tests', function () {
+    /**
+     * Generates a completion list for the given document and caret (cursor) position.
+     * @param content The content of the document.
+     * @param position The position of the caret in the document.
+     * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.
+     * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
+     * @returns A list of valid completions.
+     */
     function parseSetup(content: string, position?: number): Promise<CompletionList> {
       // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
       if (typeof position === 'undefined') {

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -37,13 +37,13 @@ describe('Default Snippet Tests', () => {
      * @returns A list of valid completions.
      */
     function parseSetup(content: string, position?: number): Promise<CompletionList> {
-      // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+      // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
       if (typeof position === 'undefined') {
         position = content.search(/\|[^]\|/); // | -> any char including newline -> |
         content =
           content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
       }
-      // console.log('position:', position, content, '>' + content.substring(position) + '<');
+      // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
       const testTextDocument = setupSchemaIDTextDocument(content);
       yamlSettings.documents = new TextDocumentTestManager();

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -41,7 +41,7 @@ describe('Hover Tests', () => {
   });
 
   /**
-   * Generates a completion list for the given document and caret (cursor) position.
+   * Generates hover information for the given document and caret (cursor) position.
    * @param content The content of the document.
    * @param position The position of the caret in the document.
    * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { ServiceSetup } from './utils/serviceSetup';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
 import { LanguageService } from '../src';
 import * as assert from 'assert';
 import { Hover, MarkupContent, Position } from 'vscode-languageserver-types';
@@ -49,12 +49,9 @@ describe('Hover Tests', () => {
    * @returns An instance of `Hover`.
    */
   function parseSetup(content: string, position?: number): Promise<Hover> {
-    // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
     if (typeof position === 'undefined') {
-      position = content.search(/\|[^]\|/); // | -> any char including newline -> |
-      content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+      ({ content, position } = caretPosition(content));
     }
-    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -40,7 +40,14 @@ describe('Hover Tests', () => {
     languageService.deleteSchema(SCHEMA_ID);
   });
 
-  function parseSetup(content: string, position): Promise<Hover> {
+  function parseSetup(content: string, position?: number): Promise<Hover> {
+    // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+    if (typeof position === 'undefined') {
+      position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+      content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+    }
+    // console.log('position:', position, content, '>' + content.substring(position) + '<');
+
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();
     (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -62,8 +69,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'cwd: test';
-      const hover = await parseSetup(content, 1);
+      const content = 'c|w|d: test'; // len: 9, pos: 1
+      const hover = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(hover.contents), true);
       assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
@@ -84,8 +91,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'cwd: test';
-      const result = await parseSetup(content, 6);
+      const content = 'cwd: t|e|st'; // len: 9, pos: 6
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -110,8 +117,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-      const result = await parseSetup(content, 15);
+      const content = 'scripts:\n  post|i|nstall: test'; // len: 28, pos: 15
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -136,8 +143,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-      const result = await parseSetup(content, 26);
+      const content = 'scripts:\n  postinstall: te|s|t'; // len: 28, pos: 26
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -163,9 +170,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'scripts:\n  postinstall: test';
-
-      const firstHover = await parseSetup(content, 3);
+      const content1 = 'scr|i|pts:\n  postinstall: test'; // len: 28, pos: 3
+      const firstHover = await parseSetup(content1);
 
       assert.strictEqual(MarkupContent.is(firstHover.contents), true);
       assert.strictEqual((firstHover.contents as MarkupContent).kind, 'markdown');
@@ -174,7 +180,8 @@ describe('Hover Tests', () => {
         `Contains custom hooks used to trigger other automated tools\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
 
-      const secondHover = await parseSetup(content, 15);
+      const content2 = 'scripts:\n  post|i|nstall: test'; // len: 28, pos: 15
+      const secondHover = await parseSetup(content2);
 
       assert.strictEqual(MarkupContent.is(secondHover.contents), true);
       assert.strictEqual(
@@ -192,8 +199,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'analytics: true';
-      const result = await parseSetup(content, 3);
+      const content = 'ana|l|ytics: true'; // len: 15, pos: 3
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -228,8 +235,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = '---\nanalytics: true\n...\n---\njson: test\n...';
-      const result = await parseSetup(content, 30);
+      const content = '---\nanalytics: true\n...\n---\njs|o|n: test\n...'; // len: 42, pos: 30
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -243,8 +250,8 @@ describe('Hover Tests', () => {
         type: 'object',
         properties: {},
       });
-      const content = 'my_unknown_hover: test';
-      const result = await parseSetup(content, 1);
+      const content = 'm|y|_unknown_hover: test'; // len: 22, pos: 1
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -255,8 +262,8 @@ describe('Hover Tests', () => {
         type: 'object',
         properties: {},
       });
-      const content = 'my_unknown_hover: test';
-      const result = await parseSetup(content, 21);
+      const content = 'my_unknown_hover: tes|t|'; // len: 22, pos: 21
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).value, '');
@@ -280,8 +287,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'authors:\n  - name: Josh';
-      const result = await parseSetup(content, 14);
+      const content = 'authors:\n  - n|a|me: Josh'; // len: 23, pos: 14
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -312,8 +319,8 @@ describe('Hover Tests', () => {
           },
         },
       });
-      const content = 'authors:\n  - name: Josh\n  - email: jp';
-      const result = await parseSetup(content, 28);
+      const content = 'authors:\n  - name: Josh\n  - |e|mail: jp'; // len: 37, pos: 28
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -392,7 +399,26 @@ describe('Hover Tests', () => {
         },
       });
 
-      const content = `ignition:
+      const content1 = `ignition:
+  proxy:
+    no_proxy:
+      - 10|.|10.10.10
+      - service.local
+storage:
+  raid:
+    - name: Raid
+      devices:
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WX41A49H9FT4
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD`; // len: 257, pos: 43
+
+      let result = await parseSetup(content1);
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `#### no\\_proxy \\(list of strings\\):\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+
+      const content2 = `ignition:
   proxy:
     no_proxy:
       - 10.10.10.10
@@ -401,17 +427,10 @@ storage:
   raid:
     - name: Raid
       devices:
-        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WX41A49H9FT4
-        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD`;
+        - /dev/disk/by-id/ata-WDC_WD|1|0SPZX-80Z10T2_WD-WX41A49H9FT4
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD`; // len: 257, pos: 160
 
-      let result = await parseSetup(content, 43);
-      assert.strictEqual(MarkupContent.is(result.contents), true);
-      assert.strictEqual(
-        (result.contents as MarkupContent).value,
-        `#### no\\_proxy \\(list of strings\\):\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
-      );
-
-      result = await parseSetup(content, 160);
+      result = await parseSetup(content2);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
@@ -429,8 +448,8 @@ storage:
           },
         },
       });
-      const content = 'childObject: \n';
-      const result = await parseSetup(content, 1);
+      const content = 'c|h|ildObject: \n'; // len: 14, pos: 1
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -451,8 +470,8 @@ storage:
           },
         },
       });
-      const content = 'animal:\n  cat';
-      const result = await parseSetup(content, 12);
+      const content = 'animal:\n  ca|t|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
@@ -486,8 +505,8 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
           },
         },
       });
-      const content = 'childObject:\r\n  prop:\r\n  ';
-      const result = await parseSetup(content, 16);
+      const content = 'childObject:\r\n  |p|rop:\r\n  '; // len: 25, pos: 16
+      const result = await parseSetup(content);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
@@ -511,8 +530,8 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
   describe('Bug fixes', () => {
     it('should convert binary data correctly', async () => {
       const content =
-        'foo: [ !!binary R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs= ]\n';
-      const result = await parseSetup(content, 20);
+        'foo: [ !!binary R0lG|O|DlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmleECcgggoBADs= ]\n'; // len: 107, pos: 20
+      const result = await parseSetup(content);
       expect(telemetry.messages).to.be.empty;
       expect(result).to.be.null;
     });

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -49,12 +49,12 @@ describe('Hover Tests', () => {
    * @returns An instance of `Hover`.
    */
   function parseSetup(content: string, position?: number): Promise<Hover> {
-    // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+    // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
     if (typeof position === 'undefined') {
       position = content.search(/\|[^]\|/); // | -> any char including newline -> |
       content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
     }
-    // console.log('position:', position, content, '>' + content.substring(position) + '<');
+    // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
 
     const testTextDocument = setupSchemaIDTextDocument(content);
     yamlSettings.documents = new TextDocumentTestManager();

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -40,6 +40,14 @@ describe('Hover Tests', () => {
     languageService.deleteSchema(SCHEMA_ID);
   });
 
+  /**
+   * Generates a completion list for the given document and caret (cursor) position.
+   * @param content The content of the document.
+   * @param position The position of the caret in the document.
+   * Alternatively, `position` can be omitted if the caret is located in the content using `|` bookends.
+   * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
+   * @returns An instance of `Hover`.
+   */
   function parseSetup(content: string, position?: number): Promise<Hover> {
     // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
     if (typeof position === 'undefined') {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -210,7 +210,15 @@ describe('Kubernetes Integration Tests', () => {
 
   describe('yamlCompletion with kubernetes', function () {
     describe('doComplete', function () {
-      function parseSetup(content: string, position): Promise<CompletionList> {
+      function parseSetup(content: string, position?: number): Promise<CompletionList> {
+        // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
+        if (typeof position === 'undefined') {
+          position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+          content =
+            content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+        }
+        // console.log('position:', position, content, '>' + content.substring(position) + '<');
+
         const testTextDocument = setupTextDocument(content);
         yamlSettings.documents = new TextDocumentTestManager();
         (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -210,15 +210,7 @@ describe('Kubernetes Integration Tests', () => {
 
   describe('yamlCompletion with kubernetes', function () {
     describe('doComplete', function () {
-      function parseSetup(content: string, position?: number): Promise<CompletionList> {
-        // console.log('original:', content.length, content, '>' + content.substring(position) + '<');
-        if (typeof position === 'undefined') {
-          position = content.search(/\|[^]\|/); // | -> any char including newline -> |
-          content =
-            content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
-        }
-        // console.log('position:', position, content, '>' + content.substring(position) + '<');
-
+      function parseSetup(content: string, position: number): Promise<CompletionList> {
         const testTextDocument = setupTextDocument(content);
         yamlSettings.documents = new TextDocumentTestManager();
         (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);

--- a/test/multipleDocuments.test.ts
+++ b/test/multipleDocuments.test.ts
@@ -54,7 +54,7 @@ describe('Multiple Documents Validation Tests', () => {
       return validationHandler.validateTextDocument(testTextDocument);
     }
 
-    function hoverSetup(content: string, position): Promise<Hover> {
+    function hoverSetup(content: string, position: number): Promise<Hover> {
       const testTextDocument = setupTextDocument(content);
       languageService.configure(languageSettingsSetup.languageSettings);
       yamlSettings.documents = new TextDocumentTestManager();

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -93,3 +93,24 @@ export function setupLanguageService(languageSettings: LanguageSettings): TestLa
     telemetry,
   };
 }
+
+/**
+ * Derives the absolute `position` of the caret given `content` containing a virtual caret.
+ * @param content The content of the document.
+ * The caret is located in the content using `|` bookends.
+ * For example, `content = 'ab|c|d'` places the caret over the `'c'`, at `position = 2`
+ * @returns The absolute position of the caret.
+ */
+export function caretPosition(content: string): { position: number; content: string } {
+  // console.log(`was: len: ${content.length}, content: "${content}", str: "${content.substring(position)}"`);
+
+  // Find bookends `|.|` in content
+  const position = content.search(/\|[^]\|/); // | -> any char including newline -> |
+  if (position === -1) throw new Error('Error in test case: no caret found in content');
+
+  // Elide bookends from content
+  content = content.substring(0, position) + content.substring(position + 1, position + 2) + content.substring(position + 3);
+
+  // console.log(`now: len: ${content.length}, content: "${content}", pos: ${position}, str: "${content.substring(position)}"`);
+  return { position, content };
+}


### PR DESCRIPTION
### What does this PR do?
This is a follow-up to #722
* The previous PR introduced the concept of a _virtual caret_. However, I only updated a few tests in order to keep the noise low so the reviewer could easily see what was going on.
* This PR updates all relevant/remaining tests to use the new functionality. Note that some tests are not updated, for example when they specify an index that is out of range (eg `parseSetup('abc', 10)`)

### Improvements
I improved the caret usage/algorithm to use "bookends" instead of absolute position. The previous method made it hard to specify some boundary cases.

- We now use caret "bookends" which surround the intended character, for example:
  - `'a|b|c'` is the same as `position = 1`, ie the caret is on the `'b'` char
  - `'ab| |'` is the same as `position = 2`, ie the caret is on the `' '` char
  - `'|\n|bc'` is the same as `position = 0`, but this one is interesting because the caret is on the `'\n'` char

### Algorithm
Here's how the `content` value is manipulated in order to derive the position given an embedded caret:
- Using an example: the original string: `content = '0123456789'`
- Imagine we want the caret on `'7'`, thus we specify: `'0123456|7|89'` instead
- Now calling `position = content.search(regex)` has the result `position === 7`
  - The regex looks for `|`, followed by `any one char including \n`, followed by `|`
- We then elide the caret "bookends", which has the result `content = '0123456789'`
- Now `content[position: 7] === '7'` which is what we originally intended with our caret placement

### Is it tested? How?
Unit tests continue to pass.

I double-checked all `position` values one-by-one in this PR, by running `test.only()` for each edited test, and ensuring the old `position` matched the new. This was an onerous task, but the benefit is that we can be sure the old and new units are testing exactly the same thing. Please see the review notes for more detail.
