### PR TITLE
fix: zero-based index

### DIFF
--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -41,7 +41,7 @@ export class TextBuffer {
   }
 
   getLineCharCode(lineNumber: number, index: number): number {
-    return this.doc.getText(Range.create(lineNumber - 1, index - 1, lineNumber - 1, index)).charCodeAt(0);
+    return this.doc.getText(Range.create(lineNumber - 1, index, lineNumber - 1, index + 1)).charCodeAt(0);
   }
 
   getText(range?: Range): string {

--- a/test/textBuffer.test.ts
+++ b/test/textBuffer.test.ts
@@ -38,7 +38,7 @@ describe('TextBuffer', () => {
 
   it('getLineCharCode should return charCode', () => {
     const buffer = new TextBuffer(TextDocument.create('file://foo/bar', 'yaml', 1, 'Foo\nbar\nfooBar\nsome'));
-    const charCode = buffer.getLineCharCode(3, 4);
+    const charCode = buffer.getLineCharCode(3, 3);
     assert.strictEqual(charCode, 'B'.charCodeAt(0));
   });
 });


### PR DESCRIPTION
### What does this PR do?

My project uses `yaml-language-server`, and I got these errors in Sentry:

```
Error: Range#create called with invalid arguments[1682, -1, 1682, 0]
4    at Object.e.create
5  at Object.e.create
6  at Zl.getLineCharCode
```

Unfortunately, I wasn't able to reproduce this error, so all my work is just following the stacktrace.

### What issues does this PR fix or reference?

The only place where the function `getLineCharCode` is used is here:

https://github.com/redhat-developer/yaml-language-server/blob/eae5206655503a59023abed1713f4623ea1bd93d/src/languageservice/utils/indentationGuesser.ts#L136-L138

Both surrounding code and description on `charCodeAt` suggest that this index should be 0-based, but the `getLineCharCode` is written with a 1-based index in mind, which seems like the source of this bug.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

I wasn't able to reproduce the original issue, so it's hard for me to test this fix.