### PR TITLE
Map key order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### [UNRELEASED] 
+
+- Add: Enforce alphabetical ordering of keys in mappings and provide codeaction to fix it. 
+
 ### 1.11.0
 - Fix: only the first choice is shown when hovering anyOf-typed properties [#784](https://github.com/redhat-developer/vscode-yaml/issues/784)
 - Fix: Description in the schema root does not get displayed [#809](https://github.com/redhat-developer/vscode-yaml/issues/809)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following settings are supported:
 - `yaml.suggest.parentSkeletonSelectedFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.\nWhen yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
 - `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid` 
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
+- `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
 
 ##### Adding custom tags
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
+    "lodash": "4.17.21",
     "request-light": "^0.5.7",
     "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^7.0.0",

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -122,6 +122,7 @@ export class SettingsHandler {
         flowMapping: settings.yaml.style?.flowMapping ?? 'allow',
         flowSequence: settings.yaml.style?.flowSequence ?? 'allow',
       };
+      this.yamlSettings.keyOrdering = settings.yaml.keyOrdering ?? false;
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -257,6 +258,7 @@ export class SettingsHandler {
       flowMapping: this.yamlSettings.style?.flowMapping,
       flowSequence: this.yamlSettings.style?.flowSequence,
       yamlVersion: this.yamlSettings.yamlVersion,
+      keyOrdering: this.yamlSettings.keyOrdering,
     };
 
     if (this.yamlSettings.schemaAssociations) {

--- a/src/languageservice/services/validation/map-key-order.ts
+++ b/src/languageservice/services/validation/map-key-order.ts
@@ -36,7 +36,7 @@ export class MapKeyOrderValidator implements AdditionalValidator {
 }
 
 function createRange(document: TextDocument, node: Pair): Range {
-  const start = node?.srcToken.start[0]?.offset || node?.srcToken?.key.offset || node?.srcToken?.sep[0]?.offset;
+  const start = node?.srcToken.start[0]?.offset ?? node?.srcToken?.key.offset ?? node?.srcToken?.sep[0]?.offset;
   const end =
     node?.srcToken?.value.offset ||
     node?.srcToken?.sep[0]?.offset ||

--- a/src/languageservice/services/validation/map-key-order.ts
+++ b/src/languageservice/services/validation/map-key-order.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import { SingleYAMLDocument } from '../../parser/yaml-documents';
+import { AdditionalValidator } from './types';
+import { isMap, Pair, visit } from 'yaml';
+
+export class MapKeyOrderValidator implements AdditionalValidator {
+  validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[] {
+    const result = [];
+
+    visit(yamlDoc.internalDocument, (key, node) => {
+      if (isMap(node)) {
+        for (let i = 1; i < node.items.length; i++) {
+          if (compare(node.items[i - 1], node.items[i]) > 0) {
+            const range = createRange(document, node.items[i - 1]);
+            result.push(
+              Diagnostic.create(
+                range,
+                `Wrong ordering of key "${node.items[i - 1].key}" in mapping`,
+                DiagnosticSeverity.Error,
+                'mapKeyOrder'
+              )
+            );
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+}
+
+function createRange(document: TextDocument, node: Pair): Range {
+  const start = node?.srcToken.start[0]?.offset || node?.srcToken?.key.offset || node?.srcToken?.sep[0]?.offset;
+  const end =
+    node?.srcToken?.value.offset ||
+    node?.srcToken?.sep[0]?.offset ||
+    node?.srcToken?.key.offset ||
+    node?.srcToken.start[node.srcToken.start.length - 1]?.offset;
+  return Range.create(document.positionAt(start), document.positionAt(end));
+}
+
+function compare(thiz: Pair, that: Pair): number {
+  const thatKey = String(that.key);
+  const thisKey = String(thiz.key);
+  return thisKey.localeCompare(thatKey);
+}

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -277,13 +277,19 @@ export class YamlCodeActions {
                 item.value?.type === 'single-quoted-scalar' ||
                 item.value?.type === 'double-quoted-scalar'
               ) {
+                const newLineIndex = item.value?.end?.findIndex((p) => p.type === 'newline') ?? -1;
+                let newLineToken = null;
                 if (uItem.value?.type === 'block-scalar') {
-                  const token = uItem.value.props.find((p) => p.type === 'newline');
-                  if (token) {
-                    item.value.end = [token as SourceToken];
-                  }
-                } else if (uItem.value) {
-                  item.value.end = uItem.value['end'];
+                  newLineToken = uItem.value?.props?.find((p) => p.type === 'newline');
+                } else if (CST.isScalar(uItem.value)) {
+                  newLineToken = uItem.value?.end?.find((p) => p.type === 'newline');
+                }
+                if (newLineToken && newLineIndex < 0) {
+                  item.value.end = item.value.end ?? [];
+                  item.value.end.push(newLineToken as SourceToken);
+                }
+                if (!newLineToken && newLineIndex > -1) {
+                  item.value.end.splice(newLineIndex, 1);
                 }
               } else if (item.value?.type === 'block-scalar') {
                 const nwline = item.value.props.find((p) => p.type === 'newline');

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -20,6 +20,7 @@ import { Telemetry } from '../telemetry';
 import { AdditionalValidator } from './validation/types';
 import { UnusedAnchorsValidator } from './validation/unused-anchors';
 import { YAMLStyleValidator } from './validation/yaml-style';
+import { MapKeyOrderValidator } from './validation/map-key-order';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic
@@ -64,6 +65,7 @@ export class YAMLValidation {
       if (settings.flowMapping === 'forbid' || settings.flowSequence === 'forbid') {
         this.validators.push(new YAMLStyleValidator(settings));
       }
+      this.validators.push(new MapKeyOrderValidator());
     }
     this.validators.push(new UnusedAnchorsValidator());
   }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -65,7 +65,9 @@ export class YAMLValidation {
       if (settings.flowMapping === 'forbid' || settings.flowSequence === 'forbid') {
         this.validators.push(new YAMLStyleValidator(settings));
       }
-      this.validators.push(new MapKeyOrderValidator());
+      if (settings.keyOrdering) {
+        this.validators.push(new MapKeyOrderValidator());
+      }
     }
     this.validators.push(new UnusedAnchorsValidator());
   }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -115,6 +115,10 @@ export interface LanguageSettings {
    * Control the use of flow sequences. Default is allow.
    */
   flowSequence?: 'allow' | 'forbid';
+  /**
+   * If set enforce alphabetical ordering of keys in mappings.
+   */
+  keyOrdering?: boolean;
 }
 
 export interface WorkspaceContextService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -29,6 +29,7 @@ export interface Settings {
       flowMapping: 'allow' | 'forbid';
       flowSequence: 'allow' | 'forbid';
     };
+    keyOrdering: boolean;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
   };
@@ -86,6 +87,7 @@ export class SettingsState {
     flowMapping: 'allow' | 'forbid';
     flowSequence: 'allow' | 'forbid';
   };
+  keyOrdering = true;
   maxItemsComputed = 5000;
 
   // File validation helpers

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -110,6 +110,37 @@ describe('Settings Handlers Tests', () => {
     });
   });
 
+  describe('Settings for key ordering should ', () => {
+    it(' reflect to the settings ', async () => {
+      const settingsHandler = new SettingsHandler(
+        connection,
+        (languageService as unknown) as LanguageService,
+        settingsState,
+        (validationHandler as unknown) as ValidationHandler,
+        {} as Telemetry
+      );
+      workspaceStub.getConfiguration.resolves([{ keyOrdering: true }, {}, {}, {}, {}]);
+
+      await settingsHandler.pullConfiguration();
+      expect(settingsState.keyOrdering).to.exist;
+      expect(settingsState.keyOrdering).to.be.true;
+    });
+    it(' reflect default values if no settings given', async () => {
+      const settingsHandler = new SettingsHandler(
+        connection,
+        (languageService as unknown) as LanguageService,
+        settingsState,
+        (validationHandler as unknown) as ValidationHandler,
+        {} as Telemetry
+      );
+      workspaceStub.getConfiguration.resolves([{}, {}, {}, {}, {}]);
+
+      await settingsHandler.pullConfiguration();
+      expect(settingsState.style).to.exist;
+      expect(settingsState.keyOrdering).to.be.false;
+    });
+  });
+
   describe('Settings for file associations should ', () => {
     it('reflect to settings state', async () => {
       const settingsHandler = new SettingsHandler(

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -71,4 +71,8 @@ export class ServiceSetup {
     this.languageSettings.flowSequence = sequence;
     return this;
   }
+  withKeyOrdering(order = true): ServiceSetup {
+    this.languageSettings.keyOrdering = order;
+    return this;
+  }
 }

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -346,7 +346,35 @@ animals: [dog , cat , mouse]  `;
       const result = actions.getCodeAction(doc, params);
       expect(result).to.be.not.empty;
       expect(result).to.have.lengthOf(1);
-      expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(0, 2, 2, 5), `aa:  cc: 1\n  gg: 2\n`)]);
+      expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(0, 2, 2, 5), `aa:  cc: 1\n  gg: 2`)]);
+    });
+    it(' should preserve comments', () => {
+      const yaml = '- cc: 1\n  gg: 2  #a comment\n  aa: 1';
+      const doc = setupTextDocument(yaml);
+      const diagnostics = [
+        createExpectedError(
+          'Wrong ordering of key "key gg" in mapping',
+          1,
+          0,
+          1,
+          8,
+          DiagnosticSeverity.Error,
+          'YAML',
+          'mapKeyOrder'
+        ),
+      ];
+      const params: CodeActionParams = {
+        context: CodeActionContext.create(diagnostics),
+        range: undefined,
+        textDocument: TextDocumentIdentifier.create(TEST_URI),
+      };
+      const actions = new YamlCodeActions(clientCapabilities);
+      const result = actions.getCodeAction(doc, params);
+      expect(result).to.be.not.empty;
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].edit.changes[TEST_URI]).deep.equal([
+        TextEdit.replace(Range.create(0, 2, 2, 7), `aa: 1\n  cc: 1\n  gg: 2  #a comment`),
+      ]);
     });
   });
 });

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -176,7 +176,8 @@ animals: [dog , cat , mouse]  `;
   describe('Map keys order Tests', () => {
     it('should report key order error', async () => {
       const yaml = '- key 2: v\n  key 1: val\n  key 5: valu\n  key 3: ff';
-
+      yamlSettings.keyOrdering = true;
+      languageSettingsSetup = new ServiceSetup().withValidate().withKeyOrdering();
       const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
         languageSettingsSetup.languageSettings
       );
@@ -210,7 +211,8 @@ animals: [dog , cat , mouse]  `;
     });
     it('should report key order error for flow style maps', async () => {
       const yaml = '- {b: 1, a: 2}';
-
+      yamlSettings.keyOrdering = true;
+      languageSettingsSetup = new ServiceSetup().withValidate().withKeyOrdering();
       const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
         languageSettingsSetup.languageSettings
       );
@@ -226,7 +228,8 @@ animals: [dog , cat , mouse]  `;
 
     it('should NOT report any errors', async () => {
       const yaml = '- key 1: val\n  key 5: valu\n- {a: 1, c: 2}';
-
+      yamlSettings.keyOrdering = true;
+      languageSettingsSetup = new ServiceSetup().withValidate().withKeyOrdering();
       const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
         languageSettingsSetup.languageSettings
       );

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -173,4 +173,67 @@ animals: [dog , cat , mouse]  `;
       ]);
     });
   });
+  describe('Map keys order Tests', () => {
+    it('should report key order error', async () => {
+      const yaml = '- key 2: v\n  key 1: val\n  key 5: valu\n  key 3: ff';
+
+      const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
+        languageSettingsSetup.languageSettings
+      );
+      validationHandler = valHandler;
+      yamlSettings = settings;
+      const result = await parseSetup(yaml);
+      expect(result).not.to.be.empty;
+      expect(result.length).to.be.equal(2);
+      expect(result).to.include.deep.members([
+        createExpectedError(
+          'Wrong ordering of key "key 2" in mapping',
+          0,
+          2,
+          0,
+          9,
+          DiagnosticSeverity.Error,
+          'YAML',
+          'mapKeyOrder'
+        ),
+        createExpectedError(
+          'Wrong ordering of key "key 5" in mapping',
+          2,
+          0,
+          2,
+          9,
+          DiagnosticSeverity.Error,
+          'YAML',
+          'mapKeyOrder'
+        ),
+      ]);
+    });
+    it('should report key order error for flow style maps', async () => {
+      const yaml = '- {b: 1, a: 2}';
+
+      const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
+        languageSettingsSetup.languageSettings
+      );
+      validationHandler = valHandler;
+      yamlSettings = settings;
+      const result = await parseSetup(yaml);
+      expect(result).not.to.be.empty;
+      expect(result.length).to.be.equal(1);
+      expect(result).to.include.deep.members([
+        createExpectedError('Wrong ordering of key "b" in mapping', 0, 3, 0, 6, DiagnosticSeverity.Error, 'YAML', 'mapKeyOrder'),
+      ]);
+    });
+
+    it('should NOT report any errors', async () => {
+      const yaml = '- key 1: val\n  key 5: valu\n- {a: 1, c: 2}';
+
+      const { validationHandler: valHandler, yamlSettings: settings } = setupLanguageService(
+        languageSettingsSetup.languageSettings
+      );
+      validationHandler = valHandler;
+      yamlSettings = settings;
+      const result = await parseSetup(yaml);
+      expect(result).to.be.empty;
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.14:
+lodash@4.17.21, lodash@^4.17.14:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
### What does this PR do?
Introduces a new setting `yaml.keyOrder` that enforces the alphabetical key order for mappings when set to true. 
In addition to validation, it also provides a code action to fix the order for the map

### What issues does this PR fix or reference?
https://github.com/redhat-developer/vscode-yaml/issues/95

### Is it tested? How?
Adds tests for validation, new settings and code action
