### PR TITLE
Fix map key order default

### DIFF
--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -87,7 +87,7 @@ export class SettingsState {
     flowMapping: 'allow' | 'forbid';
     flowSequence: 'allow' | 'forbid';
   };
-  keyOrdering = true;
+  keyOrdering = false;
   maxItemsComputed = 5000;
 
   // File validation helpers


### PR DESCRIPTION
https://github.com/redhat-developer/yaml-language-server/blame/ba7452ee94105636f7c517394f378d09a71e2f6b/README.md#L55

### What does this PR do?

Fixes the map key order default setting.


### What issues does this PR fix or reference?


### Is it tested? How?

1. Open https://gitlab.archlinux.org/archlinux/neoasknot/-/blob/main/.gitlab-ci.yml locally in Neovim
2. See a bunch of errors
3. Rebuild yaml-ls with this change
4. Reopen to see no errors