### PR TITLE
Use yaml package for formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "type": "git",
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
-  "optionalDependencies": {
-    "prettier": "2.8.7"
-  },
   "dependencies": {
     "ajv": "^8.11.0",
     "lodash": "4.17.21",
@@ -42,7 +39,7 @@
     "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^5.0.0",
     "vscode-uri": "^3.0.2",
-    "yaml": "2.2.2"
+    "yaml": "2.4.5"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "3.0.0",
@@ -65,6 +62,7 @@
     "mocha": "9.2.2",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",
+    "prettier": "2.8.7",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.3",
     "sinon-chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vscode-languageserver-types": "^3.16.0",
     "vscode-nls": "^5.0.0",
     "vscode-uri": "^3.0.2",
-    "yaml": "2.4.5"
+    "yaml": "2.5.0"
   },
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "3.0.0",

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -96,7 +96,6 @@ export class SettingsHandler {
 
       if (settings.yaml.format) {
         this.yamlSettings.yamlFormatterSettings = {
-          proseWrap: settings.yaml.format.proseWrap || 'preserve',
           printWidth: settings.yaml.format.printWidth || 80,
         };
 

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -56,7 +56,7 @@ describe('Formatter Tests', () => {
           printWidth: 20,
           proseWrap: 'always',
         });
-        assert.equal(edits[0].newText, 'comments: >\n  test test test\n  test test test\n  test test test\n  test test test\n');
+        assert.equal(edits[0].newText, 'comments: >\n  test test test test\n  test test test test\n  test test test test\n');
       });
 
       it('Formatting uses tabSize', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,10 +3222,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e"
-  integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
+yaml@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.0.tgz#c6165a721cf8000e91c36490a41d7be25176cf5d"
+  integrity sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==
 
 yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,10 +3222,10 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
-  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+yaml@2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.5.tgz#60630b206dd6d84df97003d33fc1ddf6296cca5e"
+  integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
 
 yargs-parser@20.2.4, yargs-parser@^20.2.2:
   version "20.2.4"


### PR DESCRIPTION
### What does this PR do?

This replaces Prettier as the LSP formatting solution with the `yaml` package. The `yaml` package can format YAML just fine, and we already have it as a dependency. Prettier is a big dependency.

If people want to use Prettier, other Prettier integrations are probably better suited for them. For example, the YAML language server doesn’t respect Prettier configuration files.

This is a proof of concept. I tried to map existing options to the new implementation. A more ideal solution might be to change the formatting options.

### What issues does this PR fix or reference?

Refs #933

### Is it tested? How?

```sh
npm test
```

I discovered https://github.com/eemeli/yaml/issues/562 while working on this.