### PR TITLE
fix: partial key with trailing spaces + PR#732 changes

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -105,6 +105,10 @@ export class SingleYAMLDocument extends JSONDocument {
       return [this.findClosestNode(positionOffset, textBuffer, configuredIndentation), true];
     }
 
+    const textAfterPosition = lineContent.substring(position.character);
+    const spacesAfterPositionMatch = textAfterPosition.match(/^([ ]+)\n?$/);
+    const areOnlySpacesAfterPosition = !!spacesAfterPositionMatch;
+    const countOfSpacesAfterPosition = spacesAfterPositionMatch?.[1].length;
     let closestNode: Node;
     visit(this.internalDocument, (key, node: Node) => {
       if (!node) {
@@ -115,7 +119,13 @@ export class SingleYAMLDocument extends JSONDocument {
         return;
       }
 
-      if (range[0] <= positionOffset && range[1] >= positionOffset) {
+      const isNullNodeOnTheLine = (): boolean =>
+        areOnlySpacesAfterPosition &&
+        positionOffset + countOfSpacesAfterPosition === range[2] &&
+        isScalar(node) &&
+        node.value === null;
+
+      if ((range[0] <= positionOffset && range[1] >= positionOffset) || isNullNodeOnTheLine()) {
         closestNode = node;
       } else {
         return visit.SKIP;

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -128,10 +128,15 @@ export class YamlCompletion {
     let [node, foundByClosest] = currentDoc.getNodeFromPosition(offset, textBuffer, this.indentation.length);
 
     const currentWord = this.getCurrentWord(document, offset);
+    let lineContent = textBuffer.getLineContent(position.line);
+    const lineAfterPosition = lineContent.substring(position.character);
+    const areOnlySpacesAfterPosition = /^[ ]+\n?$/.test(lineAfterPosition);
 
     this.arrayPrefixIndentation = '';
     let overwriteRange: Range = null;
-    if (node && isScalar(node) && node.value === 'null') {
+    if (areOnlySpacesAfterPosition) {
+      overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
+    } else if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);
       nodeStartPos.character += 1;
       const nodeEndPos = document.positionAt(node.range[2]);
@@ -266,7 +271,6 @@ export class YamlCompletion {
       this.getCustomTagValueCompletions(collector);
     }
 
-    let lineContent = textBuffer.getLineContent(position.line);
     if (lineContent.endsWith('\n')) {
       lineContent = lineContent.substr(0, lineContent.length - 1);
     }
@@ -324,34 +328,8 @@ export class YamlCompletion {
         }
       }
 
-      let originalNode = node;
+      const originalNode = node;
       if (node) {
-        // when the value is null but the cursor is between prop name and null value (cursor is not at the end of the line)
-        if (isMap(node) && node.items.length && isPair(node.items[0])) {
-          const pairNode = node.items[0];
-          if (
-            isScalar(pairNode.value) &&
-            isScalar(pairNode.key) &&
-            pairNode.value.value === null && // value is null
-            pairNode.key.range[2] < offset && // cursor is after colon
-            pairNode.value.range[0] > offset // cursor is before null
-          ) {
-            node = pairNode.value;
-            overwriteRange.end.character += pairNode.value.range[2] - offset; // extend range to the end of the null element
-          }
-        }
-        // when the array item value is null but the cursor is between '-' and null value (cursor is not at the end of the line)
-        if (isSeq(node) && node.items.length && isScalar(node.items[0]) && lineContent.includes('-')) {
-          const nullNode = node.items[0];
-          if (
-            nullNode.value === null && // value is null
-            nullNode.range[0] > offset // cursor is before null
-          ) {
-            node = nullNode;
-            originalNode = node;
-            overwriteRange.end.character += nullNode.range[2] - offset; // extend range to the end of the null element
-          }
-        }
         if (lineContent.length === 0) {
           node = currentDoc.internalDocument.contents as Node;
         } else {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -137,6 +137,17 @@ export class YamlCompletion {
     let overwriteRange: Range = null;
     if (areOnlySpacesAfterPosition) {
       overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
+      const isOnlyWhitespace = lineContent.trim().length === 0;
+      if (node && isScalar(node) && !isOnlyWhitespace) {
+        // line contains part of a key with trailing spaces, adjust the overwrite range to include only the text
+        const matches = lineContent.match(/^([\s-]*)[^:]+[ \t]+\n?$/);
+        if (matches?.length) {
+          overwriteRange = Range.create(
+            Position.create(position.line, matches[1].length),
+            Position.create(position.line, lineContent.length)
+          );
+        }
+      }
     } else if (node && isScalar(node) && node.value === 'null') {
       const nodeStartPos = document.positionAt(node.range[0]);
       nodeStartPos.character += 1;

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1306,7 +1306,7 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 4, 9, 2, {
+              createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
                 documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- name: test\n```' },
               })
             );

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -536,6 +536,93 @@ objB:
       expect(completion.items[0].textEdit).to.be.deep.equal({ newText: 'const', range: Range.create(0, 6, 0, 8) });
     });
 
+    it('partial key with trailing spaces', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          name: {
+            const: 'my name',
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'na  ';
+      const completion = await parseSetup(content, 0, 2);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('name', 'name: my name', 0, 0, 0, 4, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+    it('partial key with trailing spaces with new line', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          name: {
+            const: 'my name',
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'na  \n';
+      const completion = await parseSetup(content, 0, 2);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('name', 'name: my name', 0, 0, 0, 5, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+    it('partial key with leading and trailing spaces', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          name: {
+            const: 'my name',
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '  na  ';
+      const completion = await parseSetup(content, 0, 2);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('name', 'name: my name', 0, 2, 0, 4, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+
+    it('partial key with trailing spaces with special chars inside the array', async () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          array: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                'name / 123': {
+                  const: 'my name',
+                },
+              },
+            },
+          },
+        },
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'array:\n - name /   ';
+      const completion = await parseSetup(content, 1, 9);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0]).eql(
+        createExpectedCompletion('name / 123', 'name / 123: my name', 1, 3, 1, 12, 10, 2, {
+          documentation: '',
+        })
+      );
+    });
+
     it('object - 2nd nested property', async () => {
       const schema: JSONSchema = {
         properties: {


### PR DESCRIPTION
### What does this PR do?
Overwrite the range if the current line has trailing spaces.
this PR is based on PR #732 
  - that one fixed values with trailing spaces
but this one fixes properties with trailing spaces

note: it will be better to finish #732 and then this one, but it should be ok to just take this PR, because it includes all from 732.

```yaml
object:
  na#__ (#cursor, _space)
```
gives wrong code-completion range

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added unit tests