### PR TITLE
fix: show all enums on hover

### DIFF
--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -556,6 +556,37 @@ users:
       );
     });
 
+    it('Hover displays enum descriptions if present', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            type: 'string',
+            description: 'should return this description',
+            enum: ['cat', 'dog', 'non'],
+            enumDescriptions: ['', 'Canis familiaris'],
+          },
+        },
+      });
+      const content = 'animal:\n  ca|t|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Allowed Values:
+
+* \`cat\`
+* \`dog\`: Canis familiaris
+* \`non\`
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('Hover works on examples', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
@@ -577,11 +608,15 @@ users:
         (result.contents as MarkupContent).value,
         `should return this description
 
+Allowed Values:
+
+* \`cat\`
+* \`dog\`
+
 Examples:
 
-\`\`\`"cat"\`\`\`
-
-\`\`\`"dog"\`\`\`
+* \`\`\`"cat"\`\`\`
+* \`\`\`"dog"\`\`\`
 
 Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );


### PR DESCRIPTION
### What does this PR do?

This PR updates the hover service to display all possible enum values, rather than just the currently selected one. Additionally, it will display the enums regardless of whether the schema contains explicit descriptions (though it will continue to display the descriptions if present - see included test case).

<img width="447" alt="Screen Shot 2023-12-03 at 3 56 05 PM" src="https://github.com/redhat-developer/yaml-language-server/assets/245879/c536d47c-0134-4843-b3da-26362e092235">

<br />
<br />

Also: 

- Included a minor change to how examples are displayed (i.e. added markdown bullets) to make them visually consistent with the enums.
- Added a `ensureLineBreak` helper to make sure there is consistent spacing between each of the various hover sections.

### What issues does this PR fix or reference?

Fixes #941

### Is it tested? How?

- Tested locally with https://github.com/twelvelabs/stamp/blob/main/docs/stamp.schema.json
- See test cases in `test/hover.test.ts`
