### PR TITLE
feat: allow `# $schema: <url>` to specify an inline schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,19 +243,21 @@ yaml.schemas: {
 It is possible to specify a yaml schema using a modeline.
 
 ```yaml
-# yaml-language-server: $schema=<urlToTheSchema>
+# $schema: <urlToTheSchema>
 ```
+
+_Note_: In previous versions, `# yaml-language-server: $schema=<url>` was a way of specifying a schema. Although still supported for backwards compatibility, this is discouraged as it isn't supported in other editors. `# $schema: <url>` is supported by IntelliJ IDEs as well.
 
 Also it is possible to use relative path in a modeline:
 
 ```yaml
-# yaml-language-server: $schema=../relative/path/to/schema
+# $schema: ../relative/path/to/schema
 ```
 
 or absolute path:
 
 ```yaml
-# yaml-language-server: $schema=/absolute/path/to/schema
+# $schema: /absolute/path/to/schema
 ```
 
 ### Schema priority

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -309,7 +309,7 @@ export class YamlCompletion {
           const inlineSchemaCompletion = {
             kind: CompletionItemKind.Text,
             label: 'Inline schema',
-            insertText: '# yaml-language-server: $schema=',
+            insertText: '# $schema: ',
             insertTextFormat: InsertTextFormat.PlainText,
           };
           result.items.push(inlineSchemaCompletion);
@@ -317,19 +317,22 @@ export class YamlCompletion {
       }
 
       if (isModeline(lineContent) || isInComment(doc.tokens, offset)) {
-        const schemaIndex = lineContent.indexOf('$schema=');
-        if (schemaIndex !== -1 && schemaIndex + '$schema='.length <= position.character) {
-          this.schemaService.getAllSchemas().forEach((schema) => {
-            const schemaIdCompletion: CompletionItem = {
-              kind: CompletionItemKind.Constant,
-              label: schema.name ?? schema.uri,
-              detail: schema.description,
-              insertText: schema.uri,
-              insertTextFormat: InsertTextFormat.PlainText,
-              insertTextMode: InsertTextMode.asIs,
-            };
-            result.items.push(schemaIdCompletion);
-          });
+        const schemaIndex = lineContent.indexOf('$schema');
+        if (schemaIndex !== -1 && schemaIndex + '$schema:'.length <= position.character) {
+          const postSchemaChar = lineContent[schemaIndex + '$schema'.length];
+          if (postSchemaChar === ':' || postSchemaChar === '=') {
+            this.schemaService.getAllSchemas().forEach((schema) => {
+              const schemaIdCompletion: CompletionItem = {
+                kind: CompletionItemKind.Constant,
+                label: schema.name ?? schema.uri,
+                detail: schema.description,
+                insertText: schema.uri,
+                insertTextFormat: InsertTextFormat.PlainText,
+                insertTextMode: InsertTextMode.asIs,
+              };
+              result.items.push(schemaIdCompletion);
+            });
+          }
         }
         return result;
       }

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1289,7 +1289,7 @@ obj:
           4,
           18,
           DiagnosticSeverity.Error,
-          'yaml-schema: Package',
+          'yaml-schema: Composer Package',
           'https://raw.githubusercontent.com/composer/composer/master/res/composer-schema.json'
         )
       );

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -36,6 +36,17 @@ describe('YAML Schema Service', () => {
       expect(requestServiceMock).calledOnceWith('http://json-schema.org/draft-07/schema#');
     });
 
+    it('should handle inline schema http url without LSP prefix', () => {
+      const documentContent = `# $schema:http://json-schema.org/draft-07/schema# anothermodeline=value\n`;
+      const content = `${documentContent}\n---\n- `;
+      const yamlDock = parse(content);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledOnceWith('http://json-schema.org/draft-07/schema#');
+    });
+
     it('should handle inline schema https url', () => {
       const documentContent = `# yaml-language-server: $schema=https://json-schema.org/draft-07/schema# anothermodeline=value\n`;
       const content = `${documentContent}\n---\n- `;
@@ -47,8 +58,19 @@ describe('YAML Schema Service', () => {
       expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });
 
+    it('should handle inline schema https url without LSP prefix', () => {
+      const documentContent = `# $schema:https://json-schema.org/draft-07/schema# anothermodeline=value\n`;
+      const content = `${documentContent}\n---\n- `;
+      const yamlDock = parse(content);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
+    });
+
     it('should handle url with fragments', async () => {
-      const content = `# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#/definitions/schemaArray\nfoo: bar`;
+      const content = `# $schema: https://json-schema.org/draft-07/schema#/definitions/schemaArray\nfoo: bar`;
       const yamlDock = parse(content);
 
       requestServiceMock = sandbox.fake.resolves(`{"definitions": {"schemaArray": {
@@ -68,7 +90,7 @@ describe('YAML Schema Service', () => {
     });
 
     it('should handle url with fragments when root object is schema', async () => {
-      const content = `# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#/definitions/schemaArray`;
+      const content = `# $schema: https://json-schema.org/draft-07/schema#/definitions/schemaArray`;
       const yamlDock = parse(content);
 
       requestServiceMock = sandbox.fake.resolves(`{"definitions": {"schemaArray": {
@@ -94,7 +116,7 @@ describe('YAML Schema Service', () => {
     });
 
     it('should handle file path with fragments', async () => {
-      const content = `# yaml-language-server: $schema=schema.json#/definitions/schemaArray\nfoo: bar`;
+      const content = `# $schema: schema.json#/definitions/schemaArray\nfoo: bar`;
       const yamlDock = parse(content);
 
       requestServiceMock = sandbox.fake.resolves(`{"definitions": {"schemaArray": {
@@ -120,7 +142,7 @@ describe('YAML Schema Service', () => {
     });
 
     it('should handle modeline schema comment in the middle of file', () => {
-      const documentContent = `foo:\n  bar\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const documentContent = `foo:\n  bar\n# $schema: https://json-schema.org/draft-07/schema#\naa:bbb\n`;
       const content = `${documentContent}`;
       const yamlDock = parse(content);
 
@@ -131,7 +153,7 @@ describe('YAML Schema Service', () => {
     });
 
     it('should handle modeline schema comment in multiline comments', () => {
-      const documentContent = `foo:\n  bar\n#first comment\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const documentContent = `foo:\n  bar\n#first comment\n# $schema: https://json-schema.org/draft-07/schema#\naa:bbb\n`;
       const content = `${documentContent}`;
       const yamlDock = parse(content);
 


### PR DESCRIPTION
### What does this PR do?

To aid interop with [JetBrains' IntelliJ based IDEs](https://www.jetbrains.com/help/idea/yaml.html#use-schema-keyword), this adds support for specifying an inline-schema through `# $schema: <url>`. This is now the preferred way to specify an inline-schema. For backwards compatibility, the old way is still supported.

### What issues does this PR fix or reference?

Fixes #959.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested it with the `yaml-vscode` extension (and in unit tests).

1. Below the comment, list the available completion items (in VS Code: <kbd>CTRL</kbd>+<kbd>Space</kbd>)
	```yaml
	# $schema: https://json.schemastore.org/clangd.json
	```
2. Same here, list the available completions below the comment
	```yaml
	# yaml-language-server: $schema=https://json.schemastore.org/clangd.json
	```
3. 
	- In an empty file, list the available completions.
	- It should show `Inline Schema`. Use it.
	- It should complete to `# $schema: ` with the cursor at the end.
	- List the available completions. It should show all available schemas.