### PR TITLE
README: Fix syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following settings are supported:
 
 In order to use the custom tags in your YAML file you need to first specify the custom tags in the setting of your code editor. For example, we can have the following custom tags:
 
-```YAML
+```yaml
 "yaml.customTags": [
     "!Scalar-example scalar",
     "!Seq-example sequence",
@@ -70,7 +70,7 @@ The !Scalar-example would map to a scalar custom tag, the !Seq-example would map
 
 We can then use the newly defined custom tags inside our YAML file:
 
-```YAML
+```yaml
 some_key: !Scalar-example some_value
 some_sequence: !Seq-example
   - some_seq_key_1: some_seq_value_1
@@ -93,7 +93,7 @@ myProject
 
 you can do
 
-```
+```yaml
 yaml.schemas: {
     "https://json.schemastore.org/composer": "/myYamlFile.yaml"
 }
@@ -109,7 +109,7 @@ and that will associate the composer schema with myYamlFile.yaml.
 
 When associating a schema it should follow the format below
 
-```json
+```yaml
 yaml.schemas: {
     "url": "globPattern",
     "Kubernetes": "globPattern"
@@ -118,7 +118,7 @@ yaml.schemas: {
 
 e.g.
 
-```json
+```yaml
 yaml.schemas: {
     "https://json.schemastore.org/composer": "/*"
 }
@@ -126,7 +126,7 @@ yaml.schemas: {
 
 e.g.
 
-```json
+```yaml
 yaml.schemas: {
     "kubernetes": "/myYamlFile.yaml"
 }
@@ -134,7 +134,7 @@ yaml.schemas: {
 
 e.g.
 
-```json
+```yaml
 yaml.schemas: {
     "https://json.schemastore.org/composer": "/*",
     "kubernetes": "/myYamlFile.yaml"
@@ -143,7 +143,7 @@ yaml.schemas: {
 
 On Windows with full path:
 
-```json
+```yaml
 yaml.schemas: {
     "C:\\Users\\user\\Documents\\custom_schema.json": "someFilePattern.yaml",
 }
@@ -151,7 +151,7 @@ yaml.schemas: {
 
 On Mac/Linux with full path:
 
-```json
+```yaml
 yaml.schemas: {
     "/home/user/custom_schema.json": "someFilePattern.yaml",
 }
@@ -159,13 +159,13 @@ yaml.schemas: {
 
 Since `0.11.0` YAML Schemas can be used for validation:
 
-```json
+```yaml
  "/home/user/custom_schema.yaml": "someFilePattern.yaml"
 ```
 
 A schema can be associated with multiple globs using a json array, e.g.
 
-```json
+```yaml
 yaml.schemas: {
     "kubernetes": ["filePattern1.yaml", "filePattern2.yaml"]
 }
@@ -173,7 +173,7 @@ yaml.schemas: {
 
 e.g.
 
-```json
+```yaml
 "yaml.schemas": {
     "http://json.schemastore.org/composer": ["/*"],
     "file:///home/johnd/some-schema.json": ["some.yaml"],
@@ -184,7 +184,7 @@ e.g.
 
 e.g.
 
-```json
+```yaml
 "yaml.schemas": {
     "kubernetes": ["/myYamlFile.yaml"]
 }
@@ -192,7 +192,7 @@ e.g.
 
 e.g.
 
-```json
+```yaml
 "yaml.schemas": {
     "http://json.schemastore.org/composer": ["/*"],
     "kubernetes": ["/myYamlFile.yaml"]
@@ -205,7 +205,7 @@ You can also use relative paths when working with multi root workspaces.
 
 Suppose you have a multi root workspace that is laid out like:
 
-```
+```yaml
 My_first_project:
    test.yaml
    my_schema.json
@@ -216,7 +216,7 @@ My_second_project:
 
 You must then associate schemas relative to the root of the multi root workspace project.
 
-```
+```yaml
 yaml.schemas: {
     "My_first_project/my_schema.json": "test.yaml",
     "My_second_project/my_schema2.json": "test2.yaml"
@@ -229,7 +229,7 @@ yaml.schemas: {
 
 Suppose a file is meant to be a component of an existing schema (like a `job.yaml` file in a circleci orb), but there isn't a standalone schema that you can reference. If there is a nested schema definition for this subcomponent, you can reference it using a url fragment, e.g.:
 
-```
+```yaml
 yaml.schemas: {
     "https://json.schemastore.org/circleciconfig#/definitions/jobs/additionalProperties": "/src/jobs/*.yaml",
 }
@@ -275,7 +275,7 @@ The image is located at `quay.io/redhat-developer/yaml-language-server`
 
 To run the image you can use:
 
-```
+```sh
 docker run -it quay.io/redhat-developer/yaml-language-server:latest
 ```
 


### PR DESCRIPTION
All JSON is YAML, but no the other way around.

### What does this PR do?
Fix syntax highlighting in the README.

### What issues does this PR fix or reference?
Closes #944 

### Is it tested? How?
See the rendering: [here](https://github.com/pierreprinetti/yaml-language-server/blob/readme_set_yaml_on_examples/README.md).