### PR TITLE
Don't apply local schema to file itself

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -110,18 +110,21 @@ export class YAMLSchemaService extends JSONSchemaService {
   private contextService: WorkspaceContextService;
   private requestService: SchemaRequestService;
   public schemaPriorityMapping: Map<string, Set<SchemaPriority>>;
+  private associateSchemaItself: boolean;
 
   private schemaUriToNameAndDescription = new Map<string, SchemaStoreSchema>();
 
   constructor(
     requestService: SchemaRequestService,
     contextService?: WorkspaceContextService,
-    promiseConstructor?: PromiseConstructor
+    promiseConstructor?: PromiseConstructor,
+    associateSchemaItself?: boolean
   ) {
     super(requestService, contextService, promiseConstructor);
     this.customSchemaProvider = undefined;
     this.requestService = requestService;
     this.schemaPriorityMapping = new Map();
+    this.associateSchemaItself = associateSchemaItself;
   }
 
   registerCustomSchemaProvider(customSchemaProvider: CustomSchemaProvider): void {
@@ -412,7 +415,7 @@ export class YAMLSchemaService extends JSONSchemaService {
        * in language features
        */
       const normalizedResourceID = this.normalizeId(resource);
-      if (this.schemasById[normalizedResourceID]) {
+      if (this.associateSchemaItself && this.schemasById[normalizedResourceID]) {
         schemas.push(normalizedResourceID);
       }
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -186,7 +186,12 @@ export function getLanguageService(params: {
   yamlSettings?: SettingsState;
   clientCapabilities?: ClientCapabilities;
 }): LanguageService {
-  const schemaService = new YAMLSchemaService(params.schemaRequestService, params.workspaceContext);
+  const schemaService = new YAMLSchemaService(
+    params.schemaRequestService,
+    params.workspaceContext,
+    undefined,
+    params.yamlSettings?.associateSchemaItself
+  );
   const completer = new YamlCompletion(schemaService, params.clientCapabilities, yamlDocumentsCache, params.telemetry);
   const hover = new YAMLHover(schemaService, params.telemetry);
   const yamlDocumentSymbols = new YAMLDocumentSymbols(schemaService, params.telemetry);

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -60,6 +60,7 @@ export interface JSONSchemaSettings {
 export class SettingsState {
   yamlConfigurationSettings: JSONSchemaSettings[] = undefined;
   schemaAssociations: ISchemaAssociations | SchemaConfiguration[] | undefined = undefined;
+  associateSchemaItself = false;
   formatterRegistration: Thenable<Disposable> = null;
   specificValidatorPaths = [];
   schemaConfigurationSettings = [];

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -60,6 +60,7 @@ export interface TestLanguageServerSetup {
 
 export function setupLanguageService(languageSettings: LanguageSettings): TestLanguageServerSetup {
   const yamlSettings = new SettingsState();
+  yamlSettings.associateSchemaItself = true;
   process.argv.push('--node-ipc');
   const connection = createConnection();
   const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promise<string> => {


### PR DESCRIPTION
### What does this PR do?

Prevent local schema from being applied to file itself unless explicitly enabled.

Previously, when editing local schema file, the schema was applied to the file itself.
Such self association was introduced on #282 mainly for testing.

I introduced a flag `associateSchemaItself` to `SettingsState` to control that behavior.

### What issues does this PR fix or reference?

- Fixes #871.
- Related to redhat-developer/vscode-yaml/issues/894.

### Is it tested? How?

I tested this together with [vscode-yaml](https://github.com/redhat-developer/vscode-yaml), according to [its contribution guide](https://github.com/redhat-developer/vscode-yaml/blob/main/CONTRIBUTING.md).

#### Step 1: Modify `vscode-yaml/.vscode/launch.json` like below to debug on a workspace.

```diff
      {
        // A launch configuration that compiles the extension and then opens it inside a new window
        "name": "Launch Extension",
        "type": "extensionHost",
        "request": "launch",
        "runtimeExecutable": "${execPath}",
-       "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+       "args": ["--extensionDevelopmentPath=${workspaceRoot}", "${env:HOME}/my-test-workspace"],
```

#### Step 2: Build

```
cd yaml-language-server
yarn run build
```

#### Step 3: Start debugging "Launch Extension"

#### Step 4: Write some files on newly opened window

foo.yml:
```yml
hello: world
```

schema.yml:
```yml
type: object
properties:
  hello:
    type: string
additionalProperties: false
```

.vscode/settings.json:
```json
{
  "yaml.schemas": {
    "schema.yml": ["foo.yml"]
  }
}
```

#### Step 5: Check

- Open `foo.yaml` and confirm that `schema.yml` is applied.
  - Optionally check if validation works by adding some properties.
- Open `schema.yml` and confirm that no schema is applied (and there are no validation errors).
