### PR TITLE
skip sibling object when object has colon

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -621,7 +621,7 @@ export class YamlCompletion {
     const matchOriginal = matchingSchemas.find((it) => it.node.internalNode === originalNode && it.schema.properties);
     for (const schema of matchingSchemas) {
       if (
-        ((schema.node.internalNode === node && !matchOriginal) || schema.node.internalNode === originalNode) &&
+        ((schema.node.internalNode === node && !matchOriginal) || (schema.node.internalNode === originalNode && !hasColon)) &&
         !schema.inverted
       ) {
         this.collectDefaultSnippets(schema.schema, separatorAfter, collector, {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -537,7 +537,6 @@ objB:
       });
       const content = 'scripts:   \n  sample: s';
       const completion = await parseSetup(content, 0, 9); // before line brake
-      console.log(completion);
       expect(completion.items.length).equal(0);
     });
   });

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -517,6 +517,29 @@ objB:
       expect(completion.items[1].label).to.be.equal('obj1');
       expect(completion.items[1].insertText).to.be.equal('obj1:\n  prop2: ${1:value}');
     });
+
+    it('Autocomplete should not suggest items for parent object', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          scripts: {
+            type: 'object',
+            properties: {
+              sample: {
+                type: 'string',
+              },
+            },
+          },
+          scripts2: {
+            type: 'string',
+          },
+        },
+      });
+      const content = 'scripts:   \n  sample: s';
+      const completion = await parseSetup(content, 0, 9); // before line brake
+      console.log(completion);
+      expect(completion.items.length).equal(0);
+    });
   });
   describe('extra space after cursor', () => {
     it('simple const', async () => {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -535,7 +535,7 @@ objB:
           },
         },
       });
-      const content = 'scripts:   \n  sample: s';
+      const content = 'scripts:   \n  sample: | |';
       const completion = await parseSetup(content, 0, 9); // before line brake
       expect(completion.items.length).equal(0);
     });


### PR DESCRIPTION
### What does this PR do?
This PR skips the sibling object suggestion when the other object has its value

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/664

### Is it tested? How?
Yes and added UT
