### PR TITLE
feat: merge snippet props with existing props from yaml

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -44,6 +44,8 @@ const doubleQuotesEscapeRegExp = /[\\]+"/g;
 
 const parentCompletionKind = CompletionItemKind.Class;
 
+const existingProposeItem = '__';
+
 interface ParentCompletionItemOptions {
   schema: JSONSchema;
   indent?: string;
@@ -59,6 +61,7 @@ interface CompletionsCollector {
   log(message: string): void;
   getNumberOfProposals(): number;
   result: CompletionList;
+  proposed: { [key: string]: CompletionItem };
 }
 
 interface InsertText {
@@ -179,7 +182,6 @@ export class YamlCompletion {
     }
 
     const proposed: { [key: string]: CompletionItem } = {};
-    const existingProposeItem = '__';
     const collector: CompletionsCollector = {
       add: (completionItem: CompletionItem, oneOfSchema: boolean) => {
         const addSuggestionForParent = function (completionItem: CompletionItem): void {
@@ -286,6 +288,7 @@ export class YamlCompletion {
         return result.items.length;
       },
       result,
+      proposed,
     };
 
     if (this.customTags.length > 0) {
@@ -1005,6 +1008,7 @@ export class YamlCompletion {
                 indentFirstObject: false,
                 shouldIndentWithTab: false,
               },
+              [],
               1
             );
             // add space before default snippet value
@@ -1483,7 +1487,15 @@ export class YamlCompletion {
             });
             value = fixedObj;
           }
-          insertText = this.getInsertTextForSnippetValue(value, separatorAfter, settings);
+          const existingProps = Object.keys(collector.proposed).filter(
+            (proposedProp) => collector.proposed[proposedProp].label === existingProposeItem
+          );
+          insertText = this.getInsertTextForSnippetValue(value, separatorAfter, settings, existingProps);
+
+          // if snippet result is empty and value has a real value, don't add it as a completion
+          if (insertText === '' && value) {
+            continue;
+          }
           label = label || this.getLabelForSnippetValue(value);
         } else if (typeof s.bodyText === 'string') {
           let prefix = '',
@@ -1512,10 +1524,15 @@ export class YamlCompletion {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private getInsertTextForSnippetValue(value: any, separatorAfter: string, settings: StringifySettings, depth?: number): string {
+  private getInsertTextForSnippetValue(
+    value: unknown,
+    separatorAfter: string,
+    settings: StringifySettings,
+    existingProps: string[],
+    depth?: number
+  ): string {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const replacer = (value: any): string | any => {
+    const replacer = (value: unknown): string | any => {
       if (typeof value === 'string') {
         if (value[0] === '^') {
           return value.substr(1);
@@ -1526,7 +1543,9 @@ export class YamlCompletion {
       }
       return value;
     };
-    return stringifyObject(value, '', replacer, { ...settings, indentation: this.indentation }, depth) + separatorAfter;
+    return (
+      stringifyObject(value, '', replacer, { ...settings, indentation: this.indentation, existingProps }, depth) + separatorAfter
+    );
   }
 
   private addBooleanValueCompletion(value: boolean, separatorAfter: string, collector: CompletionsCollector): void {

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -97,13 +97,22 @@ describe('Default Snippet Tests', () => {
         })
         .then(done, done);
     });
-    it('Snippet in array schema should autocomplete correctly inside array item ', (done) => {
+    it('Snippet in array schema should suggest nothing inside array item if YAML already contains all props', (done) => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n    ';
       const completion = parseSetup(content, content.length);
       completion
         .then(function (result) {
+          assert.equal(result.items.length, 0);
+        })
+        .then(done, done);
+    });
+    it('Snippet in array schema should suggest only some of the props inside an array item if YAML already contains some of the props', (done) => {
+      const content = 'array:\n  - item1: asd\n    ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
           assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'item1: $1\nitem2: $2');
+          assert.equal(result.items[0].insertText, 'item2: $2');
           assert.equal(result.items[0].label, 'My array item');
         })
         .then(done, done);
@@ -163,6 +172,31 @@ describe('Default Snippet Tests', () => {
           assert.equal(result.items[0].label, 'Object item');
           assert.equal(result.items[1].insertText, 'key:\n  ');
           assert.equal(result.items[1].label, 'key');
+        })
+        .then(done, done);
+    });
+
+    it('Snippet in object schema should suggest some of the snippet props because some of them are already in the YAML', (done) => {
+      const content = 'object:\n  key:\n    key2: value\n    ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.notEqual(result.items.length, 0);
+          assert.equal(result.items[0].insertText, 'key1: ');
+          assert.equal(result.items[0].label, 'Object item');
+          assert.equal(result.items[1].insertText, 'key:\n  ');
+          assert.equal(result.items[1].label, 'key');
+        })
+        .then(done, done);
+    });
+    it('Snippet in object schema should not suggest snippet props because all of them are already in the YAML', (done) => {
+      const content = 'object:\n  key:\n    key1: value\n    key2: value\n    ';
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 1);
+          assert.equal(result.items[0].insertText, 'key:\n  ');
+          assert.equal(result.items[0].label, 'key');
         })
         .then(done, done);
     });


### PR DESCRIPTION
### What does this PR do?
merge snippet props with existing props from the yaml

#### example
existing yaml:

```yaml
object:
  prop1: some value
  # invoke completion here
```

snippet:
```
defaultSnippets:[
  {
    label: "example1",
    body: {
      prop1: {},
      prop2: {} 
   }
]
```

by this PR, it will include only `prop2` into the inserted text, because `prop1` is already in the yaml

note that only the first level of the props is checked

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added tests and modified existings