### PR TITLE
Add selection ranges support

### DIFF
--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -211,7 +211,7 @@ export class LanguageHandlers {
     return this.languageService.getFoldingRanges(textDocument, context);
   }
 
-  selectionRangeHandler(params: SelectionRangeParams): SelectionRange[] {
+  selectionRangeHandler(params: SelectionRangeParams): SelectionRange[] | undefined {
     const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
     if (!textDocument) {
       return;

--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { FoldingRange } from 'vscode-json-languageservice';
+
 import { Connection } from 'vscode-languageserver';
 import {
   CodeActionParams,
@@ -12,6 +12,7 @@ import {
   DocumentOnTypeFormattingParams,
   DocumentSymbolParams,
   FoldingRangeParams,
+  SelectionRangeParams,
   TextDocumentPositionParams,
   CodeLensParams,
   DefinitionParams,
@@ -24,6 +25,8 @@ import {
   DocumentLink,
   DocumentSymbol,
   Hover,
+  FoldingRange,
+  SelectionRange,
   SymbolInformation,
   TextEdit,
 } from 'vscode-languageserver-types';
@@ -61,6 +64,7 @@ export class LanguageHandlers {
     this.connection.onCompletion((textDocumentPosition) => this.completionHandler(textDocumentPosition));
     this.connection.onDidChangeWatchedFiles((change) => this.watchedFilesHandler(change));
     this.connection.onFoldingRanges((params) => this.foldingRangeHandler(params));
+    this.connection.onSelectionRanges((params) => this.selectionRangeHandler(params));
     this.connection.onCodeAction((params) => this.codeActionHandler(params));
     this.connection.onDocumentOnTypeFormatting((params) => this.formatOnTypeHandler(params));
     this.connection.onCodeLens((params) => this.codeLensHandler(params));
@@ -205,6 +209,15 @@ export class LanguageHandlers {
     };
 
     return this.languageService.getFoldingRanges(textDocument, context);
+  }
+
+  selectionRangeHandler(params: SelectionRangeParams): SelectionRange[] {
+    const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
+    if (!textDocument) {
+      return;
+    }
+
+    return this.languageService.getSelectionRanges(textDocument, params.positions);
   }
 
   codeActionHandler(params: CodeActionParams): CodeAction[] | undefined {

--- a/src/languageservice/services/yamlSelectionRanges.ts
+++ b/src/languageservice/services/yamlSelectionRanges.ts
@@ -1,0 +1,104 @@
+import { Position, Range, SelectionRange } from 'vscode-languageserver-types';
+import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { ASTNode } from 'vscode-json-languageservice';
+
+export function getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] | undefined {
+  if (!document) {
+    return;
+  }
+  const doc = yamlDocumentsCache.getYamlDocument(document);
+  return positions.map((position) => {
+    const ranges = getRanges(position);
+    let current: SelectionRange;
+    for (const range of ranges) {
+      current = SelectionRange.create(range, current);
+    }
+    if (!current) {
+      current = SelectionRange.create({
+        start: position,
+        end: position,
+      });
+    }
+    return current;
+  });
+
+  function getRanges(position: Position): Range[] {
+    const offset = document.offsetAt(position);
+    const result: Range[] = [];
+    for (const ymlDoc of doc.documents) {
+      let currentNode: ASTNode;
+      let currentOffset: number;
+      ymlDoc.visit((node) => {
+        const endOffset = node.offset + node.length;
+        // Skip if end offset doesn't even reach cursor position
+        if (endOffset < offset) {
+          return true;
+        }
+        let startOffset = node.offset;
+        // Recheck start offset with the trimmed one in case of this
+        // key:
+        //   - value
+        // ↑
+        if (startOffset > offset) {
+          const nodePosition = document.positionAt(startOffset);
+          if (nodePosition.line !== position.line) {
+            return true;
+          }
+          const lineBeginning = { line: nodePosition.line, character: 0 };
+          const text = document.getText({
+            start: lineBeginning,
+            end: nodePosition,
+          });
+          if (text.trim().length !== 0) {
+            return true;
+          }
+          startOffset = document.offsetAt(lineBeginning);
+          if (startOffset > offset) {
+            return true;
+          }
+        }
+        // Allow equal for children to override
+        if (!currentNode || startOffset >= currentNode.offset) {
+          currentNode = node;
+          currentOffset = startOffset;
+        }
+        return true;
+      });
+      while (currentNode) {
+        const endOffset = currentNode.offset + currentNode.length;
+        const range = {
+          start: document.positionAt(currentOffset),
+          end: document.positionAt(endOffset),
+        };
+        const text = document.getText(range);
+        const trimmedText = text.trimEnd();
+        const trimmedLength = text.length - trimmedText.length;
+        if (trimmedLength > 0) {
+          range.end = document.positionAt(endOffset - trimmedLength);
+        }
+        // Add a jump between '' "" {} []
+        const isSurroundedBy = (startCharacter: string, endCharacter?: string): boolean => {
+          return trimmedText.startsWith(startCharacter) && trimmedText.endsWith(endCharacter || startCharacter);
+        };
+        if (
+          (currentNode.type === 'string' && (isSurroundedBy("'") || isSurroundedBy('"'))) ||
+          (currentNode.type === 'object' && isSurroundedBy('{', '}')) ||
+          (currentNode.type === 'array' && isSurroundedBy('[', ']'))
+        ) {
+          result.push({
+            start: document.positionAt(currentOffset + 1),
+            end: document.positionAt(endOffset - 1),
+          });
+        }
+        result.push(range);
+        currentNode = currentNode.parent;
+        currentOffset = currentNode?.offset;
+      }
+      if (result.length > 0) {
+        break;
+      }
+    }
+    return result.reverse();
+  }
+}

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -24,6 +24,7 @@ import {
   DocumentLink,
   CodeLens,
   DefinitionLink,
+  SelectionRange,
 } from 'vscode-languageserver-types';
 import { JSONSchema } from './jsonSchema';
 import { YAMLDocumentSymbols } from './services/documentSymbols';
@@ -52,6 +53,7 @@ import { yamlDocumentsCache } from './parser/yaml-documents';
 import { SettingsState } from '../yamlSettings';
 import { JSONSchemaSelection } from '../languageserver/handlers/schemaSelectionHandlers';
 import { YamlDefinition } from './services/yamlDefinition';
+import { getSelectionRanges } from './services/yamlSelectionRanges';
 
 export enum SchemaPriority {
   SchemaStore = 1,
@@ -173,6 +175,7 @@ export interface LanguageService {
   deleteSchemaContent(schemaDeletions: SchemaDeletions): void;
   deleteSchemasWhole(schemaDeletions: SchemaDeletionsAll): void;
   getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | null;
+  getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] | undefined;
   getCodeAction(document: TextDocument, params: CodeActionParams): CodeAction[] | undefined;
   getCodeLens(document: TextDocument): Thenable<CodeLens[] | undefined> | CodeLens[] | undefined;
   resolveCodeLens(param: CodeLens): Thenable<CodeLens> | CodeLens;
@@ -254,6 +257,7 @@ export function getLanguageService(params: {
       return schemaService.deleteSchemas(schemaDeletions);
     },
     getFoldingRanges,
+    getSelectionRanges,
     getCodeAction: (document, params) => {
       return yamlCodeActions.getCodeAction(document, params);
     },

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -110,6 +110,7 @@ export class YAMLServerInit {
         definitionProvider: true,
         documentLinkProvider: {},
         foldingRangeProvider: true,
+        selectionRangeProvider: true,
         codeActionProvider: true,
         codeLensProvider: {
           resolveProvider: false,

--- a/test/yamlSelectionRanges.test.ts
+++ b/test/yamlSelectionRanges.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { Position, Range } from 'vscode-languageserver-types';
+import { setupTextDocument } from './utils/testHelper';
+import { getSelectionRanges } from '../src/languageservice/services/yamlSelectionRanges';
+
+describe('YAML Selection Ranges Tests', () => {
+  it('should provide selection ranges for object', () => {
+    const yaml = 'foo: bar';
+    const positions: Position[] = [
+      {
+        line: 0,
+        character: 1,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    const ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expect(ranges[0].range).eql(Range.create({ line: 0, character: 0 }, { line: 0, character: 3 }));
+    expect(ranges[0].parent.range).eql(Range.create({ line: 0, character: 0 }, { line: 0, character: 8 }));
+  });
+});

--- a/test/yamlSelectionRanges.test.ts
+++ b/test/yamlSelectionRanges.test.ts
@@ -3,9 +3,22 @@ import { Position, Range, SelectionRange } from 'vscode-languageserver-types';
 import { setupTextDocument } from './utils/testHelper';
 import { getSelectionRanges } from '../src/languageservice/services/yamlSelectionRanges';
 
+function isRangesEqual(range1: Range, range2: Range): boolean {
+  return (
+    range1.start.line === range2.start.line &&
+    range1.start.character === range2.start.character &&
+    range1.end.line === range2.end.line &&
+    range1.end.character === range2.end.character
+  );
+}
+
 function expectSelections(selectionRange: SelectionRange, ranges: Range[]): void {
   for (const range of ranges) {
     expect(selectionRange.range).eql(range);
+    // Deduplicate ranges
+    while (selectionRange.parent && isRangesEqual(selectionRange.range, selectionRange.parent.range)) {
+      selectionRange = selectionRange.parent;
+    }
     selectionRange = selectionRange.parent;
   }
 }
@@ -114,6 +127,64 @@ key:
       { start: { line: 0, character: 2 }, end: { line: 0, character: 16 } },
       { start: { line: 0, character: 1 }, end: { line: 0, character: 17 } },
       { start: { line: 0, character: 0 }, end: { line: 0, character: 18 } },
+    ]);
+  });
+
+  it('selection ranges for multiple positions', () => {
+    const yaml = `
+mapping:
+  key: value
+sequence:
+  - 1
+  - null
+    `;
+    const positions: Position[] = [
+      {
+        line: 2,
+        character: 10,
+      },
+      {
+        line: 5,
+        character: 8,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    const ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 2, character: 7 }, end: { line: 2, character: 12 } },
+      { start: { line: 2, character: 2 }, end: { line: 2, character: 12 } },
+      { start: { line: 1, character: 0 }, end: { line: 2, character: 12 } },
+    ]);
+    expectSelections(ranges[1], [
+      { start: { line: 5, character: 4 }, end: { line: 5, character: 8 } },
+      { start: { line: 4, character: 2 }, end: { line: 5, character: 8 } },
+      { start: { line: 3, character: 0 }, end: { line: 5, character: 8 } },
+    ]);
+  });
+
+  it('selection ranges for multiple documents', () => {
+    const yaml = `
+document1:
+  key: value
+---
+document2:
+  - 1
+  - null
+      `;
+    const positions: Position[] = [
+      {
+        line: 5,
+        character: 5,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    const ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 5, character: 4 }, end: { line: 5, character: 5 } },
+      { start: { line: 5, character: 2 }, end: { line: 6, character: 8 } },
+      { start: { line: 4, character: 0 }, end: { line: 6, character: 8 } },
     ]);
   });
 });

--- a/test/yamlSelectionRanges.test.ts
+++ b/test/yamlSelectionRanges.test.ts
@@ -1,11 +1,18 @@
 import { expect } from 'chai';
-import { Position, Range } from 'vscode-languageserver-types';
+import { Position, Range, SelectionRange } from 'vscode-languageserver-types';
 import { setupTextDocument } from './utils/testHelper';
 import { getSelectionRanges } from '../src/languageservice/services/yamlSelectionRanges';
 
+function expectSelections(selectionRange: SelectionRange, ranges: Range[]): void {
+  for (const range of ranges) {
+    expect(selectionRange.range).eql(range);
+    selectionRange = selectionRange.parent;
+  }
+}
+
 describe('YAML Selection Ranges Tests', () => {
-  it('should provide selection ranges for object', () => {
-    const yaml = 'foo: bar';
+  it('selection ranges for mapping', () => {
+    const yaml = 'key: value';
     const positions: Position[] = [
       {
         line: 0,
@@ -15,7 +22,98 @@ describe('YAML Selection Ranges Tests', () => {
     const document = setupTextDocument(yaml);
     const ranges = getSelectionRanges(document, positions);
     expect(ranges.length).equal(positions.length);
-    expect(ranges[0].range).eql(Range.create({ line: 0, character: 0 }, { line: 0, character: 3 }));
-    expect(ranges[0].parent.range).eql(Range.create({ line: 0, character: 0 }, { line: 0, character: 8 }));
+    expectSelections(ranges[0], [
+      { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } },
+      { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+    ]);
+  });
+
+  it('selection ranges for sequence', () => {
+    const yaml = `
+key:
+  - 1
+  - word
+    `;
+    let positions: Position[] = [
+      {
+        line: 3,
+        character: 8,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    let ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 3, character: 4 }, end: { line: 3, character: 8 } },
+      { start: { line: 2, character: 2 }, end: { line: 3, character: 8 } },
+      { start: { line: 1, character: 0 }, end: { line: 3, character: 8 } },
+    ]);
+
+    positions = [
+      {
+        line: 2,
+        character: 0,
+      },
+    ];
+    ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 2, character: 0 }, end: { line: 3, character: 8 } },
+      { start: { line: 1, character: 0 }, end: { line: 3, character: 8 } },
+    ]);
+  });
+
+  it('selection ranges jump for "" \'\'', () => {
+    const yaml = `
+- "word"
+- 'word'
+    `;
+    let positions: Position[] = [
+      {
+        line: 1,
+        character: 4,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    let ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 1, character: 3 }, end: { line: 1, character: 7 } },
+      { start: { line: 1, character: 2 }, end: { line: 1, character: 8 } },
+    ]);
+
+    positions = [
+      {
+        line: 2,
+        character: 4,
+      },
+    ];
+    ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 2, character: 3 }, end: { line: 2, character: 7 } },
+      { start: { line: 2, character: 2 }, end: { line: 2, character: 8 } },
+    ]);
+  });
+
+  it('selection ranges jump for [] {}', () => {
+    const yaml = '{ key: [1, true] }';
+    const positions: Position[] = [
+      {
+        line: 0,
+        character: 12,
+      },
+    ];
+    const document = setupTextDocument(yaml);
+    const ranges = getSelectionRanges(document, positions);
+    expect(ranges.length).equal(positions.length);
+    expectSelections(ranges[0], [
+      { start: { line: 0, character: 11 }, end: { line: 0, character: 15 } },
+      { start: { line: 0, character: 8 }, end: { line: 0, character: 15 } },
+      { start: { line: 0, character: 7 }, end: { line: 0, character: 16 } },
+      { start: { line: 0, character: 2 }, end: { line: 0, character: 16 } },
+      { start: { line: 0, character: 1 }, end: { line: 0, character: 17 } },
+      { start: { line: 0, character: 0 }, end: { line: 0, character: 18 } },
+    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add selection ranges support

https://github.com/redhat-developer/yaml-language-server/assets/68118705/d9534494-2ab4-4993-85b6-94c54410380b

There're some problems about selecting single word caused by [this](https://github.com/redhat-developer/vscode-yaml/blob/b72e1b7146baa97a4f28499a01eb0d4e64a19876/language-configuration.json#L37)

I don't know what that regex actually does so I can't really fix it

![image](https://github.com/redhat-developer/yaml-language-server/assets/68118705/16ee1cf8-4591-4146-a28f-938076afeaf5)
![image](https://github.com/redhat-developer/yaml-language-server/assets/68118705/384a341b-f45e-4ea2-8a2e-a0bb0e6bef2b)

### What issues does this PR fix or reference?

[vscode-yaml#307](https://github.com/redhat-developer/vscode-yaml/issues/307)

