### PR TITLE
Fix indentation with extra spaces after cursor.

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -138,7 +138,8 @@ export class YamlCompletion {
     if (areOnlySpacesAfterPosition) {
       overwriteRange = Range.create(position, Position.create(position.line, lineContent.length));
       const isOnlyWhitespace = lineContent.trim().length === 0;
-      if (node && isScalar(node) && !isOnlyWhitespace) {
+      const isOnlyDash = lineContent.match(/^\s*(-)\s*$/);
+      if (node && isScalar(node) && !isOnlyWhitespace && !isOnlyDash) {
         // line contains part of a key with trailing spaces, adjust the overwrite range to include only the text
         const matches = lineContent.match(/^([\s-]*)[^:]+[ \t]+\n?$/);
         if (matches?.length) {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -848,6 +848,82 @@ objB:
       expect(result.items.length).to.be.equal(1);
       expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
     });
+    it('array of arrays completion - should suggest correct indent when extra spaces after cursor', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          array1: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['array2'],
+              properties: {
+                array2: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    required: ['objA'],
+                    properties: {
+                      objA: {
+                        type: 'object',
+                        required: ['itemA'],
+                        properties: {
+                          itemA: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const content = 'array1:\n  -               ';
+      const result = await parseSetup(content, 1, 4);
+
+      expect(result.items.length).to.be.equal(2);
+      expect(result.items[0].insertText).to.be.equal('array2:\n    - objA:\n        itemA: ');
+    });
+    it('object of array of arrays completion - should suggest correct indent when extra spaces after cursor', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          array1: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                array2: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      objA: {
+                        type: 'object',
+                        required: ['itemA'],
+                        properties: {
+                          itemA: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const content = 'array1:\n  - array2:\n      -               ';
+      const result = await parseSetup(content, 2, 8);
+
+      expect(result.items.length).to.be.equal(1);
+      expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
+    });
   }); //'extra space after cursor'
 
   it('should suggest from additionalProperties', async () => {

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -819,6 +819,35 @@ objB:
         });
       });
     });
+    it('array completion - should suggest correct indent when extra spaces after cursor', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          test: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                objA: {
+                  type: 'object',
+                  required: ['itemA'],
+                  properties: {
+                    itemA: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const content = 'test:\n  -               ';
+      const result = await parseSetup(content, 1, 4);
+
+      expect(result.items.length).to.be.equal(1);
+      expect(result.items[0].insertText).to.be.equal('objA:\n    itemA: ');
+    });
   }); //'extra space after cursor'
 
   it('should suggest from additionalProperties', async () => {


### PR DESCRIPTION
### What does this PR do?
Fixes an indentation issue when you have trailing spaces after the hyphen.

Given the schema:
```yaml
{
  type: 'object',
  properties: {
    test: {
      type: 'array',
      items: {
        type: 'object',
        properties: {
          objA: {
            type: 'object',
            required: ['itemA'],
            properties: {
              itemA: {
                type: 'string',
              }
            }
          }
        }
      }
    }
  }
}
```
The following yaml:
```yaml
test:
  - #________(# = cursor, _ = spaces)
```
Would be autocompleted to:
```yaml
test:
  - objA:
             itemA: 
```
After the fix it autocompletes to:
```yaml
test:
  - objA:
      itemA: 
```
### What issues does this PR fix or reference?
no ref

### Is it tested? How?
Manual and unit test.