### PR TITLE
fix: snippets in additionalProperties

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -925,7 +925,8 @@ export class YamlCompletion {
             if (propertySchema) {
               this.addSchemaValueCompletions(propertySchema, separatorAfter, collector, types, 'value');
             }
-          } else if (s.schema.additionalProperties) {
+          }
+          if (s.schema.additionalProperties) {
             this.addSchemaValueCompletions(s.schema.additionalProperties, separatorAfter, collector, types, 'value');
           }
         }

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1183,6 +1183,30 @@ objB:
     expect(completion.items[0].insertText).to.be.equal('test1');
   });
 
+  it('should suggest defaultSnippets from additionalProperties', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+        },
+      },
+      additionalProperties: {
+        anyOf: [
+          {
+            type: 'string',
+            defaultSnippets: [{ label: 'snippet', body: 'snippetBody' }],
+          },
+        ],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const content = 'value: |\n|';
+    const completion = await parseCaret(content);
+
+    expect(completion.items.map((i) => i.insertText)).to.be.deep.equal(['snippetBody']);
+  });
+
   describe('should suggest prop of the object (based on not completed prop name)', () => {
     const schema: JSONSchema = {
       definitions: {


### PR DESCRIPTION
### What does this PR do?

fixes issue where `additionalProperties` were ignored on value completion if the object schema contains `properties`

check the test and code fix, it's more descriptive probabbly


### What issues does this PR fix or reference?
extends on of the previous fix https://github.com/redhat-developer/yaml-language-server/pull/717

### Is it tested? How?
adds test
