### PR TITLE
feat: add possibility to define multiple validation patterns

### DIFF
--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CompletionItemKind } from 'vscode-json-languageservice';
+import { CompletionItemKind, DiagnosticSeverity } from 'vscode-json-languageservice';
 import { SchemaVersions } from './yamlTypes';
 
 export type JSONSchemaRef = JSONSchema | boolean;
@@ -81,6 +81,7 @@ export interface JSONSchema {
 
   errorMessage?: string; // VSCode extension
   patternErrorMessage?: string; // VSCode extension
+  patterns?: Pattern[]; // VSCode extension
   deprecationMessage?: string; // VSCode extension
   enumDescriptions?: string[]; // VSCode extension
   markdownEnumDescriptions?: string[]; // VSCode extension
@@ -91,6 +92,12 @@ export interface JSONSchema {
   schemaSequence?: JSONSchema[]; // extension for multiple schemas related to multiple documents in single yaml file
 
   filePatternAssociation?: string; // extension for if condition to be able compare doc yaml uri with this file pattern association
+}
+
+export interface Pattern {
+  pattern: string;
+  message: string;
+  severity?: DiagnosticSeverity;
 }
 
 export interface JSONSchemaMap {

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1017,6 +1017,22 @@ function validate(
       }
     }
 
+    if (Array.isArray(schema.patterns)) {
+      for (const pattern of schema.patterns) {
+        const regex = safeCreateUnicodeRegExp(pattern.pattern);
+        if (!regex.test(node.value)) {
+          validationResult.problems.push({
+            location: { offset: node.offset, length: node.length },
+            severity: pattern.severity || DiagnosticSeverity.Warning,
+            message:
+              pattern.message || localize('patternWarning', 'String does not match the pattern of "{0}".', pattern.pattern),
+            source: getSchemaSource(schema, originalSchema),
+            schemaUri: getSchemaUri(schema, originalSchema),
+          });
+        }
+      }
+    }
+
     if (schema.format) {
       switch (schema.format) {
         case 'uri':

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -400,6 +400,43 @@ describe('Validation Tests', () => {
         })
         .then(done, done);
     });
+    it('Test patterns', async () => {
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          prop: {
+            type: 'string',
+            patterns: [
+              {
+                pattern: '^[^\\d]',
+                message: 'Can not start with numeric',
+                severity: 3,
+              },
+              {
+                pattern: '^[^A-Z]',
+                message: 'Can not start with capital letter',
+                severity: 4,
+              },
+            ],
+          },
+        },
+      });
+      const result = await parseSetup('prop: "1-test"');
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        { message: result[0].message, severity: result[0].severity },
+        { message: 'Can not start with numeric', severity: 3 },
+        'pattern 1'
+      );
+
+      const result2 = await parseSetup('prop: "A-test"');
+      assert.equal(result2.length, 1);
+      assert.deepEqual(
+        { message: result2[0].message, severity: result2[0].severity },
+        { message: 'Can not start with capital letter', severity: 4 },
+        'pattern 2'
+      );
+    });
   });
 
   describe('Number tests', () => {


### PR DESCRIPTION
### What does this PR do?
add the possibility to define multiple validation patterns
The previous implementation supported only single pattern and single patternErrorMessage. It was too hard to define various validations.
With this implementation, it's possible to define multiple patterns (conditions) with more specific messages

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
unit test