### PR TITLE
Only look at parent when line and cursor indents match

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -197,7 +197,12 @@ export class SingleYAMLDocument extends JSONDocument {
       const position = textBuffer.getPosition(node.range[0]);
       const lineContent = textBuffer.getLineContent(position.line);
       currentLine = currentLine === '' ? lineContent.trim() : currentLine;
-      if (currentLine.startsWith('-') && indentation === configuredIndentation && currentLine === lineContent.trim()) {
+      if (
+        currentLine.startsWith('-') &&
+        indentation === configuredIndentation &&
+        indentation === getIndentation(lineContent, position.character) &&
+        currentLine === lineContent.trim()
+      ) {
         position.character += indentation;
       }
       if (position.character > indentation && position.character > 0) {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2251,6 +2251,33 @@ describe('Auto Completion Tests', () => {
       expect(completion.items[0].insertText).eq('prop2: ');
     });
 
+    it('should complete properties of an object under a list', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          steps: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                task: {
+                  type: 'string',
+                },
+                inputs: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const content = 'steps:\n- task: PowerShell@2\n  '; // len: 30
+      const completion = await parseSetup(content, 30);
+      expect(completion.items).lengthOf(1);
+      expect(completion.items[0].label).eq('inputs');
+    });
+
     it('should complete string which contains number in default value', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?

Given
```yaml
steps:
- task: PowerShell@2
  |
```
We should be completing properties for the object that `task` is a part of, not the list under `steps`.

Previously, the parent algorithm would see that the current indentation == the configured indentation and incorrectly choose the parent list as the "real" closest node, despite the cursor clearly being more indented than the list.

Now, we also verify that the indentation of the current node equals the cursor indentation before deciding to look at the parent.

### What issues does this PR fix or reference?

N/A, I caught this when trying to catch azure-pipelines-language-server back up with yaml-language-server.

### Is it tested? How?

Added a unit test and confirmed that all tests pass.