### PR TITLE
feat: exclude deprecated schema from autocompletion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -697,6 +697,10 @@ export class YamlCompletion {
       });
     }
     for (const schema of matchingSchemas) {
+      if (schema.schema.deprecationMessage) {
+        continue;
+      }
+
       if (
         ((schema.node.internalNode === node && !matchOriginal) ||
           (schema.node.internalNode === originalNode && !hasColon) ||

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1206,4 +1206,38 @@ test1:
     expect(completion.items[0].insertText).to.be.equal('${1:property}: ');
     expect(completion.items[0].documentation).to.be.equal('Property Description');
   });
+
+  describe('Deprecated schema', () => {
+    it('should not autocomplete deprecated schema', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          prop1: { type: 'string' },
+        },
+        deprecationMessage: 'Deprecated',
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = '';
+      const completion = await parseSetup(content, 0, 1);
+
+      expect(completion.items.length).equal(0);
+    });
+    it('should autocomplete inside deprecated schema', async () => {
+      const schema: JSONSchema = {
+        properties: {
+          obj1: {
+            properties: {
+              item1: { type: 'string' },
+            },
+          },
+        },
+        deprecationMessage: 'Deprecated',
+      };
+      languageService.addSchema(SCHEMA_ID, schema);
+      const content = 'obj1:\n | |';
+      const completion = await parseCaret(content);
+
+      expect(completion.items.length).equal(1);
+      expect(completion.items[0].label).equal('item1');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
exclude deprecated schema from autocompletion
useful when you want to exclude some subschemas from autocompletion, but you need it to be there for validation purposes. So you can't just remove it.

```json
"anyOf":[
  {
     "$ref": "schema1",
     "deprecatedMessage": "Deprecated: use schema2 instead"
   },
  {
     "$ref": "schema2",
   }
]
```

### What issues does this PR fix or reference?
no ref


### Is it tested? How?
added tests