### PR TITLE
Remove ide-yaml from known clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,6 @@ This repository only contains the server implementation. Here are some known cli
 
 - [Eclipse Che](https://www.eclipse.org/che/)
 - [vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for VSCode
-- [ide-yaml](https://atom.io/packages/ide-yaml) for Atom editor
 - [coc-yaml](https://github.com/neoclide/coc-yaml) for [coc.nvim](https://github.com/neoclide/coc.nvim)
 - [Eclipse Wild Web Developer](https://marketplace.eclipse.org/content/eclipse-wild-web-developer-web-development-eclipse-ide) for Eclipse IDE
 - [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs


### PR DESCRIPTION
### What does this PR do?

Atom has been sunset. The link is no longer available.  Clicking the link would take the user to a GitHub blog post about this instead.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

Clicking the removed link.