### PR TITLE
845 type errors inform wrong type when parent schema has keyword title

### DIFF
--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -3,6 +3,7 @@ import { JSONSchema } from '../jsonSchema';
 import * as path from 'path';
 
 export function getSchemaTypeName(schema: JSONSchema): string {
+  const closestTitleWithType = schema.type && schema.closestTitle;
   if (schema.title) {
     return schema.title;
   }
@@ -14,9 +15,9 @@ export function getSchemaTypeName(schema: JSONSchema): string {
   }
   return Array.isArray(schema.type)
     ? schema.type.join(' | ')
-    : schema.closestTitle
+    : closestTitleWithType
     ? schema.type.concat('(', schema.closestTitle, ')')
-    : schema.type; //object
+    : schema.type || schema.closestTitle; //object
 }
 
 /**

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -15,7 +15,7 @@ export function getSchemaTypeName(schema: JSONSchema): string {
   return Array.isArray(schema.type)
     ? schema.type.join(' | ')
     : schema.closestTitle
-    ? schema.type.concat(' ', '(', schema.closestTitle, ')')
+    ? schema.type.concat('(', schema.closestTitle, ')')
     : schema.type; //object
 }
 

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -12,7 +12,7 @@ export function getSchemaTypeName(schema: JSONSchema): string {
   if (schema.$ref || schema._$ref) {
     return getSchemaRefTypeTitle(schema.$ref || schema._$ref);
   }
-  return schema.closestTitle || (Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type); //object
+  return (Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type) || schema.closestTitle; //object
 }
 
 /**

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -12,7 +12,11 @@ export function getSchemaTypeName(schema: JSONSchema): string {
   if (schema.$ref || schema._$ref) {
     return getSchemaRefTypeTitle(schema.$ref || schema._$ref);
   }
-  return (Array.isArray(schema.type) ? schema.type.join(' | ') : schema.type) || schema.closestTitle; //object
+  return Array.isArray(schema.type)
+    ? schema.type.join(' | ')
+    : schema.closestTitle
+    ? schema.type.concat(' ', '(', schema.closestTitle, ')')
+    : schema.type; //object
 }
 
 /**

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1020,7 +1020,7 @@ describe('Auto Completion Tests', () => {
         it('should suggest "then" block if "if" match filePatternAssociation', async () => {
           schema.if.filePatternAssociation = SCHEMA_ID;
           languageService.addSchema(SCHEMA_ID, schema);
-          const content = 'name: aName\n';
+          const content = 'name: aName\n ';
           const completion = await parseSetup(content, content.length);
           expect(completion.items.map((i) => i.label)).to.deep.equal(['pineapple', 'basket']);
         });

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -586,6 +586,7 @@ describe('Validation Tests', () => {
     it('Error on incorrect value type (object)', (done) => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
+        title: 'Check incorrect value type object',
         properties: {
           scripts: {
             type: 'object',
@@ -611,7 +612,7 @@ describe('Validation Tests', () => {
               0,
               13,
               DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
+              `yaml-schema: Check incorrect value type object`,
               `file:///${SCHEMA_ID}`
             )
           );

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -586,7 +586,7 @@ describe('Validation Tests', () => {
     it('Error on incorrect value type (object)', (done) => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',
-        title: 'Check incorrect value type object',
+        title: 'Object',
         properties: {
           scripts: {
             type: 'object',
@@ -606,13 +606,13 @@ describe('Validation Tests', () => {
           assert.deepEqual(
             result[0],
             createDiagnosticWithData(
-              ObjectTypeError,
+              'Incorrect type. Expected "object(Object)".',
               0,
               9,
               0,
               13,
               DiagnosticSeverity.Error,
-              `yaml-schema: Check incorrect value type object`,
+              `yaml-schema: Object`,
               `file:///${SCHEMA_ID}`
             )
           );

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -9,7 +9,6 @@ import {
   StringTypeError,
   BooleanTypeError,
   ArrayTypeError,
-  ObjectTypeError,
   IncludeWithoutValueError,
   BlockMappingEntryError,
   DuplicateKeyError,


### PR DESCRIPTION
### What does this PR do?
This PR shows schema type when mismatch error along with it title
![image](https://user-images.githubusercontent.com/93245779/222428752-0184ac39-35aa-4c84-8c21-2c08aeaa45ac.png)

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/845

### Is it tested? How?
Yes. Added UT
