### PR TITLE
fix(indentation): hover behavior when indentation not set

### DIFF
--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -20,13 +20,10 @@ describe('Hover Tests', () => {
   let telemetry: TestTelemetry;
 
   before(() => {
-    languageSettingsSetup = new ServiceSetup()
-      .withHover()
-      .withIndentation('  ')
-      .withSchemaFileMatch({
-        uri: 'http://google.com',
-        fileMatch: ['bad-schema.yaml'],
-      });
+    languageSettingsSetup = new ServiceSetup().withHover().withSchemaFileMatch({
+      uri: 'http://google.com',
+      fileMatch: ['bad-schema.yaml'],
+    });
     const {
       languageService: langService,
       languageHandler: langHandler,
@@ -513,7 +510,26 @@ users:
       );
     });
 
-    it('hover on value and its description has multiline, indentationa and special string', async () => {
+    it('hover on value and its description has multiline, indentation and special string', async () => {
+      (() => {
+        languageSettingsSetup = new ServiceSetup()
+          .withHover()
+          .withIndentation('  ')
+          .withSchemaFileMatch({
+            uri: 'http://google.com',
+            fileMatch: ['bad-schema.yaml'],
+          });
+        const {
+          languageService: langService,
+          languageHandler: langHandler,
+          yamlSettings: settings,
+          telemetry: testTelemetry,
+        } = setupLanguageService(languageSettingsSetup.languageSettings);
+        languageService = langService;
+        languageHandler = langHandler;
+        yamlSettings = settings;
+        telemetry = testTelemetry;
+      })();
       //https://github.com/redhat-developer/vscode-yaml/issues/886
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -22,7 +22,6 @@ describe('Kubernetes Integration Tests', () => {
     const fileMatch = ['*.yml', '*.yaml'];
     languageSettingsSetup = new ServiceSetup()
       .withHover()
-      .withIndentation('  ')
       .withValidate()
       .withCompletion()
       .withSchemaFileMatch({


### PR DESCRIPTION
### What does this PR do?

The previous behavior for hover replaces indentations with the `&emsp;` entity, because Markdown treats whitespace at the beginning of a line in a special way. However, when the indentation setting wasn't set, the regex that does that replace was set to empty (`""`) and so would include an `&emsp;` entity between every character.

This went under the radar because the previous PR #844 also changed the tests setup to include a `.withIndentation` call, which made sure all tests were passing.

In this PR I'm reverting that to the default behavior for most tests, but overriding the default only on the test introduced in #844.

### What issues does this PR fix or reference?

The issue is referenced on a comment of PR #844. [here](https://github.com/redhat-developer/yaml-language-server/pull/844#issuecomment-1480559728)

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

I have tested this fix with a neovim setup as described in the original problem report in [the PR comment](https://github.com/redhat-developer/yaml-language-server/pull/844#issuecomment-1480591337).

At the risk of simply repeating myself, below is the full set of reproduction steps:

<details>
  <summary>Open for steps</summary>
  
1. Download neovim (I used v0.8.3)
2. Create a new folder `cd $(mktemp)`
3. create a file named `init.lua` with the following contents:

```lua
local settings = {
  yaml = {
    schemas = {
      ["https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json"] = ".gitlab-ci.y*l",
    },
    hover = true,
  }
}

vim.api.nvim_create_autocmd('FileType', {
  pattern = "yaml",
  callback = function(args)
    vim.lsp.start({
      name = 'yamlls',
      cmd = { 'yaml-language-server', '--stdio' }, -- replace with local installation as necessary
      root_dir = vim.fn.fnamemodify('./.gitlab-ci.yaml', ':p:h'),
      settings = settings
    })
  end
})

vim.keymap.set('n', '<space>', vim.lsp.buf.hover, {})
```

5. create a file called `.gitlab-ci.yaml` with the following contents
```yaml
stages:
  - hello
```

6. run neovim with `nvim --noplugin -u init.lua .gitlab-ci.yaml`.

7. give it a couple of seconds to spin up `yaml-language-server` and press `<space>` with the cursor on top of the `stages` word.

![image](https://user-images.githubusercontent.com/1714520/227104127-7cc0adb5-59a0-4b8a-9d1d-8ce64394a83e.png)

8. With this PR patch, the result is the following
![image](https://user-images.githubusercontent.com/1714520/227812133-55ee5b7b-0b6a-4599-82dc-b2eaff4f37e8.png)

</details>