### PR TITLE
Add volar-service-yaml to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ This repository only contains the server implementation. Here are some known cli
 - [monaco-yaml](https://monaco-yaml.js.org) for Monaco editor
 - [Vim-EasyComplete](https://github.com/jayli/vim-easycomplete) for Vim/NeoVim
 - [nova-yaml](https://github.com/robb-j/nova-yaml/) for Nova
+- [volar-service-yaml](https://github.com/volarjs/services/tree/master/packages/yaml) for Volar
 
 ## Developer Support
 


### PR DESCRIPTION
### What does this PR do?

This adds [`volar-service-yaml`](https://github.com/volarjs/services/tree/master/packages/yaml) to the list of integrations. This makes it possible to integrate `yaml-language-server` for YAML embedded in other text documents, such as markdown frontmatter.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

Clicked the link to make sure it’s correct.