### PR TITLE
fix: undefined error in mergingResult.problemArgs

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -400,7 +400,7 @@ export class ValidationResult {
               (problemType !== ProblemType.missingRequiredPropWarning || isArrayEqual(p.problemArgs, bestResult.problemArgs)) // missingProp is merged only with same problemArg
           );
           if (mergingResult) {
-            if (mergingResult.problemArgs.length) {
+            if (mergingResult.problemArgs?.length) {
               mergingResult.problemArgs
                 .filter((p) => !bestResult.problemArgs.includes(p))
                 .forEach((p) => bestResult.problemArgs.push(p));


### PR DESCRIPTION
### What does this PR do?
fix previous issue when `mergingResult.problemArgs` could be undefined. Then, the schema parser could end with an error.

### What issues does this PR fix or reference?
no ref


### Is it tested? How?
just manually, not sure when exactly the error occurred, didn't spend much time to find the exact schema definition that caused this issue. But it's obvious that there should be a check, because `problemArgs` could be undefined (based on the definition)