### PR TITLE
Make Telemetry an interface

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -10,7 +10,7 @@ import { checkSchemaURI, JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from '../
 import { LanguageService, LanguageSettings, SchemaPriority } from '../../languageservice/yamlLanguageService';
 import { SchemaSelectionRequests } from '../../requestTypes';
 import { Settings, SettingsState } from '../../yamlSettings';
-import { Telemetry } from '../telemetry';
+import { Telemetry } from '../../languageservice/telemetry';
 import { ValidationHandler } from './validationHandlers';
 
 export class SettingsHandler {

--- a/src/languageserver/telemetry.ts
+++ b/src/languageserver/telemetry.ts
@@ -4,20 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Connection } from 'vscode-languageserver';
+import { TelemetryEvent, Telemetry as TelemetryType } from '../languageservice/telemetry';
 
-/**
- * Due to LSP limitation this object must be JSON serializable
- */
-export interface TelemetryEvent {
-  name: string;
-  type?: string;
-  properties?: unknown;
-  measures?: unknown;
-  traits?: unknown;
-  context?: unknown;
-}
-
-export class Telemetry {
+export class Telemetry implements TelemetryType {
   constructor(private readonly connection: Connection) {}
 
   send(event: TelemetryEvent): void {

--- a/src/languageserver/telemetry.ts
+++ b/src/languageserver/telemetry.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Connection } from 'vscode-languageserver';
-import { TelemetryEvent, Telemetry as TelemetryType } from '../languageservice/telemetry';
+import { TelemetryEvent, Telemetry } from '../languageservice/telemetry';
 
-export class Telemetry implements TelemetryType {
+export class TelemetryImpl implements Telemetry {
   constructor(private readonly connection: Connection) {}
 
   send(event: TelemetryEvent): void {

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -11,7 +11,7 @@ import { JSONDocumentSymbols } from 'vscode-json-languageservice/lib/umd/service
 import { DocumentSymbolsContext } from 'vscode-json-languageservice/lib/umd/jsonLanguageTypes';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { isMap, isSeq, Node } from 'yaml';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
 

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -9,7 +9,7 @@ import { YamlCommands } from '../../commands';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { JSONSchema } from '../jsonSchema';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { getSchemaUrls } from '../utils/schemaUrls';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
 import { getSchemaTitle } from '../utils/schemaUtils';

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -18,7 +18,7 @@ import {
   TextEdit,
 } from 'vscode-languageserver-types';
 import { Node, isPair, isScalar, isMap, YAMLMap, isSeq, YAMLSeq, isNode, Pair } from 'yaml';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { SingleYAMLDocument, YamlDocuments } from '../parser/yaml-documents';
 import { YamlVersion } from '../parser/yamlParser07';
 import { filterInvalidCustomTags, matchOffsetToDocument } from '../utils/arrUtils';

--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -7,7 +7,7 @@ import { DefinitionParams } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DefinitionLink, LocationLink, Range } from 'vscode-languageserver-types';
 import { isAlias } from 'yaml';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { matchOffsetToDocument } from '../utils/arrUtils';
 import { convertErrorToTelemetryMsg } from '../utils/objects';

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -17,7 +17,7 @@ import { getNodeValue, IApplicableSchema } from '../parser/jsonParser07';
 import { JSONSchema } from '../jsonSchema';
 import { URI } from 'vscode-uri';
 import * as path from 'path';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
 import { ASTNode } from 'vscode-json-languageservice';
 

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -5,7 +5,7 @@
 import { findLinks as JSONFindLinks } from 'vscode-json-languageservice/lib/umd/services/jsonLinks';
 import { DocumentLink } from 'vscode-languageserver-types';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
 

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -16,7 +16,7 @@ import { YAML_SOURCE } from '../parser/jsonParser07';
 import { TextBuffer } from '../utils/textBuffer';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { convertErrorToTelemetryMsg } from '../utils/objects';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { AdditionalValidator } from './validation/types';
 import { UnusedAnchorsValidator } from './validation/unused-anchors';
 import { YAMLStyleValidator } from './validation/yaml-style';

--- a/src/languageservice/telemetry.ts
+++ b/src/languageservice/telemetry.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Due to LSP limitation this object must be JSON serializable
+ */
+export interface TelemetryEvent {
+  name: string;
+  type?: string;
+  properties?: unknown;
+  measures?: unknown;
+  traits?: unknown;
+  context?: unknown;
+}
+
+export interface Telemetry {
+  send(event: TelemetryEvent): void;
+
+  sendError(name: string, properties: unknown): void;
+
+  sendTrack(name: string, properties: unknown): void;
+}

--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -1,6 +1,6 @@
 import { WorkspaceFolder } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import { Telemetry } from '../../languageserver/telemetry';
+import { Telemetry } from '../telemetry';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { isBoolean } from './objects';
 import { isRelativePath, relativeToAbsolutePath } from './paths';

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -47,7 +47,7 @@ import { commandExecutor } from '../languageserver/commandExecutor';
 import { doDocumentOnTypeFormatting } from './services/yamlOnTypeFormatting';
 import { YamlCodeLens } from './services/yamlCodeLens';
 import { registerCommands } from './services/yamlCommands';
-import { Telemetry } from '../languageserver/telemetry';
+import { Telemetry } from './telemetry';
 import { YamlVersion } from './parser/yamlParser07';
 import { YamlCompletion } from './services/yamlCompletion';
 import { yamlDocumentsCache } from './parser/yaml-documents';

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { YAMLServerInit } from './yamlServerInit';
 import { SettingsState } from './yamlSettings';
 import { promises as fs } from 'fs';
 import { convertErrorToTelemetryMsg } from './languageservice/utils/objects';
-import { Telemetry } from './languageserver/telemetry';
+import { TelemetryImpl } from './languageserver/telemetry';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 nls.config(process.env['VSCODE_NLS_CONFIG'] as any);
@@ -69,6 +69,6 @@ const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promi
 };
 
 const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
-const telemetry = new Telemetry(connection);
+const telemetry = new TelemetryImpl(connection);
 
 new YAMLServerInit(connection, yamlSettings, workspaceContext, schemaRequestService, telemetry).start();

--- a/src/webworker/yamlServerMain.ts
+++ b/src/webworker/yamlServerMain.ts
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Connection, RequestType } from 'vscode-languageserver';
 import { createConnection, BrowserMessageReader, BrowserMessageWriter } from 'vscode-languageserver/browser';
-import { Telemetry } from '../languageserver/telemetry';
+import { TelemetryImpl } from '../languageserver/telemetry';
 import { schemaRequestHandler, workspaceContext } from '../languageservice/services/schemaRequestHandler';
 import { YAMLServerInit } from '../yamlServerInit';
 import { SettingsState } from '../yamlSettings';
@@ -46,6 +46,6 @@ const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promi
 };
 
 const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);
-const telemetry = new Telemetry(connection);
+const telemetry = new TelemetryImpl(connection);
 
 new YAMLServerInit(connection, yamlSettings, workspaceContext, schemaRequestService, telemetry).start();

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -16,7 +16,7 @@ import { SettingsHandler } from './languageserver/handlers/settingsHandlers';
 import { YamlCommands } from './commands';
 import { WorkspaceHandlers } from './languageserver/handlers/workspaceHandlers';
 import { commandExecutor } from './languageserver/commandExecutor';
-import { Telemetry } from './languageserver/telemetry';
+import { Telemetry } from './languageservice/telemetry';
 
 export class YAMLServerInit {
   languageService: LanguageService;

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -11,7 +11,7 @@ import { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver
 import { LanguageService, LanguageSettings, SchemaConfiguration, SchemaPriority } from '../src';
 import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import { Telemetry } from '../src/languageserver/telemetry';
+import { Telemetry } from '../src/languageservice/telemetry';
 import { SettingsState } from '../src/yamlSettings';
 import { setupLanguageService } from './utils/testHelper';
 import { TestWorkspace } from './utils/testsTypes';

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -6,7 +6,7 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { checkSchemaURI } from '../src/languageservice/utils/schemaUrls';
-import { Telemetry } from '../src/languageserver/telemetry';
+import { TelemetryImpl } from '../src/languageserver/telemetry';
 import { URI } from 'vscode-uri';
 import { Connection } from 'vscode-languageserver';
 
@@ -16,9 +16,9 @@ chai.use(sinonChai);
 describe('Telemetry Tests', () => {
   const sandbox = sinon.createSandbox();
 
-  let telemetry: sinon.SinonStubbedInstance<Telemetry>;
+  let telemetry: sinon.SinonStubbedInstance<TelemetryImpl>;
   beforeEach(() => {
-    const telemetryInstance = new Telemetry({} as Connection);
+    const telemetryInstance = new TelemetryImpl({} as Connection);
     telemetry = sandbox.stub(telemetryInstance);
   });
 
@@ -28,12 +28,12 @@ describe('Telemetry Tests', () => {
 
   describe('Kubernetos schema mapping', () => {
     it('should not report if schema is not k8s', () => {
-      checkSchemaURI([], URI.parse('file:///some/path'), 'file:///some/path/to/schema.json', (telemetry as unknown) as Telemetry);
+      checkSchemaURI([], URI.parse('file:///some/path'), 'file:///some/path/to/schema.json', telemetry);
       expect(telemetry.send).not.called;
     });
 
     it('should report if schema is k8s', () => {
-      checkSchemaURI([], URI.parse('file:///some/path'), 'kubernetes', (telemetry as unknown) as Telemetry);
+      checkSchemaURI([], URI.parse('file:///some/path'), 'kubernetes', telemetry);
       expect(telemetry.send).calledOnceWith({ name: 'yaml.schema.configured', properties: { kubernetes: true } });
     });
   });

--- a/test/utils/testsTypes.ts
+++ b/test/utils/testsTypes.ts
@@ -16,7 +16,7 @@ import {
   DeleteFilesParams,
 } from 'vscode-languageserver-protocol';
 import { Connection, RemoteWorkspace } from 'vscode-languageserver';
-import { Telemetry } from '../../src/languageserver/telemetry';
+import { TelemetryImpl } from '../../src/languageserver/telemetry';
 import { TelemetryEvent } from '../../src/languageservice/telemetry';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -58,7 +58,7 @@ export class TestWorkspace implements RemoteWorkspace {
   }
 }
 
-export class TestTelemetry extends Telemetry {
+export class TestTelemetry extends TelemetryImpl {
   messages: TelemetryEvent[] = [];
   constructor(connection: Connection) {
     super(connection);

--- a/test/utils/testsTypes.ts
+++ b/test/utils/testsTypes.ts
@@ -16,7 +16,8 @@ import {
   DeleteFilesParams,
 } from 'vscode-languageserver-protocol';
 import { Connection, RemoteWorkspace } from 'vscode-languageserver';
-import { Telemetry, TelemetryEvent } from '../../src/languageserver/telemetry';
+import { Telemetry } from '../../src/languageserver/telemetry';
+import { TelemetryEvent } from '../../src/languageservice/telemetry';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -11,7 +11,8 @@ import { setupTextDocument } from './utils/testHelper';
 import { JSONSchema } from '../src/languageservice/jsonSchema';
 import { CodeLens, Command, Range } from 'vscode-languageserver-protocol';
 import { YamlCommands } from '../src/commands';
-import { Telemetry } from '../src/languageserver/telemetry';
+import { TelemetryImpl } from '../src/languageserver/telemetry';
+import { Telemetry } from '../src/languageservice/telemetry';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -19,13 +20,13 @@ chai.use(sinonChai);
 describe('YAML CodeLens', () => {
   const sandbox = sinon.createSandbox();
   let yamlSchemaService: sinon.SinonStubbedInstance<YAMLSchemaService>;
-  let telemetryStub: sinon.SinonStubbedInstance<Telemetry>;
+  let telemetryStub: sinon.SinonStubbedInstance<TelemetryImpl>;
   let telemetry: Telemetry;
 
   beforeEach(() => {
     yamlSchemaService = sandbox.createStubInstance(YAMLSchemaService);
-    telemetryStub = sandbox.createStubInstance(Telemetry);
-    telemetry = (telemetryStub as unknown) as Telemetry;
+    telemetryStub = sandbox.createStubInstance(TelemetryImpl);
+    telemetry = telemetryStub;
   });
 
   afterEach(() => {

--- a/test/yamlDefinition.test.ts
+++ b/test/yamlDefinition.test.ts
@@ -7,7 +7,7 @@ import { setupTextDocument, TEST_URI } from './utils/testHelper';
 import { expect } from 'chai';
 import { YamlDefinition } from '../src/languageservice/services/yamlDefinition';
 import { LocationLink, Position, Range } from 'vscode-languageserver-types';
-import { Telemetry } from '../src/languageserver/telemetry';
+import { Telemetry } from '../src/languageservice/telemetry';
 
 describe('YAML Definition', () => {
   it('should not provide definition for non anchor node', () => {


### PR DESCRIPTION
### What does this PR do?

In `monaco-yaml` I’m interested in stubbing the Telemetry option. However, currently everywhere this is used uses a type annotation based on the class. This means the implementation must match this class, including private properties. By accepting an interface instead, it’s possible to pass alternative implementations.

### What issues does this PR fix or reference?

https://github.com/remcohaszing/monaco-yaml/issues/190

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

By running `tsc`.