### PR TITLE
fix: default snippet in array

### DIFF
--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -402,6 +402,39 @@ objB:
       })
     );
   });
+  it('Autocomplete with snippet without hypen (-) inside an array', async () => {
+    languageService.addSchema(SCHEMA_ID, {
+      type: 'object',
+      properties: {
+        array1: {
+          type: 'array',
+          items: {
+            type: 'object',
+            defaultSnippets: [
+              {
+                label: 'My array item',
+                body: { item1: '$1' },
+              },
+            ],
+            required: ['thing1'],
+            properties: {
+              thing1: {
+                type: 'object',
+                required: ['item1'],
+                properties: {
+                  item1: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const content = 'array1:\n  - thing1:\n    item1: $1\n  | |';
+    const completion = await parseCaret(content);
+
+    expect(completion.items[1].insertText).to.be.equal('- item1: ');
+  });
   describe('array indent on different index position', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where default snippets where not being entered correctly within an array.

Given the following schema:
```json
{
  "type": "object",
  "properties": {
    "array1": {
      "type": "array",
      "items": {
        "type": "object",
        "defaultSnippets": [
          {
            "label": "My array item",
            "body": { "item1": "$1" }
          }
        ],
        "required": ["thing1"],
        "properties": {
          "thing1": {
            "type": "object",
            "required": ["item1"],
            "properties": {
              "item1": { "type": "string" }
            }
          }
        }
      }
    }
  }
}
```

When autocomplete is attempted on:
```yaml
array1:
  - thing1:
      item1: aa
  #cursor here
 ```
It previously autocompleted to:
```yaml
array1:
  - thing1:
      item1: aa

      item1:
```
After the fix it correctly indents as:
```yaml
array1:
  - thing1:
      item1: aa
  - item1: 
```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
Manual testing and unit test.
