### PR TITLE
feat: add diagnostic data with missing properties

### DIFF
--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1308,7 +1308,25 @@ obj:
           16,
           DiagnosticSeverity.Error,
           'yaml-schema: Drone CI configuration file',
-          'https://json.schemastore.org/drone'
+          'https://json.schemastore.org/drone',
+          {
+            properties: [
+              'type',
+              'environment',
+              'steps',
+              'volumes',
+              'services',
+              'image_pull_secrets',
+              'node',
+              'concurrency',
+              'name',
+              'platform',
+              'workspace',
+              'clone',
+              'trigger',
+              'depends_on',
+            ],
+          }
         )
       );
     });
@@ -1587,6 +1605,35 @@ obj:
         const result = await parseSetup(content);
         expect(result.length).to.eq(1);
         expect(result[0].message).to.eq('Property prop2 is not allowed.');
+        expect((result[0].data as { properties: unknown })?.properties).to.deep.eq(['prop1']);
+      });
+
+      it('should return additional prop error when there is unknown prop - suggest missing props)', async () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            prop1: {
+              type: 'string',
+            },
+            prop2: {
+              type: 'string',
+            },
+          },
+        };
+        languageService.addSchema(SCHEMA_ID, schema);
+        const content = `prop1: value1\npropX: you should not be there 'propX'`;
+        const result = await parseSetup(content);
+        expect(
+          result.map((r) => ({
+            message: r.message,
+            properties: (r.data as { properties: unknown })?.properties,
+          }))
+        ).to.deep.eq([
+          {
+            message: 'Property propX is not allowed.',
+            properties: ['prop2'],
+          },
+        ]);
       });
 
       it('should allow additional props on object when additionalProp is true on object', async () => {

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -38,10 +38,11 @@ export function createDiagnosticWithData(
   endCharacter: number,
   severity: DiagnosticSeverity = 1,
   source = 'YAML',
-  schemaUri: string | string[]
+  schemaUri: string | string[],
+  data: Record<string, unknown> = {}
 ): Diagnostic {
   const diagnostic: Diagnostic = createExpectedError(message, startLine, startCharacter, endLine, endCharacter, severity, source);
-  diagnostic.data = { schemaUri: typeof schemaUri === 'string' ? [schemaUri] : schemaUri };
+  diagnostic.data = { schemaUri: typeof schemaUri === 'string' ? [schemaUri] : schemaUri, ...data };
   return diagnostic;
 }
 


### PR DESCRIPTION
### What does this PR do?
When problem `'Property {0} is not allowed.'` is found during diagnostic it will extend `diagnostic.data` by possible props that could be inside the object.
 - `diagnostic.data = Object.keys(schema.properties) subtract seenProperties`

then it can be used inside `CodeAction` to suggest proper properties instead of the wrong one.

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added tests