### PR TITLE
Fix some small type issues

### DIFF
--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -229,7 +229,7 @@ export class LanguageHandlers {
     return this.languageService.getCodeAction(textDocument, params);
   }
 
-  codeLensHandler(params: CodeLensParams): Thenable<CodeLens[] | undefined> | CodeLens[] | undefined {
+  codeLensHandler(params: CodeLensParams): PromiseLike<CodeLens[] | undefined> | CodeLens[] | undefined {
     const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
     if (!textDocument) {
       return;
@@ -237,7 +237,7 @@ export class LanguageHandlers {
     return this.languageService.getCodeLens(textDocument);
   }
 
-  codeLensResolveHandler(param: CodeLens): Thenable<CodeLens> | CodeLens {
+  codeLensResolveHandler(param: CodeLens): PromiseLike<CodeLens> | CodeLens {
     return this.languageService.resolveCodeLens(param);
   }
 

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -44,7 +44,7 @@ export class YamlCodeLens {
 
     return result;
   }
-  resolveCodeLens(param: CodeLens): Thenable<CodeLens> | CodeLens {
+  resolveCodeLens(param: CodeLens): PromiseLike<CodeLens> | CodeLens {
     return param;
   }
 }

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -21,7 +21,7 @@ export class YAMLFormatter {
     }
   }
 
-  public format(document: TextDocument, options: FormattingOptions & CustomFormatterOptions): TextEdit[] {
+  public format(document: TextDocument, options: Partial<FormattingOptions> & CustomFormatterOptions = {}): TextEdit[] {
     if (!this.formatterEnabled) {
       return [];
     }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -157,28 +157,28 @@ export interface CustomFormatterOptions {
 }
 
 export interface LanguageService {
-  configure(settings: LanguageSettings): void;
-  registerCustomSchemaProvider(schemaProvider: CustomSchemaProvider): void;
-  doComplete(document: TextDocument, position: Position, isKubernetes: boolean): Promise<CompletionList>;
-  doValidation(document: TextDocument, isKubernetes: boolean): Promise<Diagnostic[]>;
-  doHover(document: TextDocument, position: Position): Promise<Hover | null>;
-  findDocumentSymbols(document: TextDocument, context: DocumentSymbolsContext): SymbolInformation[];
-  findDocumentSymbols2(document: TextDocument, context: DocumentSymbolsContext): DocumentSymbol[];
-  findLinks(document: TextDocument): Promise<DocumentLink[]>;
-  resetSchema(uri: string): boolean;
-  doFormat(document: TextDocument, options: CustomFormatterOptions): TextEdit[];
-  doDefinition(document: TextDocument, params: DefinitionParams): DefinitionLink[] | undefined;
-  doDocumentOnTypeFormatting(document: TextDocument, params: DocumentOnTypeFormattingParams): TextEdit[] | undefined;
-  addSchema(schemaID: string, schema: JSONSchema): void;
-  deleteSchema(schemaID: string): void;
-  modifySchemaContent(schemaAdditions: SchemaAdditions): void;
-  deleteSchemaContent(schemaDeletions: SchemaDeletions): void;
-  deleteSchemasWhole(schemaDeletions: SchemaDeletionsAll): void;
-  getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | null;
-  getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] | undefined;
-  getCodeAction(document: TextDocument, params: CodeActionParams): CodeAction[] | undefined;
-  getCodeLens(document: TextDocument): Thenable<CodeLens[] | undefined> | CodeLens[] | undefined;
-  resolveCodeLens(param: CodeLens): Thenable<CodeLens> | CodeLens;
+  configure: (settings: LanguageSettings) => void;
+  registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => void;
+  doComplete: (document: TextDocument, position: Position, isKubernetes: boolean) => Promise<CompletionList>;
+  doValidation: (document: TextDocument, isKubernetes: boolean) => Promise<Diagnostic[]>;
+  doHover: (document: TextDocument, position: Position) => Promise<Hover | null>;
+  findDocumentSymbols: (document: TextDocument, context?: DocumentSymbolsContext) => SymbolInformation[];
+  findDocumentSymbols2: (document: TextDocument, context?: DocumentSymbolsContext) => DocumentSymbol[];
+  findLinks: (document: TextDocument) => Promise<DocumentLink[]>;
+  resetSchema: (uri: string) => boolean;
+  doFormat: (document: TextDocument, options?: CustomFormatterOptions) => TextEdit[];
+  doDefinition: (document: TextDocument, params: DefinitionParams) => DefinitionLink[] | undefined;
+  doDocumentOnTypeFormatting: (document: TextDocument, params: DocumentOnTypeFormattingParams) => TextEdit[] | undefined;
+  addSchema: (schemaID: string, schema: JSONSchema) => void;
+  deleteSchema: (schemaID: string) => void;
+  modifySchemaContent: (schemaAdditions: SchemaAdditions) => void;
+  deleteSchemaContent: (schemaDeletions: SchemaDeletions) => void;
+  deleteSchemasWhole: (schemaDeletions: SchemaDeletionsAll) => void;
+  getFoldingRanges: (document: TextDocument, context: FoldingRangesContext) => FoldingRange[] | null;
+  getSelectionRanges: (document: TextDocument, positions: Position[]) => SelectionRange[] | undefined;
+  getCodeAction: (document: TextDocument, params: CodeActionParams) => CodeAction[] | undefined;
+  getCodeLens: (document: TextDocument) => PromiseLike<CodeLens[] | undefined> | CodeLens[] | undefined;
+  resolveCodeLens: (param: CodeLens) => PromiseLike<CodeLens> | CodeLens;
 }
 
 export function getLanguageService(params: {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -60,7 +60,7 @@ export interface JSONSchemaSettings {
 export class SettingsState {
   yamlConfigurationSettings: JSONSchemaSettings[] = undefined;
   schemaAssociations: ISchemaAssociations | SchemaConfiguration[] | undefined = undefined;
-  formatterRegistration: Thenable<Disposable> = null;
+  formatterRegistration: PromiseLike<Disposable> = null;
   specificValidatorPaths = [];
   schemaConfigurationSettings = [];
   yamlShouldValidate = true;


### PR DESCRIPTION
### What does this PR do?

Some parameters are optional, but were marked as required.

Language service methods were marked as bound methods, but they don’t have to be called as such.

The `Thenable` type from `json-rpc` was used. These were replaced with the builtin TypeScript type `PromiseLike`.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```sh
tsc
```