### PR TITLE
fix: completion nested array item to flat structure

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -35,7 +35,7 @@ import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { asSchema } from '../parser/jsonParser07';
 import { indexOf, isInComment, isMapContainsEmptyPair } from '../utils/astUtils';
 import { isModeline } from './modelineUtil';
-import { getSchemaTypeName } from '../utils/schemaUtils';
+import { getSchemaTypeName, isAnyOfAllOfOneOfType, isPrimitiveType } from '../utils/schemaUtils';
 import { YamlNode } from '../jsonASTTypes';
 
 const localize = nls.loadMessageBundle();
@@ -58,6 +58,7 @@ interface CompletionsCollector {
   error(message: string): void;
   log(message: string): void;
   getNumberOfProposals(): number;
+  result: CompletionList;
 }
 
 interface InsertText {
@@ -277,6 +278,7 @@ export class YamlCompletion {
       getNumberOfProposals: () => {
         return result.items.length;
       },
+      result,
     };
 
     if (this.customTags.length > 0) {
@@ -687,24 +689,9 @@ export class YamlCompletion {
                     pair
                   ) {
                     if (Array.isArray(propertySchema.items)) {
-                      this.addSchemaValueCompletions(propertySchema.items[0], separatorAfter, collector, {});
+                      this.addSchemaValueCompletions(propertySchema.items[0], separatorAfter, collector, {}, 'property');
                     } else if (typeof propertySchema.items === 'object' && propertySchema.items.type === 'object') {
-                      const insertText = `- ${this.getInsertTextForObject(
-                        propertySchema.items,
-                        separatorAfter,
-                        '  '
-                      ).insertText.trimLeft()}`;
-                      const documentation = this.getDocumentationWithMarkdownText(
-                        `Create an item of an array${propertySchema.description ? ' (' + propertySchema.description + ')' : ''}`,
-                        insertText
-                      );
-                      collector.add({
-                        kind: this.getSuggestionKind(propertySchema.items.type),
-                        label: '- (array item)',
-                        documentation,
-                        insertText,
-                        insertTextFormat: InsertTextFormat.Snippet,
-                      });
+                      this.addArrayItemValueCompletion(propertySchema.items, separatorAfter, collector);
                     }
                   }
 
@@ -758,8 +745,15 @@ export class YamlCompletion {
         //  test:
         //    - item1
         // it will treated as a property key since `:` has been appended
-        if (nodeParent && isSeq(nodeParent) && schema.schema.type !== 'object') {
-          this.addSchemaValueCompletions(schema.schema, separatorAfter, collector, {}, Array.isArray(nodeParent.items));
+        if (nodeParent && isSeq(nodeParent) && isPrimitiveType(schema.schema)) {
+          this.addSchemaValueCompletions(
+            schema.schema,
+            separatorAfter,
+            collector,
+            {},
+            'property',
+            Array.isArray(nodeParent.items)
+          );
         }
 
         if (schema.schema.propertyNames && schema.schema.additionalProperties && schema.schema.type === 'object') {
@@ -823,7 +817,7 @@ export class YamlCompletion {
     }
 
     if (!node) {
-      this.addSchemaValueCompletions(schema.schema, '', collector, types);
+      this.addSchemaValueCompletions(schema.schema, '', collector, types, 'value');
       return;
     }
 
@@ -851,57 +845,25 @@ export class YamlCompletion {
               if (Array.isArray(s.schema.items)) {
                 const index = this.findItemAtOffset(node, document, offset);
                 if (index < s.schema.items.length) {
-                  this.addSchemaValueCompletions(s.schema.items[index], separatorAfter, collector, types);
+                  this.addSchemaValueCompletions(s.schema.items[index], separatorAfter, collector, types, 'value');
                 }
-              } else if (typeof s.schema.items === 'object' && s.schema.items.type === 'object') {
-                const insertText = `- ${this.getInsertTextForObject(s.schema.items, separatorAfter, '  ').insertText.trimLeft()}`;
-                const documentation = this.getDocumentationWithMarkdownText(
-                  `Create an item of an array${s.schema.description ? ' (' + s.schema.description + ')' : ''}`,
-                  insertText
-                );
-                collector.add({
-                  kind: this.getSuggestionKind(s.schema.items.type),
-                  label: '- (array item)',
-                  documentation,
-                  insertText,
-                  insertTextFormat: InsertTextFormat.Snippet,
-                });
-
-                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
-              } else if (typeof s.schema.items === 'object' && s.schema.items.anyOf) {
-                s.schema.items.anyOf
-                  .filter((i) => typeof i === 'object')
-                  .forEach((i: JSONSchema, index) => {
-                    const schemaType = getSchemaTypeName(i);
-                    const insertText = `- ${this.getInsertTextForObject(i, separatorAfter).insertText.trimLeft()}`;
-                    //append insertText to documentation
-                    const schemaTypeTitle = schemaType ? ' type `' + schemaType + '`' : '';
-                    const schemaDescription = s.schema.description ? ' (' + s.schema.description + ')' : '';
-                    const documentation = this.getDocumentationWithMarkdownText(
-                      `Create an item of an array${schemaTypeTitle}${schemaDescription}`,
-                      insertText
-                    );
-                    collector.add({
-                      kind: this.getSuggestionKind(i.type),
-                      label: '- (array item) ' + (schemaType || index + 1),
-                      documentation: documentation,
-                      insertText: insertText,
-                      insertTextFormat: InsertTextFormat.Snippet,
-                    });
-                  });
-                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
+              } else if (
+                typeof s.schema.items === 'object' &&
+                (s.schema.items.type === 'object' || isAnyOfAllOfOneOfType(s.schema.items))
+              ) {
+                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types, 'value', true);
               } else {
-                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types);
+                this.addSchemaValueCompletions(s.schema.items, separatorAfter, collector, types, 'value');
               }
             }
           }
           if (s.schema.properties) {
             const propertySchema = s.schema.properties[parentKey];
             if (propertySchema) {
-              this.addSchemaValueCompletions(propertySchema, separatorAfter, collector, types);
+              this.addSchemaValueCompletions(propertySchema, separatorAfter, collector, types, 'value');
             }
           } else if (s.schema.additionalProperties) {
-            this.addSchemaValueCompletions(s.schema.additionalProperties, separatorAfter, collector, types);
+            this.addSchemaValueCompletions(s.schema.additionalProperties, separatorAfter, collector, types, 'value');
           }
         }
       }
@@ -914,6 +876,30 @@ export class YamlCompletion {
         this.addNullValueCompletion(separatorAfter, collector);
       }
     }
+  }
+
+  private addArrayItemValueCompletion(
+    schema: JSONSchema,
+    separatorAfter: string,
+    collector: CompletionsCollector,
+    index?: number
+  ): void {
+    const schemaType = getSchemaTypeName(schema);
+    const insertText = `- ${this.getInsertTextForObject(schema, separatorAfter).insertText.trimLeft()}`;
+    //append insertText to documentation
+    const schemaTypeTitle = schemaType ? ' type `' + schemaType + '`' : '';
+    const schemaDescription = schema.description ? ' (' + schema.description + ')' : '';
+    const documentation = this.getDocumentationWithMarkdownText(
+      `Create an item of an array${schemaTypeTitle}${schemaDescription}`,
+      insertText
+    );
+    collector.add({
+      kind: this.getSuggestionKind(schema.type),
+      label: '- (array item) ' + (schemaType || index),
+      documentation: documentation,
+      insertText: insertText,
+      insertTextFormat: InsertTextFormat.Snippet,
+    });
   }
 
   private getInsertTextForProperty(
@@ -1251,25 +1237,32 @@ export class YamlCompletion {
     separatorAfter: string,
     collector: CompletionsCollector,
     types: unknown,
+    completionType: 'property' | 'value',
     isArray?: boolean
   ): void {
     if (typeof schema === 'object') {
       this.addEnumValueCompletions(schema, separatorAfter, collector, isArray);
       this.addDefaultValueCompletions(schema, separatorAfter, collector);
       this.collectTypes(schema, types);
+
+      if (isArray && completionType === 'value' && !isAnyOfAllOfOneOfType(schema)) {
+        // add array only for final types (no anyOf, allOf, oneOf)
+        this.addArrayItemValueCompletion(schema, separatorAfter, collector);
+      }
+
       if (Array.isArray(schema.allOf)) {
         schema.allOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, completionType, isArray);
         });
       }
       if (Array.isArray(schema.anyOf)) {
         schema.anyOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, completionType, isArray);
         });
       }
       if (Array.isArray(schema.oneOf)) {
         schema.oneOf.forEach((s) => {
-          return this.addSchemaValueCompletions(s, separatorAfter, collector, types);
+          return this.addSchemaValueCompletions(s, separatorAfter, collector, types, completionType, isArray);
         });
       }
     }

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -55,3 +55,11 @@ export function getSchemaTitle(schema: JSONSchema, url: string): string {
 
   return baseName;
 }
+
+export function isPrimitiveType(schema: JSONSchema): boolean {
+  return schema.type !== 'object' && !isAnyOfAllOfOneOfType(schema);
+}
+
+export function isAnyOfAllOfOneOfType(schema: JSONSchema): boolean {
+  return !!(schema.anyOf || schema.allOf || schema.oneOf);
+}

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1050,8 +1050,8 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- ', 2, 2, 2, 2, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
+              createExpectedCompletion('- (array item) object', '- ', 2, 2, 2, 2, 9, 2, {
+                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
               })
             );
           })
@@ -1085,8 +1085,8 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- ', 1, 0, 1, 0, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- \n```' },
+              createExpectedCompletion('- (array item) object', '- ', 1, 0, 1, 0, 9, 2, {
+                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
               })
             );
           })
@@ -1306,8 +1306,8 @@ describe('Auto Completion Tests', () => {
             assert.equal(result.items.length, 1);
             assert.deepEqual(
               result.items[0],
-              createExpectedCompletion('- (array item)', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array\n ```\n- name: test\n```' },
+              createExpectedCompletion('- (array item) object', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
+                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- name: test\n```' },
               })
             );
           })
@@ -2529,7 +2529,7 @@ describe('Auto Completion Tests', () => {
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item)');
+          assert.equal(result.items[0].label, '- (array item) obj1');
         })
         .then(done, done);
     });
@@ -2586,7 +2586,7 @@ describe('Auto Completion Tests', () => {
       completion
         .then(function (result) {
           assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item)');
+          assert.equal(result.items[0].label, '- (array item) obj1');
         })
         .then(done, done);
     });
@@ -2598,8 +2598,19 @@ describe('Auto Completion Tests', () => {
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].label, '- (array item) obj1');
+          expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2']);
+        })
+        .then(done, done);
+    });
+
+    it('Array nested anyOf without "-" should return all array items', (done) => {
+      const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'test_array_nested_anyOf:\n  - obj1:\n    name:1\n  ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2', '- (array item) obj3']);
         })
         .then(done, done);
     });

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -275,10 +275,10 @@ objB:
     const completion = await parseCaret(content);
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
-      createExpectedCompletion('- (array item)', '- ', 1, 2, 1, 2, 9, 2, {
+      createExpectedCompletion('- (array item) object', '- ', 1, 2, 1, 2, 9, 2, {
         documentation: {
           kind: 'markdown',
-          value: 'Create an item of an array\n ```\n- \n```',
+          value: 'Create an item of an array type `object`\n ```\n- \n```',
         },
       })
     );

--- a/test/fixtures/testArrayCompletionSchema.json
+++ b/test/fixtures/testArrayCompletionSchema.json
@@ -1,85 +1,110 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "definitions": {
-      "obj1": {
-        "properties": {
-          "obj1": {
-            "type": "object"
-          }
-        },
-        "required": [
-          "obj1"
-        ],
-        "type": "object"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "obj1": {
+      "properties": {
+        "obj1": {
+          "type": "object"
+        }
       },
-      "obj2": {
-        "properties": {
-          "obj2": {
-            "type": "object"
-          }
-        },
-        "required": [
-          "obj2"
-        ],
-        "type": "object"
-      }
+      "required": ["obj1"],
+      "type": "object"
     },
-    "properties": {
-      "test_simpleArrayObject": {
-        "items": {
-          "$ref": "#/definitions/obj1"
-        },
-        "type": "array"
+    "obj2": {
+      "properties": {
+        "obj2": {
+          "type": "object"
+        }
       },
-      "test_array_anyOf_2objects": {
-        "items": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/obj1"
-            },
-            {
-              "$ref": "#/definitions/obj2"
-            }
-          ]
-        },
-        "type": "array"
+      "required": ["obj2"],
+      "type": "object"
+    },
+    "obj3": {
+      "properties": {
+        "obj3": {
+          "type": "object"
+        }
       },
-      "test_array_anyOf_strAndObj": {
-        "items": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/obj1"
-            }
-          ]
-        },
-        "type": "array"
+      "required": ["obj3"],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "test_simpleArrayObject": {
+      "items": {
+        "$ref": "#/definitions/obj1"
       },
-      "test_anyOfObjectAndNull": {
+      "type": "array"
+    },
+    "test_array_anyOf_2objects": {
+      "items": {
         "anyOf": [
           {
             "$ref": "#/definitions/obj1"
           },
           {
-            "type": "null"
+            "$ref": "#/definitions/obj2"
           }
         ]
       },
-      "test_anyOfArrAndNull": {
+      "type": "array"
+    },
+    "test_array_anyOf_strAndObj": {
+      "items": {
         "anyOf": [
           {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "string"
           },
           {
-            "type": "null"
+            "$ref": "#/definitions/obj1"
           }
         ]
-      }
+      },
+      "type": "array"
     },
-    "type": "object"
-  }
+    "test_anyOfObjectAndNull": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/obj1"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "test_anyOfArrAndNull": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "test_array_nested_anyOf": {
+      "items": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/obj1"
+              },
+              {
+                "$ref": "#/definitions/obj2"
+              }
+            ]
+          },
+          {
+            "$ref": "#/definitions/obj3"
+          }
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
### What does this PR do?
 - fix array nested structure
    - the previous implementation didn't go deeper into nested schemas (nested anyof)
 - unify array item value completion
    - there were three almost identical implementation 

schema:
```json
"test_array_nested_anyOf": {
      "items": {
        "anyOf": [
          {
            "anyOf": [
              {
                "$ref": "#/definitions/obj1"
              },
              {
                "$ref": "#/definitions/obj2"
              }
            ]
          },
          {
            "$ref": "#/definitions/obj3"
          }
        ]
      },
      "type": "array"
    }
```

#### Previous
```yaml
test_array_nested_anyOf:
  # invoke here
```
gives only two items:
 1st for `anyOf`
 2nd for `obj3`

<img width="208" alt="image" src="https://user-images.githubusercontent.com/38421337/182145964-d0244de4-66cc-4737-99b4-22ec435cb7b2.png">


#### After
The nested array item structure is flattened
<img width="213" alt="image" src="https://user-images.githubusercontent.com/38421337/182146316-2c1cf0c2-cbae-4501-a42a-b5631e71a938.png">

note that without `- obj1: null` in screenshots YLS doesn't know that we are in an array and won't give any results


### What issues does this PR fix or reference?
no ref


### Is it tested? How?
add UT and modify existing
