### PR TITLE
Document url fragment references

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ yaml.schemas: {
 
 ### Nested Schema References
 
-Suppose a file's schema is a subcomponent of an existing schema (like a `jobs/example.yml` file in a circleci orb) and there isn't an existing schema file for that subcomponent. If there is a nested schema definition for this subcomponent, you can reference it using a url fragment, e.g.:
+Suppose a file is meant to be a component of an existing schema (like a `job.yaml` file in a circleci orb), but there isn't a standalone schema that you can reference. If there is a nested schema definition for this subcomponent, you can reference it using a url fragment, e.g.:
 
 ```
 yaml.schemas: {

--- a/README.md
+++ b/README.md
@@ -224,6 +224,19 @@ yaml.schemas: {
 
 `yaml.schemas` allows you to specify json schemas that you want to validate against the yaml that you write. Kubernetes is an optional field. It does not require a url as the language server will provide that. You just need the keyword kubernetes and a glob pattern.
 
+### Nested Schema References
+
+Suppose a file's schema is a subcomponent of an existing schema (like a `jobs/example.yml` file in a circleci orb) and there isn't an existing schema file for that subcomponent. If there is a nested schema definition for this subcomponent, you can reference it using a url fragment, e.g.:
+
+```
+yaml.schemas: {
+    "https://json.schemastore.org/circleciconfig#/definitions/jobs/additionalProperties": "/src/jobs/*.yaml",
+}
+```
+
+> **Note**
+> This will require reading your existing schema and understanding the schemastore structure a bit. (TODO: link to a documentation or blog post here?)
+
 ### Using inlined schema
 
 It is possible to specify a yaml schema using a modeline.


### PR DESCRIPTION
### What does this PR do?

Adds a README section covering the ability to use URL fragments to reference components of existing schemas.

### What issues does this PR fix or reference?

Documents an existing feature that allows one to support components of existing schemas while maintaining [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).

### Is it tested? How?

I've tested this feature with inline configuration, using circleciconfig as an example, e.g.:

```yaml
# yaml-language-server: $schema=https://json.schemastore.org/circleciconfig.json#/definitions/jobs/additionalProperties
```

I haven't *actually* tested it with server-side configuration yet, partially because the path-based association is kind of weak (`/src/jobs/*.yml` + `/src/jobs/*.yaml`)

### My questions / comments

1. Is there good documentation somewhere on how schemastore schemas work? It took me a while to figure out how to reference the schema for an individual circleci job (i.e. `additionalProperties`)
2. Should the documentation use an example other than circleci? I just used this because it's the example I'm currently working on and I can't think of another practical example off the top of my head.
    1. Is there a practical example using a schema for a more redhat / open source tool? (tekton springs to mind, but I don't know enough about it to actually find an example there)
3. feel free to tear this apart / rewrite it -- I just thought it would be more helpful to submit a PR as a first draft / example, rather than just posting an issue asking for it to be documented
