### PR TITLE
Fix auto complete enum string with quote on number

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -29,7 +29,7 @@ import { YAMLSchemaService } from './yamlSchemaService';
 import { ResolvedSchema } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { stringifyObject, StringifySettings } from '../utils/json';
-import { convertErrorToTelemetryMsg, isDefined, isNumber, isString } from '../utils/objects';
+import { convertErrorToTelemetryMsg, isDefined, isString } from '../utils/objects';
 import * as nls from 'vscode-nls';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { asSchema } from '../parser/jsonParser07';

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1201,19 +1201,19 @@ export class YamlCompletion {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private getInsertTextForValue(value: any, separatorAfter: string, type: string | string[]): string {
     if (value === null) {
-      value = 'null'; // replace type null with string 'null'
+      return 'null'; // replace type null with string 'null'
     }
     switch (typeof value) {
       case 'object': {
         const indent = this.indentation;
         return this.getInsertTemplateForValue(value, indent, { index: 1 }, separatorAfter);
       }
-    }
-    const types = Array.isArray(type) ? type : type;
-    if (types && (types === 'string' || types[0] === 'string')) {
-      if (Array.isArray(types) && types.includes('integer') && isNumber(value)) {
+      case 'number':
+      case 'boolean':
         return this.getInsertTextForPlainText(value + separatorAfter);
-      }
+    }
+    type = Array.isArray(type) ? type[0] : type;
+    if (type === 'string') {
       value = convertToStringValue(value);
     }
     return this.getInsertTextForPlainText(value + separatorAfter);

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1210,7 +1210,7 @@ export class YamlCompletion {
       }
     }
     const types = Array.isArray(type) ? type : type;
-    if (types === 'string' || types[0] === 'string') {
+    if (types && (types === 'string' || types[0] === 'string')) {
       if (Array.isArray(types) && types.includes('integer') && isNumber(value)) {
         return this.getInsertTextForPlainText(value + separatorAfter);
       }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1309,7 +1309,7 @@ export class YamlCompletion {
         collector.add({
           kind: this.getSuggestionKind(schema.type),
           label: this.getLabelForValue(enm),
-          insertText: this.getInsertTextForValue(enm, separatorAfter, undefined),
+          insertText: this.getInsertTextForValue(enm, separatorAfter, schema.type),
           insertTextFormat: InsertTextFormat.Snippet,
           documentation: documentation,
         });
@@ -1550,7 +1550,7 @@ function convertToStringValue(param: unknown): string {
     value = value.replace(doubleQuotesEscapeRegExp, '"');
   }
 
-  let doQuote = value.charAt(0) === '@';
+  let doQuote = !isNaN(parseInt(value)) || value.charAt(0) === '@';
 
   if (!doQuote) {
     // need to quote value if in `foo: bar`, `foo : bar` (mapping) or `foo:` (partial map) format

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -29,7 +29,7 @@ import { YAMLSchemaService } from './yamlSchemaService';
 import { ResolvedSchema } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { stringifyObject, StringifySettings } from '../utils/json';
-import { convertErrorToTelemetryMsg, isDefined, isString } from '../utils/objects';
+import { convertErrorToTelemetryMsg, isDefined, isNumber, isString } from '../utils/objects';
 import * as nls from 'vscode-nls';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { asSchema } from '../parser/jsonParser07';
@@ -1209,8 +1209,11 @@ export class YamlCompletion {
         return this.getInsertTemplateForValue(value, indent, { index: 1 }, separatorAfter);
       }
     }
-    type = Array.isArray(type) ? type[0] : type;
-    if (type === 'string') {
+    const types = Array.isArray(type) ? type : type;
+    if (types === 'string' || types[0] === 'string') {
+      if (Array.isArray(types) && types.includes('integer') && isNumber(value)) {
+        return this.getInsertTextForPlainText(value + separatorAfter);
+      }
       value = convertToStringValue(value);
     }
     return this.getInsertTextForPlainText(value + separatorAfter);

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -319,21 +319,22 @@ objB:
         version: {
           type: 'array',
           items: {
-            enum: ['12.1', 13, '13.1', '14.0', 'all', 14.4, false, null],
-            type: ['string', 'integer', 'number', 'boolean', 'object'],
+            enum: ['12.1', 13, '13.1', '14.0', 'all', 14.4, false, null, ['test']],
+            type: ['string', 'integer', 'number', 'boolean', 'object', 'array'],
           },
         },
       },
     });
     const content = 'version:\n  - ';
     const completion = await parseSetup(content, 2, 0);
-    expect(completion.items).lengthOf(8);
+    expect(completion.items).lengthOf(9);
     expect(completion.items[0].insertText).equal('"12.1"');
     expect(completion.items[1].insertText).equal('13');
     expect(completion.items[4].insertText).equal('all');
     expect(completion.items[5].insertText).equal('14.4');
     expect(completion.items[6].insertText).equal('false');
     expect(completion.items[7].insertText).equal('null');
+    expect(completion.items[8].insertText).equal('\n  - ${1:test}\n');
   });
 
   it('Autocomplete indent on array when parent is array', async () => {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -293,6 +293,26 @@ objB:
     expect(completion.items[1].insertText).equal('PodTemplate');
   });
 
+  it('Test that properties have enum of string type with number', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        version: {
+          type: 'array',
+          items: {
+            enum: ['12.1', '13.0', '13.1', '14.0', 'all'],
+            type: 'string',
+          },
+        },
+      },
+    });
+    const content = 'version:\n  - ';
+    const completion = await parseSetup(content, 2, 0);
+    expect(completion.items).lengthOf(5);
+    expect(completion.items[0].insertText).equal('"12.1"');
+    expect(completion.items[4].insertText).equal('all');
+  });
+
   it('Autocomplete indent on array when parent is array', async () => {
     languageService.addSchema(SCHEMA_ID, {
       type: 'object',

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -319,8 +319,8 @@ objB:
         version: {
           type: 'array',
           items: {
-            enum: ['12.1', '13.0', '13.1', '14.0', 'all'],
-            type: 'string',
+            enum: ['12.1', 13, '13.1', '14.0', 'all'],
+            type: ['string', 'integer'],
           },
         },
       },
@@ -329,6 +329,7 @@ objB:
     const completion = await parseSetup(content, 2, 0);
     expect(completion.items).lengthOf(5);
     expect(completion.items[0].insertText).equal('"12.1"');
+    expect(completion.items[1].insertText).equal('13');
     expect(completion.items[4].insertText).equal('all');
   });
 

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -319,18 +319,21 @@ objB:
         version: {
           type: 'array',
           items: {
-            enum: ['12.1', 13, '13.1', '14.0', 'all'],
-            type: ['string', 'integer'],
+            enum: ['12.1', 13, '13.1', '14.0', 'all', 14.4, false, null],
+            type: ['string', 'integer', 'number', 'boolean', 'object'],
           },
         },
       },
     });
     const content = 'version:\n  - ';
     const completion = await parseSetup(content, 2, 0);
-    expect(completion.items).lengthOf(5);
+    expect(completion.items).lengthOf(8);
     expect(completion.items[0].insertText).equal('"12.1"');
     expect(completion.items[1].insertText).equal('13');
     expect(completion.items[4].insertText).equal('all');
+    expect(completion.items[5].insertText).equal('14.4');
+    expect(completion.items[6].insertText).equal('false');
+    expect(completion.items[7].insertText).equal('null');
   });
 
   it('Autocomplete indent on array when parent is array', async () => {


### PR DESCRIPTION
### What does this PR do?

This PR adding double quotes to the number when enum type is string and it has number variable on it. 
Ex: "enum": ["12.1", "13.0", "13.1", "14.0", "all"]

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/709

### Is it tested? How?
Yes, added UT
