### PR TITLE
feat: add if filePatternAssociation

### DIFF
--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -89,6 +89,8 @@ export interface JSONSchema {
   allowComments?: boolean; // VSCode extension
 
   schemaSequence?: JSONSchema[]; // extension for multiple schemas related to multiple documents in single yaml file
+
+  filePatternAssociation?: string; // extension for if condition to be able compare doc yaml uri with this file pattern association
 }
 
 export interface JSONSchemaMap {

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -819,7 +819,8 @@ function validate(
             source: getSchemaSource(schema, originalSchema),
             schemaUri: getSchemaUri(schema, originalSchema),
           });
-          validationResult.merge(subValidationResult);
+          // don't want to expose the error up to code-completion results
+          // validationResult.merge(subValidationResult);
         }
       }
 

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -40,6 +40,7 @@ export class SingleYAMLDocument extends JSONDocument {
     const copy = new SingleYAMLDocument(this.lineCounter);
     copy.isKubernetes = this.isKubernetes;
     copy.disableAdditionalProperties = this.disableAdditionalProperties;
+    copy.uri = this.uri;
     copy.currentDocIndex = this.currentDocIndex;
     copy._lineComments = this.lineComments.slice();
     // this will re-create root node

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -111,6 +111,11 @@ export class YamlCompletion {
 
     setKubernetesParserOption(doc.documents, isKubernetes);
 
+    // set parser options
+    for (const jsonDoc of doc.documents) {
+      jsonDoc.uri = document.uri;
+    }
+
     const offset = document.offsetAt(position);
     const text = document.getText();
 

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -86,6 +86,7 @@ export class YAMLValidation {
         currentYAMLDoc.isKubernetes = isKubernetes;
         currentYAMLDoc.currentDocIndex = index;
         currentYAMLDoc.disableAdditionalProperties = this.disableAdditionalProperties;
+        currentYAMLDoc.uri = textDocument.uri;
 
         const validation = await this.jsonValidation.doValidation(textDocument, currentYAMLDoc);
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -944,6 +944,38 @@ describe('Auto Completion Tests', () => {
           })
         );
       });
+
+      describe('Conditional Schema', () => {
+        const schema = {
+          type: 'object',
+          title: 'basket',
+          properties: {
+            name: { type: 'string' },
+          },
+          if: {
+            filePatternAssociation: SCHEMA_ID,
+          },
+          then: {
+            properties: {
+              pineapple: { type: 'string' },
+            },
+            required: ['pineapple'],
+          },
+          else: {
+            properties: {
+              tomato: { type: 'string' },
+            },
+            required: ['tomato'],
+          },
+        };
+        it('should suggest "then" block if "if" match filePatternAssociation', async () => {
+          schema.if.filePatternAssociation = SCHEMA_ID;
+          languageService.addSchema(SCHEMA_ID, schema);
+          const content = 'name: aName\n';
+          const completion = await parseSetup(content, content.length);
+          expect(completion.items.map((i) => i.label)).to.deep.equal(['pineapple', 'basket']);
+        });
+      });
     });
 
     describe('Array Specific Tests', function () {

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1390,10 +1390,7 @@ obj:
         const content = 'name: aName';
         const result = await parseSetup(content);
 
-        expect(result.map((r) => r.message)).to.deep.eq([
-          "filePatternAssociation 'wrong' does not match with doc uri 'default_schema_id.yaml'.",
-          'Missing property "tomato".',
-        ]);
+        expect(result.map((r) => r.message)).to.deep.eq(['Missing property "tomato".']);
       });
     });
   });

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1349,6 +1349,53 @@ obj:
       const result = await parseSetup(content);
       expect(result[0].message).to.eq('Missing property "pineapple".');
     });
+
+    describe('filePatternAssociation', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+        if: {
+          filePatternAssociation: SCHEMA_ID,
+        },
+        then: {
+          required: ['pineapple'],
+        },
+        else: {
+          required: ['tomato'],
+        },
+      };
+      it('validator use "then" block if "if" match filePatternAssociation', async () => {
+        schema.if.filePatternAssociation = SCHEMA_ID;
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'name: aName';
+        const result = await parseSetup(content);
+
+        expect(result.map((r) => r.message)).to.deep.eq(['Missing property "pineapple".']);
+      });
+      it('validator use "then" block if "if" match filePatternAssociation - regexp', async () => {
+        schema.if.filePatternAssociation = '*.yaml'; // SCHEMA_ID: "default_schema_id.yaml"
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'name: aName';
+        const result = await parseSetup(content);
+
+        expect(result.map((r) => r.message)).to.deep.eq(['Missing property "pineapple".']);
+      });
+      it('validator use "else" block if "if" not match filePatternAssociation', async () => {
+        schema.if.filePatternAssociation = 'wrong';
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = 'name: aName';
+        const result = await parseSetup(content);
+
+        expect(result.map((r) => r.message)).to.deep.eq([
+          "filePatternAssociation 'wrong' does not match with doc uri 'default_schema_id.yaml'.",
+          'Missing property "tomato".',
+        ]);
+      });
+    });
   });
 
   describe('Schema with uri-reference', () => {


### PR DESCRIPTION
### What does this PR do?
this PR adds the ability to extend 'schema if condition' with `filePatternAssociation`. it means that it's possible to extend if condition to be connected to some yaml filename.

basically, it's something similar to `yamlValidation: [{filematch, url}]` to find whole schema based on yaml filename, but this feature is for finding subschema based on the yaml name.

I added this because my schemas are dynamically created and I need some small modifications inside the schema based on the filename. 

```js
     {
          type: 'object',
          title: 'basket',
          properties: {
            name: { type: 'string' },
          },
          if: {
            filePatternAssociation: '*fruit.yaml',
          },
          then: {
            properties: {
              pineapple: { type: 'string' },
            },
            required: ['pineapple'],
          },
          else: {
            properties: {
              carrot: { type: 'string' },
            },
            required: ['carrot'],
          },
        }
```

yaml: `some-fruit.yaml`
```yaml
name: some fruit
pinnaple: 'ok'
```

yaml: `some-vegetable.yaml`
```yaml
name: some vegetable
carrot: 'ok'
```

I hope it can be useful for you too.

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added unit test for validation and codecompletion