### PR TITLE
Add API to update AST tree from internal document

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -69,10 +69,20 @@ export class SingleYAMLDocument extends JSONDocument {
       this._lineComments.push(`#${this._internalDocument.comment}`);
     }
   }
+  /**
+   * Updates the internal AST tree of the object
+   * from the internal node. This is call whenever the
+   * internalDocument is set but also can be called to
+   * reflect any changes on the underlying document
+   * without setting the internalDocument explicitly.
+   */
+  public updateFromInternalDocument(): void {
+    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument, this.lineCounter);
+  }
 
   set internalDocument(document: Document) {
     this._internalDocument = document;
-    this.root = convertAST(null, this._internalDocument.contents as Node, this._internalDocument, this.lineCounter);
+    this.updateFromInternalDocument();
   }
 
   get internalDocument(): Document {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -342,8 +342,7 @@ export class YamlCompletion {
           const map = currentDoc.internalDocument.createNode({});
           map.range = [offset, offset + 1, offset + 1];
           currentDoc.internalDocument.contents = map;
-          // eslint-disable-next-line no-self-assign
-          currentDoc.internalDocument = currentDoc.internalDocument;
+          currentDoc.updateFromInternalDocument();
           node = map;
         } else {
           node = currentDoc.findClosestNode(offset, textBuffer);
@@ -369,17 +368,14 @@ export class YamlCompletion {
                         const index = indexOf(currentDoc.internalDocument.contents, parent);
                         if (typeof index === 'number') {
                           currentDoc.internalDocument.set(index, map);
-                          // eslint-disable-next-line no-self-assign
-                          currentDoc.internalDocument = currentDoc.internalDocument;
+                          currentDoc.updateFromInternalDocument();
                         }
                       } else if (parentParent && (isMap(parentParent) || isSeq(parentParent))) {
                         parentParent.set(parent.key, map);
-                        // eslint-disable-next-line no-self-assign
-                        currentDoc.internalDocument = currentDoc.internalDocument;
+                        currentDoc.updateFromInternalDocument();
                       } else {
                         currentDoc.internalDocument.set(parent.key, map);
-                        // eslint-disable-next-line no-self-assign
-                        currentDoc.internalDocument = currentDoc.internalDocument;
+                        currentDoc.updateFromInternalDocument();
                       }
 
                       currentProperty = (map as YAMLMap).items[0];
@@ -402,8 +398,7 @@ export class YamlCompletion {
                     const map = this.createTempObjNode(currentWord, node, currentDoc);
                     parent.delete(node);
                     parent.add(map);
-                    // eslint-disable-next-line no-self-assign
-                    currentDoc.internalDocument = currentDoc.internalDocument;
+                    currentDoc.updateFromInternalDocument();
                     node = map;
                   } else {
                     node = parent;
@@ -426,12 +421,10 @@ export class YamlCompletion {
 
                           if (parentParent && (isMap(parentParent) || isSeq(parentParent))) {
                             parentParent.set(parent.key, map);
-                            // eslint-disable-next-line no-self-assign
-                            currentDoc.internalDocument = currentDoc.internalDocument;
+                            currentDoc.updateFromInternalDocument();
                           } else {
                             currentDoc.internalDocument.set(parent.key, map);
-                            // eslint-disable-next-line no-self-assign
-                            currentDoc.internalDocument = currentDoc.internalDocument;
+                            currentDoc.updateFromInternalDocument();
                           }
                           currentProperty = (map as YAMLMap).items[0];
                           node = map;
@@ -448,15 +441,13 @@ export class YamlCompletion {
                     const map = this.createTempObjNode(currentWord, node, currentDoc);
                     parent.delete(node);
                     parent.add(map);
-                    // eslint-disable-next-line no-self-assign
-                    currentDoc.internalDocument = currentDoc.internalDocument;
+                    currentDoc.updateFromInternalDocument();
                     node = map;
                   } else if (lineContent.charAt(position.character - 1) === '-') {
                     const map = this.createTempObjNode('', node, currentDoc);
                     parent.delete(node);
                     parent.add(map);
-                    // eslint-disable-next-line no-self-assign
-                    currentDoc.internalDocument = currentDoc.internalDocument;
+                    currentDoc.updateFromInternalDocument();
                     node = map;
                   } else {
                     node = parent;
@@ -474,8 +465,7 @@ export class YamlCompletion {
           } else if (isScalar(node)) {
             const map = this.createTempObjNode(currentWord, node, currentDoc);
             currentDoc.internalDocument.contents = map;
-            // eslint-disable-next-line no-self-assign
-            currentDoc.internalDocument = currentDoc.internalDocument;
+            currentDoc.updateFromInternalDocument();
             currentProperty = map.items[0];
             node = map;
           } else if (isMap(node)) {
@@ -488,8 +478,7 @@ export class YamlCompletion {
             if (lineContent.charAt(position.character - 1) !== '-') {
               const map = this.createTempObjNode(currentWord, node, currentDoc);
               map.items = [];
-              // eslint-disable-next-line no-self-assign
-              currentDoc.internalDocument = currentDoc.internalDocument;
+              currentDoc.updateFromInternalDocument();
               for (const pair of node.items) {
                 if (isMap(pair)) {
                   pair.items.forEach((value) => {


### PR DESCRIPTION
### What does this PR do?

Adds a new API to update the internal AST from the internal document without requiring re-assigning the internal document.

### What issues does this PR fix or reference?
Fixes eslint issues about self-assigning 

### Is it tested? How?
Existing test set
