### PR TITLE
Update to Prettier 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
     "type": "git",
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
-  "optionalDependencies": {
-    "prettier": "2.8.7"
-  },
   "dependencies": {
     "ajv": "^8.11.0",
     "lodash": "4.17.21",
+    "prettier": "^3.0.0",
     "request-light": "^0.5.7",
     "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^9.0.0",
@@ -49,7 +47,6 @@
     "@types/chai": "^4.2.12",
     "@types/mocha": "8.2.2",
     "@types/node": "16.x",
-    "@types/prettier": "2.7.2",
     "@types/sinon": "^9.0.5",
     "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
@@ -57,9 +54,9 @@
     "chai": "^4.2.0",
     "coveralls": "3.1.1",
     "eslint": "^8.24.0",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "mocha": "9.2.2",

--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -114,7 +114,7 @@ export class LanguageHandlers {
    * Called when the formatter is invoked
    * Returns the formatted document content using prettier
    */
-  formatterHandler(formatParams: DocumentFormattingParams): TextEdit[] {
+  formatterHandler(formatParams: DocumentFormattingParams): Promise<TextEdit[]> {
     const document = this.yamlSettings.documents.get(formatParams.textDocument.uri);
 
     if (!document) {

--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -14,7 +14,10 @@ import { SchemaModificationNotification } from '../../requestTypes';
 
 export class RequestHandlers {
   private languageService: LanguageService;
-  constructor(private readonly connection: Connection, languageService: LanguageService) {
+  constructor(
+    private readonly connection: Connection,
+    languageService: LanguageService
+  ) {
     this.languageService = languageService;
   }
 

--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -14,7 +14,11 @@ export class ValidationHandler {
   private languageService: LanguageService;
   private yamlSettings: SettingsState;
 
-  constructor(private readonly connection: Connection, languageService: LanguageService, yamlSettings: SettingsState) {
+  constructor(
+    private readonly connection: Connection,
+    languageService: LanguageService,
+    yamlSettings: SettingsState
+  ) {
     this.languageService = languageService;
     this.yamlSettings = yamlSettings;
 

--- a/src/languageserver/handlers/workspaceHandlers.ts
+++ b/src/languageserver/handlers/workspaceHandlers.ts
@@ -7,7 +7,10 @@ import { ExecuteCommandParams, Connection } from 'vscode-languageserver';
 import { CommandExecutor } from '../commandExecutor';
 
 export class WorkspaceHandlers {
-  constructor(private readonly connection: Connection, private readonly commandExecutor: CommandExecutor) {}
+  constructor(
+    private readonly connection: Connection,
+    private readonly commandExecutor: CommandExecutor
+  ) {}
 
   registerHandlers(): void {
     this.connection.onExecuteCommand((params) => this.executeCommand(params));

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -286,7 +286,10 @@ export interface ISchemaCollector {
 
 class SchemaCollector implements ISchemaCollector {
   schemas: IApplicableSchema[] = [];
-  constructor(private focusOffset = -1, private exclude: ASTNode = null) {}
+  constructor(
+    private focusOffset = -1,
+    private exclude: ASTNode = null
+  ) {}
   add(schema: IApplicableSchema): void {
     this.schemas.push(schema);
   }

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -17,7 +17,10 @@ import { convertErrorToTelemetryMsg } from '../utils/objects';
 export class YAMLDocumentSymbols {
   private jsonDocumentSymbols;
 
-  constructor(schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {
+  constructor(
+    schemaService: YAMLSchemaService,
+    private readonly telemetry?: Telemetry
+  ) {
     this.jsonDocumentSymbols = new JSONDocumentSymbols(schemaService);
 
     // override 'getKeyLabel' to handle complex mapping

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -15,7 +15,10 @@ import { convertErrorToTelemetryMsg } from '../utils/objects';
 import { getSchemaTitle } from '../utils/schemaUtils';
 
 export class YamlCodeLens {
-  constructor(private schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {}
+  constructor(
+    private schemaService: YAMLSchemaService,
+    private readonly telemetry?: Telemetry
+  ) {}
 
   async getCodeLens(document: TextDocument): Promise<CodeLens[]> {
     const result = [];

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -6,9 +6,8 @@
 
 import { Range, Position, TextEdit, FormattingOptions } from 'vscode-languageserver-types';
 import { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
-import * as prettier from 'prettier';
-import { Options } from 'prettier';
-import * as parser from 'prettier/parser-yaml';
+import { format, Options } from 'prettier';
+import * as parser from 'prettier/plugins/yaml';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 export class YAMLFormatter {
@@ -20,7 +19,10 @@ export class YAMLFormatter {
     }
   }
 
-  public format(document: TextDocument, options: Partial<FormattingOptions> & CustomFormatterOptions = {}): TextEdit[] {
+  public async format(
+    document: TextDocument,
+    options: Partial<FormattingOptions> & CustomFormatterOptions = {}
+  ): Promise<TextEdit[]> {
     if (!this.formatterEnabled) {
       return [];
     }
@@ -43,7 +45,7 @@ export class YAMLFormatter {
         printWidth: options.printWidth,
       };
 
-      const formatted = prettier.format(text, prettierOptions);
+      const formatted = await format(text, prettierOptions);
 
       return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
     } catch (error) {

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -26,7 +26,10 @@ export class YAMLHover {
   private indentation: string;
   private schemaService: YAMLSchemaService;
 
-  constructor(schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {
+  constructor(
+    schemaService: YAMLSchemaService,
+    private readonly telemetry?: Telemetry
+  ) {
     this.shouldHover = true;
     this.schemaService = schemaService;
   }

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -48,7 +48,10 @@ export class YAMLValidation {
 
   private MATCHES_MULTIPLE = 'Matches multiple schemas when only one must validate.';
 
-  constructor(schemaService: YAMLSchemaService, private readonly telemetry?: Telemetry) {
+  constructor(
+    schemaService: YAMLSchemaService,
+    private readonly telemetry?: Telemetry
+  ) {
     this.validationEnabled = true;
     this.jsonValidation = new JSONValidation(schemaService, Promise);
   }

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -16,8 +16,8 @@ export function getSchemaTypeName(schema: JSONSchema): string {
   return Array.isArray(schema.type)
     ? schema.type.join(' | ')
     : closestTitleWithType
-    ? schema.type.concat('(', schema.closestTitle, ')')
-    : schema.type || schema.closestTitle; //object
+      ? schema.type.concat('(', schema.closestTitle, ')')
+      : schema.type || schema.closestTitle; //object
 }
 
 /**

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -166,7 +166,7 @@ export interface LanguageService {
   findDocumentSymbols2: (document: TextDocument, context?: DocumentSymbolsContext) => DocumentSymbol[];
   findLinks: (document: TextDocument) => Promise<DocumentLink[]>;
   resetSchema: (uri: string) => boolean;
-  doFormat: (document: TextDocument, options?: CustomFormatterOptions) => TextEdit[];
+  doFormat: (document: TextDocument, options?: CustomFormatterOptions) => Promise<TextEdit[]>;
   doDefinition: (document: TextDocument, params: DefinitionParams) => DefinitionLink[] | undefined;
   doDocumentOnTypeFormatting: (document: TextDocument, params: DocumentOnTypeFormattingParams) => TextEdit[] | undefined;
   addSchema: (schemaID: string, schema: JSONSchema) => void;

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -24,7 +24,7 @@ describe('Formatter Tests', () => {
   describe('Formatter', function () {
     describe('Test that formatter works with custom tags', function () {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      function parseSetup(content: string, options: any = {}): TextEdit[] {
+      function parseSetup(content: string, options: any = {}): Promise<TextEdit[]> {
         const testTextDocument = setupTextDocument(content);
         yamlSettings.documents = new TextDocumentTestManager();
         (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
@@ -35,31 +35,32 @@ describe('Formatter Tests', () => {
         });
       }
 
-      it('Formatting works without custom tags', () => {
+      it('Formatting works without custom tags', async () => {
         const content = 'cwd: test';
-        const edits = parseSetup(content);
+        const edits = await parseSetup(content);
+        console.dir({ edits });
         assert.notEqual(edits.length, 0);
         assert.equal(edits[0].newText, 'cwd: test\n');
       });
 
-      it('Formatting works with custom tags', () => {
+      it('Formatting works with custom tags', async () => {
         const content = 'cwd:       !Test test';
-        const edits = parseSetup(content);
+        const edits = await parseSetup(content);
         assert.notEqual(edits.length, 0);
         assert.equal(edits[0].newText, 'cwd: !Test test\n');
       });
 
-      it('Formatting wraps text', () => {
+      it('Formatting wraps text', async () => {
         const content = `comments: >
                 test test test test test test test test test test test test`;
-        const edits = parseSetup(content, {
+        const edits = await parseSetup(content, {
           printWidth: 20,
           proseWrap: 'always',
         });
         assert.equal(edits[0].newText, 'comments: >\n  test test test\n  test test test\n  test test test\n  test test test\n');
       });
 
-      it('Formatting uses tabSize', () => {
+      it('Formatting uses tabSize', async () => {
         const content = `map:
   k1: v1
   k2: v2
@@ -68,7 +69,7 @@ list:
   - item2
 `;
 
-        const edits = parseSetup(content, {
+        const edits = await parseSetup(content, {
           tabSize: 5,
         });
 
@@ -82,7 +83,7 @@ list:
         assert.equal(edits[0].newText, expected);
       });
 
-      it('Formatting uses tabWidth', () => {
+      it('Formatting uses tabWidth', async () => {
         const content = `map:
   k1: v1
   k2: v2
@@ -91,7 +92,7 @@ list:
   - item2
 `;
 
-        const edits = parseSetup(content, {
+        const edits = await parseSetup(content, {
           tabWidth: 5,
         });
 
@@ -105,7 +106,7 @@ list:
         assert.equal(edits[0].newText, expected);
       });
 
-      it('Formatting uses tabWidth over tabSize', () => {
+      it('Formatting uses tabWidth over tabSize', async () => {
         const content = `map:
   k1: v1
   k2: v2
@@ -114,7 +115,7 @@ list:
   - item2
 `;
 
-        const edits = parseSetup(content, {
+        const edits = await parseSetup(content, {
           tabSize: 3,
           tabWidth: 5,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,6 +347,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pkgr/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
+  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
+
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.3"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz"
@@ -424,11 +429,6 @@
   version "16.11.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.60.tgz#a1fbca80c18dd80c8783557304cdb7d55ac3aff5"
   integrity sha512-kYIYa1D1L+HDv5M5RXQeEu1o0FKA6yedZIoyugm/MBPROkLpX4L7HRxMrPVyo8bnvjpW/wDlqFNGzXNMb7AdRw==
-
-"@types/prettier@2.7.2":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
-  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
 "@types/sinon-chai@^3.2.5":
   version "3.2.5"
@@ -1153,10 +1153,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
-  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+eslint-config-prettier@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -1193,12 +1193,13 @@ eslint-plugin-import@^2.26.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-prettier@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
-  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+eslint-plugin-prettier@^5.0.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz#17cfade9e732cef32b5f5be53bd4e07afd8e67e1"
+  integrity sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+    synckit "^0.8.6"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -2570,10 +2571,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.8.7:
-  version "2.8.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
-  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
+prettier@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.1.tgz#e68935518dd90bb7ec4821ba970e68f8de16e1ac"
+  integrity sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"
@@ -2783,7 +2784,7 @@ side-channel@^1.0.4:
 
 signal-exit@^3.0.2:
   version "3.0.7"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 sinon-chai@^3.5.0:
@@ -2928,6 +2929,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+synckit@^0.8.6:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.8.tgz#fe7fe446518e3d3d49f5e429f443cf08b6edfcd7"
+  integrity sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
@@ -2995,6 +3004,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### What does this PR do?

This updates Prettier to version 3.

- Prettier 3 is async, so related functions were made async.
- Code was reformatted using Prettier.
- Prettier now ships their own types, so `@types/prettier` was removed.
- Prettier was moved to `dependencies`. `optionalDependencies` is for dependencies that have a `install` script that may fail. This isn’t the case for Prettier.
- `eslint-plugin-prettier` was updated as well.

Alternatively the formatting functionality could be removed. IMO people should just use Prettier themselves for formatting YAML instead of relying on this `yaml-language-server`.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```sh
npm test
```