### PR TITLE
Add null check for `customTags`

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -293,7 +293,7 @@ export class YamlCompletion {
       proposed,
     };
 
-    if (this.customTags.length > 0) {
+    if (this.customTags && this.customTags.length > 0) {
       this.getCustomTagValueCompletions(collector);
     }
 

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -3126,5 +3126,10 @@ describe('Auto Completion Tests', () => {
         expect(result.items.map((i) => i.label)).to.have.members(['fruit', 'vegetable']);
       });
     });
+    it('Should function when settings are undefined', async () => {
+      languageService.configure({ completion: true });
+      const content = '';
+      await parseSetup(content, 0);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Add null check for `customTags` setting, so if the setting is not set completion will not fail.

### What issues does this PR fix or reference?
Fixes #807

### Is it tested? How?
I added an integration test.

