### PR TITLE
Allow users to change the default k8s schema

### DIFF
--- a/src/languageserver/handlers/notificationHandlers.ts
+++ b/src/languageserver/handlers/notificationHandlers.ts
@@ -8,6 +8,7 @@ import { LanguageService, SchemaConfiguration } from '../../languageservice/yaml
 import {
   CustomSchemaRequest,
   DynamicCustomSchemaRequestRegistration,
+  KubernetesURLNotification,
   SchemaAssociationNotification,
   SchemaSelectionRequests,
   VSCodeContentRequestRegistration,
@@ -36,8 +37,13 @@ export class NotificationHandlers {
       this.schemaAssociationNotificationHandler(associations)
     );
     this.connection.onNotification(DynamicCustomSchemaRequestRegistration.type, () => this.dynamicSchemaRequestHandler());
+    this.connection.onNotification(KubernetesURLNotification.type, (url) => this.kubernetesURLNotification(url));
     this.connection.onNotification(VSCodeContentRequestRegistration.type, () => this.vscodeContentRequestHandler());
     this.connection.onNotification(SchemaSelectionRequests.type, () => this.schemaSelectionRequestHandler());
+  }
+
+  private kubernetesURLNotification(url: string): void {
+    this.yamlSettings.kubernetesSchemaUrl = url;
   }
 
   /**

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -6,7 +6,7 @@ import { configure as configureHttpRequests, xhr } from 'request-light';
 import { Connection, DidChangeConfigurationNotification, DocumentFormattingRequest } from 'vscode-languageserver';
 import { convertErrorToTelemetryMsg } from '../../languageservice/utils/objects';
 import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
-import { checkSchemaURI, JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from '../../languageservice/utils/schemaUrls';
+import { checkSchemaURI, JSON_SCHEMASTORE_URL } from '../../languageservice/utils/schemaUrls';
 import { LanguageService, LanguageSettings, SchemaPriority } from '../../languageservice/yamlLanguageService';
 import { SchemaSelectionRequests } from '../../requestTypes';
 import { Settings, SettingsState } from '../../yamlSettings';
@@ -336,11 +336,11 @@ export class SettingsHandler {
       languageSettings.schemas.push({ uri, fileMatch: fileMatch, schema: schema, priority: priorityLevel });
     }
 
-    if (fileMatch.constructor === Array && uri === KUBERNETES_SCHEMA_URL) {
+    if (fileMatch.constructor === Array && uri === this.yamlSettings.kubernetesSchemaUrl) {
       fileMatch.forEach((url) => {
         this.yamlSettings.specificValidatorPaths.push(url);
       });
-    } else if (uri === KUBERNETES_SCHEMA_URL) {
+    } else if (uri === this.yamlSettings.kubernetesSchemaUrl) {
       this.yamlSettings.specificValidatorPaths.push(fileMatch);
     }
 

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -46,6 +46,10 @@ export namespace DynamicCustomSchemaRequestRegistration {
   export const type: NotificationType<{}> = new NotificationType('yaml/registerCustomSchemaRequest');
 }
 
+export namespace KubernetesURLNotification {
+  export const type: NotificationType<string> = new NotificationType('yaml/kubernetesURL');
+}
+
 export namespace VSCodeContentRequestRegistration {
   export const type: NotificationType<{}> = new NotificationType('yaml/registerContentRequest');
 }

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -4,7 +4,7 @@ import { ISchemaAssociations } from './requestTypes';
 import { URI } from 'vscode-uri';
 import { JSONSchema } from './languageservice/jsonSchema';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { JSON_SCHEMASTORE_URL } from './languageservice/utils/schemaUrls';
+import { JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from './languageservice/utils/schemaUrls';
 import { YamlVersion } from './languageservice/parser/yamlParser07';
 
 // Client settings interface to grab settings relevant for the language server
@@ -76,6 +76,7 @@ export class SettingsState {
   customTags = [];
   schemaStoreEnabled = true;
   schemaStoreUrl = JSON_SCHEMASTORE_URL;
+  kubernetesSchemaUrl = KUBERNETES_SCHEMA_URL;
   indentation: string | undefined = undefined;
   disableAdditionalProperties = false;
   disableDefaultProperties = false;


### PR DESCRIPTION
### What does this PR do?

Currently, there is no way to set the Kubernetes schema, it is hard-coded and a lot of internal magic depends on it. If you try to do it through the existing methods, i.e. a comment or an association, it offers a subpar experience with bad diagnostics and incomplete completion suggestions.

This PR exposes new notification to allow third party extensions and users to change the default Kubernetes schema on the fly and still get diagnostics and autocompletion from the LS.

### What issues does this PR fix or reference?

https://github.com/redhat-developer/yaml-language-server/issues/778
