### PR TITLE
Fix missing quote and syntax highlight in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following settings are supported:
 - `[yaml].editor.formatOnType`: Enable/disable on type indent and auto formatting array
 - `yaml.disableDefaultProperties`: Disable adding not required properties with default values into completion text
 - `yaml.suggest.parentSkeletonSelectedFirst`: If true, the user must select some parent skeleton first before autocompletion starts to suggest the rest of the properties.\nWhen yaml object is not empty, autocompletion ignores this setting and returns all properties and skeletons.
-- `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid` 
+- `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid`
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
 - `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
 
@@ -58,7 +58,7 @@ The following settings are supported:
 
 In order to use the custom tags in your YAML file you need to first specify the custom tags in the setting of your code editor. For example, we can have the following custom tags:
 
-```YAML
+```json
 "yaml.customTags": [
     "!Scalar-example scalar",
     "!Seq-example sequence",
@@ -70,7 +70,7 @@ The !Scalar-example would map to a scalar custom tag, the !Seq-example would map
 
 We can then use the newly defined custom tags inside our YAML file:
 
-```YAML
+```yaml
 some_key: !Scalar-example some_value
 some_sequence: !Seq-example
   - some_seq_key_1: some_seq_value_1
@@ -93,8 +93,8 @@ myProject
 
 you can do
 
-```
-yaml.schemas: {
+```json
+"yaml.schemas": {
     "https://json.schemastore.org/composer": "/myYamlFile.yaml"
 }
 ```
@@ -110,7 +110,7 @@ and that will associate the composer schema with myYamlFile.yaml.
 When associating a schema it should follow the format below
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "url": "globPattern",
     "Kubernetes": "globPattern"
 }
@@ -119,7 +119,7 @@ yaml.schemas: {
 e.g.
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "https://json.schemastore.org/composer": "/*"
 }
 ```
@@ -127,7 +127,7 @@ yaml.schemas: {
 e.g.
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "kubernetes": "/myYamlFile.yaml"
 }
 ```
@@ -135,7 +135,7 @@ yaml.schemas: {
 e.g.
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "https://json.schemastore.org/composer": "/*",
     "kubernetes": "/myYamlFile.yaml"
 }
@@ -144,7 +144,7 @@ yaml.schemas: {
 On Windows with full path:
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "C:\\Users\\user\\Documents\\custom_schema.json": "someFilePattern.yaml",
 }
 ```
@@ -152,7 +152,7 @@ yaml.schemas: {
 On Mac/Linux with full path:
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "/home/user/custom_schema.json": "someFilePattern.yaml",
 }
 ```
@@ -166,7 +166,7 @@ Since `0.11.0` YAML Schemas can be used for validation:
 A schema can be associated with multiple globs using a json array, e.g.
 
 ```json
-yaml.schemas: {
+"yaml.schemas": {
     "kubernetes": ["filePattern1.yaml", "filePattern2.yaml"]
 }
 ```
@@ -216,8 +216,8 @@ My_second_project:
 
 You must then associate schemas relative to the root of the multi root workspace project.
 
-```
-yaml.schemas: {
+```json
+"yaml.schemas": {
     "My_first_project/my_schema.json": "test.yaml",
     "My_second_project/my_schema2.json": "test2.yaml"
 }
@@ -229,8 +229,8 @@ yaml.schemas: {
 
 Suppose a file is meant to be a component of an existing schema (like a `job.yaml` file in a circleci orb), but there isn't a standalone schema that you can reference. If there is a nested schema definition for this subcomponent, you can reference it using a url fragment, e.g.:
 
-```
-yaml.schemas: {
+```json
+"yaml.schemas": {
     "https://json.schemastore.org/circleciconfig#/definitions/jobs/additionalProperties": "/src/jobs/*.yaml",
 }
 ```


### PR DESCRIPTION
### What does this PR do?

Fix some missing quotes and syntax highlighting in README

Before 

![image](https://github.com/redhat-developer/yaml-language-server/assets/68118705/906b69d1-49e7-401b-b9d7-272b277d382b)

After

![image](https://github.com/redhat-developer/yaml-language-server/assets/68118705/d6c78af5-b69e-40d0-80c3-8509eff29d21)
