### PR TITLE
fix: crash when url is undefined

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -20,7 +20,7 @@ export class SettingsHandler {
     private readonly yamlSettings: SettingsState,
     private readonly validationHandler: ValidationHandler,
     private readonly telemetry: Telemetry
-  ) { }
+  ) {}
 
   async registerHandlers(): Promise<void> {
     if (this.yamlSettings.hasConfigurationCapability && this.yamlSettings.clientDynamicRegisterSupport) {

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -180,7 +180,7 @@ export class SettingsHandler {
   private async setSchemaStoreSettingsIfNotSet(): Promise<void> {
     const schemaStoreIsSet = this.yamlSettings.schemaStoreSettings.length !== 0;
     let schemaStoreUrl = '';
-    if (this.yamlSettings.schemaStoreUrl.length !== 0) {
+    if (this.yamlSettings.schemaStoreUrl?.length !== 0) {
       schemaStoreUrl = this.yamlSettings.schemaStoreUrl;
     } else {
       schemaStoreUrl = JSON_SCHEMASTORE_URL;

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -20,7 +20,7 @@ export class SettingsHandler {
     private readonly yamlSettings: SettingsState,
     private readonly validationHandler: ValidationHandler,
     private readonly telemetry: Telemetry
-  ) {}
+  ) { }
 
   async registerHandlers(): Promise<void> {
     if (this.yamlSettings.hasConfigurationCapability && this.yamlSettings.clientDynamicRegisterSupport) {
@@ -81,7 +81,7 @@ export class SettingsHandler {
 
       if (settings.yaml.schemaStore) {
         this.yamlSettings.schemaStoreEnabled = settings.yaml.schemaStore.enable;
-        if (settings.yaml.schemaStore.url.length !== 0) {
+        if (settings.yaml.schemaStore.url?.length !== 0) {
           this.yamlSettings.schemaStoreUrl = settings.yaml.schemaStore.url;
         }
       }


### PR DESCRIPTION
### What does this PR do?
When the url property in the schema store is undefined the program crashes. It should also be considered adding some useful logging. Enabling schemastore without an url doesnt seem to do much.

### What issues does this PR fix or reference?
I couldnt find any issues referencing this. I can make one if thats wanted

### Is it tested? How?
Tested it locally. Try installing the package and running it with yaml.schemastore.enabled = true without specifying an url. After adding the `?` it wont crash anymore


## Stacktrace 
1. setConfiguration
`[ERROR][2024-03-15 22:13:53] ...lsp/handlers.lua:535	"TypeError: Cannot read properties of undefined (reading 'length')\n    at SettingsHandler.setConfiguration (C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\yaml-language-server\\out\\server\\src\\languageserver\\handlers\\settingsHandlers.js:80:43)\n    at SettingsHandler.pullConfiguration (C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\yaml-language-server\\out\\server\\src\\languageserver\\handlers\\settingsHandlers.js:58:16)"`

2. setSchemaStoreSettingsIfNotSet
`[ERROR][2024-03-15 22:29:16] ...lsp/handlers.lua:535	"TypeError: Cannot read properties of undefined (reading 'length')\n    at SettingsHandler.setSchemaStoreSettingsIfNotSet (C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\yaml-language-server\\out\\server\\src\\languageserver\\handlers\\settingsHandlers.js:166:42)\n    at SettingsHandler.setConfiguration (C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\yaml-language-server\\out\\server\\src\\languageserver\\handlers\\settingsHandlers.js:135:16)\n    at SettingsHandler.pullConfiguration (C:\\Users\\User\\AppData\\Roaming\\npm\\node_modules\\yaml-language-server\\out\\server\\src\\languageserver\\handlers\\settingsHandlers.js:58:16)"
`
