### PR TITLE
multipleof does not work for floats

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -27,6 +27,7 @@ import { isArrayEqual } from '../utils/arrUtils';
 import { Node, Pair } from 'yaml';
 import { safeCreateUnicodeRegExp } from '../utils/strings';
 import { FilePatternAssociation } from '../services/yamlSchemaService';
+import { floatSafeRemainder } from '../utils/math';
 
 const localize = nls.loadMessageBundle();
 const MSG_PROPERTY_NOT_ALLOWED = 'Property {0} is not allowed.';
@@ -930,7 +931,7 @@ function validate(
     const val = node.value;
 
     if (isNumber(schema.multipleOf)) {
-      if (val % schema.multipleOf !== 0) {
+      if (floatSafeRemainder(val, schema.multipleOf) !== 0) {
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/utils/math.ts
+++ b/src/languageservice/utils/math.ts
@@ -1,8 +1,3 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
 export function floatSafeRemainder(val: number, step: number): number {
   const valDecCount = (val.toString().split('.')[1] || '').length;
   const stepDecCount = (step.toString().split('.')[1] || '').length;

--- a/src/languageservice/utils/math.ts
+++ b/src/languageservice/utils/math.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function floatSafeRemainder(
+    val: number,
+    step: number
+): number {
+    const valDecCount = (val.toString().split('.')[1] || '').length;
+    const stepDecCount = (step.toString().split('.')[1] || '').length;
+    const decCount = Math.max(valDecCount, stepDecCount);
+    const valInt = parseInt(val.toFixed(decCount).replace('.', ''));
+    const stepInt = parseInt(step.toFixed(decCount).replace('.', ''));
+    return (valInt % stepInt) / Math.pow(10, decCount);
+}

--- a/src/languageservice/utils/math.ts
+++ b/src/languageservice/utils/math.ts
@@ -3,14 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export function floatSafeRemainder(
-    val: number,
-    step: number
-): number {
-    const valDecCount = (val.toString().split('.')[1] || '').length;
-    const stepDecCount = (step.toString().split('.')[1] || '').length;
-    const decCount = Math.max(valDecCount, stepDecCount);
-    const valInt = parseInt(val.toFixed(decCount).replace('.', ''));
-    const stepInt = parseInt(step.toFixed(decCount).replace('.', ''));
-    return (valInt % stepInt) / Math.pow(10, decCount);
+export function floatSafeRemainder(val: number, step: number): number {
+  const valDecCount = (val.toString().split('.')[1] || '').length;
+  const stepDecCount = (step.toString().split('.')[1] || '').length;
+  const decCount = Math.max(valDecCount, stepDecCount);
+  const valInt = parseInt(val.toFixed(decCount).replace('.', ''));
+  const stepInt = parseInt(step.toFixed(decCount).replace('.', ''));
+  return (valInt % stepInt) / Math.pow(10, decCount);
 }

--- a/test/jsonParser.test.ts
+++ b/test/jsonParser.test.ts
@@ -1541,6 +1541,28 @@ describe('JSON Parser', () => {
     }
   });
 
+  it('multipleOfFloat', function () {
+    const schema: JsonSchema.JSONSchema = {
+      type: 'array',
+      items: {
+        type: 'number',
+        multipleOf: 0.05,
+      },
+    };
+    {
+      const { textDoc, jsonDoc } = toDocument('[0.9]');
+      const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+      assert.strictEqual(semanticErrors.length, 0);
+    }
+    {
+      const { textDoc, jsonDoc } = toDocument('[42.3222222]');
+      const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+      assert.strictEqual(semanticErrors.length, 1);
+    }
+  });
+
   it('dependencies with array', function () {
     const schema: JsonSchema.JSONSchema = {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
In the case of float numbers the multipleOf is not calculated accurately because of the floating point math used in JavaScript. This PR adds a function which does a float safe remainder operation. The remainder in the multipleOf logic is replaced by this function.

### What issues does this PR fix or reference?
Ref #985 

### Is it tested? How?
Added test `multipleOfFloat`