### PR TITLE
fix: extra space after position

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -105,6 +105,10 @@ export class SingleYAMLDocument extends JSONDocument {
       return [this.findClosestNode(positionOffset, textBuffer, configuredIndentation), true];
     }
 
+    const textAfterPosition = lineContent.substring(position.character);
+    const spacesAfterPositionMatch = textAfterPosition.match(/^([ ]+)\n?$/);
+    const areOnlySpacesAfterPosition = !!spacesAfterPositionMatch;
+    const countOfSpacesAfterPosition = spacesAfterPositionMatch?.[1].length;
     let closestNode: Node;
     visit(this.internalDocument, (key, node: Node) => {
       if (!node) {
@@ -115,7 +119,13 @@ export class SingleYAMLDocument extends JSONDocument {
         return;
       }
 
-      if (range[0] <= positionOffset && range[1] >= positionOffset) {
+      const isNullNodeOnTheLine = (): boolean =>
+        areOnlySpacesAfterPosition &&
+        positionOffset + countOfSpacesAfterPosition === range[2] &&
+        isScalar(node) &&
+        node.value === null;
+
+      if ((range[0] <= positionOffset && range[1] >= positionOffset) || isNullNodeOnTheLine()) {
         closestNode = node;
       } else {
         return visit.SKIP;

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -128,10 +128,15 @@ export class YamlCompletion {
     let [node, foundByClosest] = currentDoc.getNodeFromPosition(offset, textBuffer, this.indentation.length);
 
     const currentWord = this.getCurrentWord(document, offset);
+    let lineContent = textBuffer.getLineContent(position.line);
+    const lineAfterPosition = lineContent.substring(position.character);
+    const areOnlySpacesAfterPosition = /^[ ]+\n?$/.test(lineAfterPosition);
 
     this.arrayPrefixIndentation = '';
     let overwriteRange: Range = null;
-    if (node && isScalar(node) && node.value === 'null') {
+    if (areOnlySpacesAfterPosition) {
+      overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
+    } else if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);
       nodeStartPos.character += 1;
       const nodeEndPos = document.positionAt(node.range[2]);
@@ -266,7 +271,6 @@ export class YamlCompletion {
       this.getCustomTagValueCompletions(collector);
     }
 
-    let lineContent = textBuffer.getLineContent(position.line);
     if (lineContent.endsWith('\n')) {
       lineContent = lineContent.substr(0, lineContent.length - 1);
     }
@@ -324,34 +328,8 @@ export class YamlCompletion {
         }
       }
 
-      let originalNode = node;
+      const originalNode = node;
       if (node) {
-        // when the value is null but the cursor is between prop name and null value (cursor is not at the end of the line)
-        if (isMap(node) && node.items.length && isPair(node.items[0])) {
-          const pairNode = node.items[0];
-          if (
-            isScalar(pairNode.value) &&
-            isScalar(pairNode.key) &&
-            pairNode.value.value === null && // value is null
-            pairNode.key.range[2] < offset && // cursor is after colon
-            pairNode.value.range[0] > offset // cursor is before null
-          ) {
-            node = pairNode.value;
-            overwriteRange.end.character += pairNode.value.range[2] - offset; // extend range to the end of the null element
-          }
-        }
-        // when the array item value is null but the cursor is between '-' and null value (cursor is not at the end of the line)
-        if (isSeq(node) && node.items.length && isScalar(node.items[0]) && lineContent.includes('-')) {
-          const nullNode = node.items[0];
-          if (
-            nullNode.value === null && // value is null
-            nullNode.range[0] > offset // cursor is before null
-          ) {
-            node = nullNode;
-            originalNode = node;
-            overwriteRange.end.character += nullNode.range[2] - offset; // extend range to the end of the null element
-          }
-        }
         if (lineContent.length === 0) {
           node = currentDoc.internalDocument.contents as Node;
         } else {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1306,7 +1306,7 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 4, 9, 2, {
+              createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
                 documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- name: test\n```' },
               })
             );


### PR DESCRIPTION
### What does this PR do?
fix another situation with extra space after the current cursor.
My previous fixes covered only some of the possible situations (https://github.com/redhat-developer/yaml-language-server/pull/696, https://github.com/redhat-developer/yaml-language-server/pull/697)

there were still problems in this type of yaml (2nd position)

```yaml
array:
  - prop1: val1
     prop2: #__ (#cursor, _space)
```

```yaml
obj:
  prop1: val1
  prop2: #__ (#cursor, _space)
```

This fix will solve this situation (for object, arrays in one place) by finding the correct node inside `getNodeFromPosition`, instead of fixing it later and trying to find a better node (null node).

Another part of this PR is to overwrite range - remove extra space 

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
modified and added unit tests