### PR TITLE
feat(modeline): Modeline takes precendence over registerContributor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,15 @@ or absolute path:
 # yaml-language-server: $schema=/absolute/path/to/schema
 ```
 
+### Schema priority
+
+The following is the priority of schema association in highest to lowest priority:
+1. Modeline
+2. CustomSchemaProvider API
+3. yaml.settings
+4. Schema association notification
+5. Schema Store
+
 ## Containerized Language Server
 
 An image is provided for users who would like to use the YAML language server without having to install dependencies locally.

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -59,7 +59,6 @@ export enum SchemaPriority {
   SchemaStore = 1,
   SchemaAssociation = 2,
   Settings = 3,
-  Modeline = 4,
 }
 
 export interface SchemasSettings {


### PR DESCRIPTION
### What does this PR do?
Problem:
- Right now, when a file is watched by the registerContributor API a user has no way of overriding that schema. In certain cases, a user may want to override the schema provided by the registerContributor API on a file by file basis.

Solution:
- Make the modeline become a higher priority then the registerContributor API. That way users have the ability to always override the schema for the given file.

### What issues does this PR fix or reference?
https://github.com/aws/aws-toolkit-vscode/issues/3012

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
