### PR TITLE
feat: unify string insert text for array and property

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1205,7 +1205,7 @@ export class YamlCompletion {
         insertText = `\${${insertIndex++}:0}`;
         break;
       case 'string':
-        insertText = `\${${insertIndex++}:""}`;
+        insertText = `\${${insertIndex++}}`;
         break;
       case 'object':
         {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -1047,7 +1047,7 @@ describe('Auto Completion Tests', () => {
         const completion = parseSetup(content, content.lastIndexOf('Ba') + 2); // pos: 3+2
         completion
           .then(function (result) {
-            assert.strictEqual('fooBar:\n  - ${1:""}', result.items[0].insertText);
+            assert.strictEqual('fooBar:\n  - ${1}', result.items[0].insertText);
           })
           .then(done, done);
       });

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -482,7 +482,7 @@ objB:
 
     expect(completion.items.length).equal(1);
     expect(completion.items[0]).to.be.deep.equal(
-      createExpectedCompletion('objectWithArray', 'objectWithArray:\n    - ${1:""}', 1, 4, 1, 4, 10, 2, {
+      createExpectedCompletion('objectWithArray', 'objectWithArray:\n    - ${1}', 1, 4, 1, 4, 10, 2, {
         documentation: '',
       })
     );


### PR DESCRIPTION
### What does this PR do?
unify string text inserting for array and property

when you choose string property from completion you get
`na` -> `name: `

but for array, it generated extra quotes:
`arr` -> 
```
array:
  - ""
```

These extra quotes caused, that it wasn't possible to invoke completion just after the code insert, but you had to delete `""` continue...

the behavior is just a little bit different than for property text inserting.

https://github.com/redhat-developer/yaml-language-server/assets/38421337/8d73fb4a-8b10-49d9-ac27-ac37362d89c4

Note that I didn't change it for `number` nor for `bool` because it seems to me a little bit different scenario

### What issues does this PR fix or reference?


### Is it tested? How?
update current tests
