### PR TITLE
fix: render examples as yaml on hover

### DIFF
--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -595,7 +595,14 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
             type: 'string',
             description: 'should return this description',
             enum: ['cat', 'dog'],
-            examples: ['cat', 'dog'],
+            examples: [
+              'cat',
+              {
+                animal: {
+                  type: 'dog',
+                },
+              },
+            ],
           },
         },
       });
@@ -613,10 +620,18 @@ Allowed Values:
 * \`cat\`
 * \`dog\`
 
-Examples:
+Example:
 
-* \`\`\`"cat"\`\`\`
-* \`\`\`"dog"\`\`\`
+\`\`\`yaml
+cat
+\`\`\`
+
+Example:
+
+\`\`\`yaml
+animal:
+  type: dog
+\`\`\`
 
 Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );


### PR DESCRIPTION
### What does this PR do?

This MR improves the rendering of examples on hover by:

1. Rendering the examples as YAML rather than JSON.
2. Adding an info string to the [fenced code block](https://github.github.com/gfm/#fenced-code-blocks) so that the examples are properly syntax highlighted. According to the LSP spec, [markdown content should be expected to be GFM](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent), so this shouldn't be an issue for clients.
3. Moving the indentation escaping logic to `toMarkdown`, so that we only escape non-markdown strings. Currently the escaping is done on the entire hover content, regardless of whether that content contains actual markdown. This change also fixes a bug where intentional indentation in `markdownDescription` is erroneously escaped.

Before:

<img width="823" alt="Screenshot 2023-12-27 at 3 17 58 PM" src="https://github.com/redhat-developer/yaml-language-server/assets/245879/09a54f13-d298-4de1-88a9-a0c96268c5ec">

After:

<img width="782" alt="Screenshot 2023-12-27 at 3 12 24 PM" src="https://github.com/redhat-developer/yaml-language-server/assets/245879/91cf1d93-4860-4d01-b71a-26351b2c2da0">

Note: I originally tried to keep the single header (rather than repeating it per-example), but the code fences don't appear to have a margin applied so the examples were all bunched together. Repeating the header looked much nicer.

### What issues does this PR fix or reference?

- Fixes: redhat-developer/vscode-yaml#896
- Fixes: redhat-developer/vscode-yaml#959
- Fixes: redhat-developer/vscode-yaml#960
- Fixes: redhat-developer/vscode-yaml#961
- Fixes: redhat-developer/vscode-yaml#965

### Is it tested? How?

I updated an existing unit test. Also tested manually with the following (see screenshots):

- `schema.json`:

```json
{
    "$id": "schema.json",
    "$schema": "https://json-schema.org/draft-07/schema",
    "title": "Example Schema",
    "properties": {
        "example": {
            "title": "Example Property",
            "description": "This property has examples that should be rendered as YAML code blocks.",
            "examples": [
                "string value",
                {
                    "object_value": {
                        "enabled": true
                    }
                }
            ],
            "type": [
                "object",
                "string"
            ]
        }
    },
    "type": "object"
}
```

- `example.yaml`:

```yaml
# yaml-language-server: $schema=schema.json
example: "hello"
```