### PR TITLE
fix: proper indenting of snippet within an array

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -634,6 +634,7 @@ export class YamlCompletion {
     const lineContent = textBuffer.getLineContent(overwriteRange.start.line);
     const hasOnlyWhitespace = lineContent.trim().length === 0;
     const hasColon = lineContent.indexOf(':') !== -1;
+    const isInArray = lineContent.trimLeft().indexOf('-') === 0;
     const nodeParent = doc.getParent(node);
     const matchOriginal = matchingSchemas.find((it) => it.node.internalNode === originalNode && it.schema.properties);
     for (const schema of matchingSchemas) {
@@ -644,7 +645,7 @@ export class YamlCompletion {
         this.collectDefaultSnippets(schema.schema, separatorAfter, collector, {
           newLineFirst: false,
           indentFirstObject: false,
-          shouldIndentWithTab: false,
+          shouldIndentWithTab: isInArray,
         });
 
         const schemaProperties = schema.schema.properties;

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -232,7 +232,7 @@ describe('Default Snippet Tests', () => {
       const completion = parseSetup(content);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 14); // This is just checking the total number of snippets in the defaultSnippets.json
+          assert.equal(result.items.length, 15); // This is just checking the total number of snippets in the defaultSnippets.json
           assert.equal(result.items[4].label, 'longSnippet');
           // eslint-disable-next-line
           assert.equal(
@@ -299,6 +299,17 @@ describe('Default Snippet Tests', () => {
             result.items[0].insertText,
             'apple:\n  - name: source\n    resource:\n      prop1: value1\n      prop2: value2'
           );
+        })
+        .then(done, done);
+    });
+
+    it('Test snippet in array indented completion', (done) => {
+      const content = 'arrayWithSnippet:\n  - ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 4);
+          assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
         })
         .then(done, done);
     });

--- a/test/fixtures/defaultSnippets.json
+++ b/test/fixtures/defaultSnippets.json
@@ -216,6 +216,18 @@
           "suggestionKind": 9
         }
       ]
+    },
+    "arrayWithSnippet": {
+      "type": "array",
+      "items": {
+        "defaultSnippets": [
+          {
+            "label": "My array item",
+            "body": { "item1": "$1", "item2": "$2" }
+          }
+        ],
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
When choosing a snippet to auto-complete within an array, the indentation level was wrong on the lines below the insertion point.

```yaml
example:
  - #cursor here
```
would auto-complete to:
```yaml
example:
  - item1: "some item"
  item2: "another item"
```
rather than:
```yaml
example:
  - item1: "some item"
    item2: "another item"
```


### What issues does this PR fix or reference?
no ref

### Is it tested? How?
Manual tests as well as new unit test.