### PR TITLE
fix: completion value with dash

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -168,9 +168,6 @@ export class YamlCompletion {
       overwriteRange = Range.create(nodeStartPos, nodeEndPos);
     } else if (node && isScalar(node) && node.value) {
       const start = document.positionAt(node.range[0]);
-      if (offset > 0 && start.character > 0 && text.charAt(offset - 1) === '-') {
-        start.character -= 1;
-      }
       overwriteRange = Range.create(start, document.positionAt(node.range[1]));
     } else if (node && isScalar(node) && node.value === null && currentWord === '-') {
       overwriteRange = Range.create(position, position);

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -228,6 +228,31 @@ describe('Auto Completion Tests', () => {
           .then(done, done);
       });
 
+      it('Autocomplete on default value (with value content contains dash)', (done) => {
+        languageService.addSchema(SCHEMA_ID, {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              default: 'yaml-language',
+            },
+          },
+        });
+        const content = 'name: yaml-';
+        const completion = parseSetup(content, content.length);
+        completion
+          .then(function (result) {
+            assert.equal(result.items.length, 1);
+            assert.deepEqual(
+              result.items[0],
+              createExpectedCompletion('yaml-language', 'yaml-language', 0, 6, 0, 11, 12, 2, {
+                detail: 'Default value',
+              })
+            );
+          })
+          .then(done, done);
+      });
+
       it('Autocomplete on boolean value (without value content)', (done) => {
         languageService.addSchema(SCHEMA_ID, {
           type: 'object',


### PR DESCRIPTION
### What does this PR do?
fix the completion item range when yaml contains a word ending with a dash symbol.


https://user-images.githubusercontent.com/38421337/212872479-136c433b-9588-4c7c-a3d9-747a64af719d.mov


I removed the piece of code that caused this problem (all existing tests passed after removing it).
To be honest I am not sure why this code was there. I tried to think about but I wasn't able to find a scenario when is needed to subtract one character if the current position contains `-`

note that this example didn't use removed piece of code
```yaml
array:
 -
```

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
added test