### PR TITLE
fix: nested anyof const

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -786,6 +786,10 @@ function validate(
         validationResult.merge(bestMatch.validationResult);
         validationResult.propertiesMatches += bestMatch.validationResult.propertiesMatches;
         validationResult.propertiesValueMatches += bestMatch.validationResult.propertiesValueMatches;
+        validationResult.enumValueMatch = validationResult.enumValueMatch || bestMatch.validationResult.enumValueMatch;
+        if (bestMatch.validationResult.enumValues?.length) {
+          validationResult.enumValues = (validationResult.enumValues || []).concat(bestMatch.validationResult.enumValues);
+        }
         matchingSchemas.merge(bestMatch.matchingSchemas);
       }
       return matches.length;

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -894,7 +894,10 @@ function validate(
 
     if (isDefined(schema.const)) {
       const val = getNodeValue(node);
-      if (!equals(val, schema.const)) {
+      if (
+        !equals(val, schema.const) &&
+        !(callFromAutoComplete && isString(val) && isString(schema.const) && schema.const.startsWith(val))
+      ) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/utils/objects.ts
+++ b/src/languageservice/utils/objects.ts
@@ -62,7 +62,7 @@ export function isNumber(val: unknown): val is number {
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function isDefined(val: unknown): val is object {
+export function isDefined(val: unknown): val is object | string | number | boolean {
   return typeof val !== 'undefined';
 }
 

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -2016,7 +2016,7 @@ obj:
         },
       },
     };
-    languageService.addSchema(SCHEMA_ID, schema);
+    schemaProvider.addSchema(SCHEMA_ID, schema);
     const content = `options:\n  provider: testX`;
     const result = await parseSetup(content);
     assert.deepEqual(

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1974,4 +1974,54 @@ obj:
       expect(telemetry.messages).to.be.empty;
     });
   });
+  it('Nested AnyOf const should correctly evaluate and merge problems', async () => {
+    // note that 'missing form property' is necessary to trigger the bug (there has to be some problem in both subSchemas)
+    // order of the object in `anyOf` is also important
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        options: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                form: {
+                  type: 'string',
+                },
+                provider: {
+                  type: 'string',
+                  const: 'test1',
+                },
+              },
+              required: ['form', 'provider'],
+            },
+            {
+              type: 'object',
+              properties: {
+                form: {
+                  type: 'string',
+                },
+                provider: {
+                  anyOf: [
+                    {
+                      type: 'string',
+                      const: 'testX',
+                    },
+                  ],
+                },
+              },
+              required: ['form', 'provider'],
+            },
+          ],
+        },
+      },
+    };
+    languageService.addSchema(SCHEMA_ID, schema);
+    const content = `options:\n  provider: testX`;
+    const result = await parseSetup(content);
+    assert.deepEqual(
+      result.map((e) => e.message),
+      ['Missing property "form".'] // not inclide provider error
+    );
+  });
 });


### PR DESCRIPTION
### What does this PR do?
fix validation of nested `anyOf` consts
schema:
```json
{
  "type": "object",
  "properties": {
    "options": {
      "anyOf": [
        {
          "type": "object",
          "properties": {
            "form": {
              "type": "string"
            },
            "provider": {
              "type": "string",
              "const": "test1"
            }
          },
          "required": [
            "form",
            "provider"
          ]
        },
        {
          "type": "object",
          "properties": {
            "form": {
              "type": "string"
            },
            "provider": {
              "anyOf": [
                {
                  "type": "string",
                  "const": "testX"
                }
              ]
            }
          },
          "required": [
            "form",
            "provider"
          ]
        }
      ]
    }
  }
}
```

will produce this error:
<img width="292" alt="image" src="https://github.com/redhat-developer/yaml-language-server/assets/38421337/6c7fbd68-61ff-44e3-9aa5-00fbdeb3fae1">

https://github.com/redhat-developer/yaml-language-server/assets/38421337/8524d0ea-5adf-453a-bbe4-e42a3464c4d8

note that 'missing form property' is necessary to trigger the bug (there has to be some problem in both subSchemas)
order of the object in `anyOf` is also important

### What issues does this PR fix or reference?
no existing issue

### Is it tested? How?
unit test