### PR TITLE
Feat/add title source hover settings

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -7,7 +7,7 @@
 
 import { Hover, MarkupContent, MarkupKind, Position, Range } from 'vscode-languageserver-types';
 import { matchOffsetToDocument } from '../utils/arrUtils';
-import { LanguageSettings } from '../yamlLanguageService';
+import { LanguageSettings, HoverSettings } from '../yamlLanguageService';
 import { YAMLSchemaService } from './yamlSchemaService';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -24,7 +24,7 @@ import { ASTNode } from 'vscode-json-languageservice';
 export class YAMLHover {
   private shouldHover: boolean;
   private indentation: string;
-  private hoverSettings: LanguageSettings['hoverSettings'];
+  private hoverSettings: HoverSettings;
   private schemaService: YAMLSchemaService;
 
   constructor(schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {
@@ -36,7 +36,7 @@ export class YAMLHover {
     if (languageSettings) {
       this.shouldHover = languageSettings.hover;
       this.indentation = languageSettings.indentation;
-      this.hoverSettings = languageSettings.hoverSettings;
+      this.hoverSettings = languageSettings.hoverSettings ?? {};
     }
   }
 
@@ -110,9 +110,8 @@ export class YAMLHover {
       return value.replace(/\|\|\s*$/, '');
     };
 
-    const hoverSettings = this.hoverSettings || {};
-    const showSource = !!hoverSettings?.showSource;
-    const showTitle = !!hoverSettings?.showTitle;
+    const showSource = this.hoverSettings?.showSource ?? true; // showSource enabled by default
+    const showTitle = this.hoverSettings?.showTitle ?? true; // showTitle enabled by default
 
     return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
       if (schema && node && !schema.errors.length) {

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -24,6 +24,7 @@ import { ASTNode } from 'vscode-json-languageservice';
 export class YAMLHover {
   private shouldHover: boolean;
   private indentation: string;
+  private hoverSettings: LanguageSettings['hoverSettings'];
   private schemaService: YAMLSchemaService;
 
   constructor(schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {
@@ -35,6 +36,7 @@ export class YAMLHover {
     if (languageSettings) {
       this.shouldHover = languageSettings.hover;
       this.indentation = languageSettings.indentation;
+      this.hoverSettings = languageSettings.hoverSettings;
     }
   }
 
@@ -108,6 +110,10 @@ export class YAMLHover {
       return value.replace(/\|\|\s*$/, '');
     };
 
+    const hoverSettings = this.hoverSettings || {};
+    const showSource = hoverSettings.hasOwnProperty('showSource') ? hoverSettings.showSource : true;
+    const showTitle = hoverSettings.hasOwnProperty('showTitle') ? hoverSettings.showTitle : true;
+    
     return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
       if (schema && node && !schema.errors.length) {
         const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
@@ -160,7 +166,7 @@ export class YAMLHover {
           return true;
         });
         let result = '';
-        if (title) {
+        if (showTitle && title) {
           result = '#### ' + toMarkdown(title);
         }
         if (markdownDescription) {
@@ -184,7 +190,7 @@ export class YAMLHover {
             result += `\n\n\`\`\`${example}\`\`\``;
           });
         }
-        if (result.length > 0 && schema.schema.url) {
+        if (showSource && result.length > 0 && schema.schema.url) {
           result += `\n\nSource: [${getSchemaName(schema.schema)}](${schema.schema.url})`;
         }
         return createHover(result);

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -111,9 +111,9 @@ export class YAMLHover {
     };
 
     const hoverSettings = this.hoverSettings || {};
-    const showSource = hoverSettings.hasOwnProperty('showSource') ? hoverSettings.showSource : true;
-    const showTitle = hoverSettings.hasOwnProperty('showTitle') ? hoverSettings.showTitle : true;
-    
+    const showSource = !!hoverSettings?.showSource;
+    const showTitle = !!hoverSettings?.showTitle;
+
     return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
       if (schema && node && !schema.errors.length) {
         const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -69,10 +69,15 @@ export interface SchemasSettings {
   versions?: SchemaVersions;
 }
 
+export interface HoverSettings {
+  showSource?: boolean;
+  showTitle?: boolean;
+}
+
 export interface LanguageSettings {
   validate?: boolean; //Setting for whether we want to validate the schema
   hover?: boolean; //Setting for whether we want to have hover results
-  hoverSettings?: { showSource?: boolean; showTitle?: boolean }; // Settings for hover parts
+  hoverSettings?: HoverSettings; // Settings for hover parts
   completion?: boolean; //Setting for whether we want to have completion results
   format?: boolean; //Setting for whether we want to have the formatter or not
   isKubernetes?: boolean; //If true then its validating against kubernetes

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -72,7 +72,7 @@ export interface SchemasSettings {
 export interface LanguageSettings {
   validate?: boolean; //Setting for whether we want to validate the schema
   hover?: boolean; //Setting for whether we want to have hover results
-  hoverSettings?: {showSource?: boolean; showTitle?: boolean;}; // Settings for hover parts
+  hoverSettings?: { showSource?: boolean; showTitle?: boolean }; // Settings for hover parts
   completion?: boolean; //Setting for whether we want to have completion results
   format?: boolean; //Setting for whether we want to have the formatter or not
   isKubernetes?: boolean; //If true then its validating against kubernetes

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -72,6 +72,7 @@ export interface SchemasSettings {
 export interface LanguageSettings {
   validate?: boolean; //Setting for whether we want to validate the schema
   hover?: boolean; //Setting for whether we want to have hover results
+  hoverSettings?: {showSource?: boolean; showTitle?: boolean;}; // Settings for hover parts
   completion?: boolean; //Setting for whether we want to have completion results
   format?: boolean; //Setting for whether we want to have the formatter or not
   isKubernetes?: boolean; //If true then its validating against kubernetes

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -551,6 +551,114 @@ users:
       );
     });
 
+    it('Hover hides title and source when disabled', async () => {
+      (() => {
+        languageSettingsSetup = new ServiceSetup()
+          .withHover()
+          .withSchemaFileMatch({
+            uri: 'http://google.com',
+            fileMatch: ['bad-schema.yaml'],
+          })
+          .withHoverSettings({
+            showTitle: false,
+            showSource: false,
+          });
+        const {
+          languageService: langService,
+          languageHandler: langHandler,
+          yamlSettings: settings,
+          telemetry: testTelemetry,
+        } = setupLanguageService(languageSettingsSetup.languageSettings);
+        languageService = langService;
+        languageHandler = langHandler;
+        yamlSettings = settings;
+        telemetry = testTelemetry;
+      })();
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        title: 'Living being',
+        properties: {
+          animal: {
+            type: 'string',
+            description: 'should return this description',
+            enum: ['cat', 'dog'],
+            examples: ['cat', 'dog'],
+          },
+        },
+      });
+      const content = 'animal:\n  ca|t|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Examples:
+
+\`\`\`"cat"\`\`\`
+
+\`\`\`"dog"\`\`\``
+      );
+    });
+
+    it('Hover works when title and source explicitely enabled', async () => {
+      (() => {
+        languageSettingsSetup = new ServiceSetup()
+          .withHover()
+          .withSchemaFileMatch({
+            uri: 'http://google.com',
+            fileMatch: ['bad-schema.yaml'],
+          })
+          .withHoverSettings({
+            showTitle: true,
+            showSource: true,
+          });
+        const {
+          languageService: langService,
+          languageHandler: langHandler,
+          yamlSettings: settings,
+          telemetry: testTelemetry,
+        } = setupLanguageService(languageSettingsSetup.languageSettings);
+        languageService = langService;
+        languageHandler = langHandler;
+        yamlSettings = settings;
+        telemetry = testTelemetry;
+      })();
+      languageService.addSchema(SCHEMA_ID, {
+        type: 'object',
+        title: 'Living being',
+        properties: {
+          animal: {
+            type: 'string',
+            description: 'should return this description',
+            enum: ['cat', 'dog'],
+            examples: ['cat', 'dog'],
+          },
+        },
+      });
+      const content = 'animal:\n  ca|t|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `#### Living being
+
+should return this description
+
+Examples:
+
+\`\`\`"cat"\`\`\`
+
+\`\`\`"dog"\`\`\`
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('Hover works on examples', async () => {
       languageService.addSchema(SCHEMA_ID, {
         type: 'object',

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { LanguageSettings, SchemasSettings } from '../../src/languageservice/yamlLanguageService';
+import { HoverSettings, LanguageSettings, SchemasSettings } from '../../src/languageservice/yamlLanguageService';
 
 export class ServiceSetup {
   /*
@@ -12,6 +12,7 @@ export class ServiceSetup {
   languageSettings: LanguageSettings = {
     validate: false,
     hover: false,
+    hoverSettings: {},
     completion: false,
     format: false,
     isKubernetes: false,
@@ -30,6 +31,11 @@ export class ServiceSetup {
 
   withHover(): ServiceSetup {
     this.languageSettings.hover = true;
+    return this;
+  }
+
+  withHoverSettings(hoverSettings: HoverSettings): ServiceSetup {
+    this.languageSettings.hoverSettings = hoverSettings;
     return this;
   }
 


### PR DESCRIPTION
### What does this PR do?

It adds hover settings to enable/disable Title and Source from hover tooltip

### What issues does this PR fix or reference?

It is based on the work of @nikalexxx from 2022/05, see [here](https://github.com/redhat-developer/yaml-language-server/pull/718) for context and pictures of what the PR does
Original didn't pass the CI because of format/lint issues.
It is now correctly linted

### Is it tested? How?
Two unitary tests were added, correctly showing the result when the new settings are enabled/disabled
