### PR TITLE
add missing field descriptions for anyOf

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -141,7 +141,7 @@ export class YAMLHover {
             if (s.schema.anyOf && isAllSchemasMatched(node, matchingSchemas, s.schema)) {
               //if append title and description of all matched schemas on hover
               title = '';
-              markdownDescription = s.schema.description ? (s.schema.description + '\n') : '';
+              markdownDescription = s.schema.description ? s.schema.description + '\n' : '';
               s.schema.anyOf.forEach((childSchema: JSONSchema, index: number) => {
                 title += childSchema.title || s.schema.closestTitle || '';
                 markdownDescription += childSchema.markdownDescription || this.toMarkdown(childSchema.description) || '';

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -103,7 +103,7 @@ export class YAMLHover {
     };
 
     const removePipe = (value: string): string => {
-      return value.replace(/\|\|\s*$/, '');
+      return value.replace(/\s\|\|\s*$/, '');
     };
 
     return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
@@ -141,7 +141,7 @@ export class YAMLHover {
             if (s.schema.anyOf && isAllSchemasMatched(node, matchingSchemas, s.schema)) {
               //if append title and description of all matched schemas on hover
               title = '';
-              markdownDescription = '';
+              markdownDescription = s.schema.description ? (s.schema.description + '\n') : '';
               s.schema.anyOf.forEach((childSchema: JSONSchema, index: number) => {
                 title += childSchema.title || s.schema.closestTitle || '';
                 markdownDescription += childSchema.markdownDescription || this.toMarkdown(childSchema.description) || '';

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -764,6 +764,32 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
       expect(telemetry.messages).to.be.empty;
     });
+    it('should show the parent description in anyOf (no child descriptions)', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        title: 'The Root',
+        description: 'Root Object',
+        type: 'object',
+        properties: {
+          optionalZipFile: {
+            title: 'ZIP file',
+            anyOf: [{ type: "string", pattern: "\\.zip$" }, { type: "null" }],
+            default: null,
+            description: "Optional ZIP file path."
+          },
+        },
+        required: ['optionalZipFile'],
+        additionalProperties: false,
+      });
+      let content = 'optionalZipF|i|le:';
+      let result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `#### ZIP file || ZIP file\n\nOptional ZIP file path.\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+      expect(telemetry.messages).to.be.empty;
+    });
   });
 
   describe('Bug fixes', () => {

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -772,16 +772,16 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
         properties: {
           optionalZipFile: {
             title: 'ZIP file',
-            anyOf: [{ type: "string", pattern: "\\.zip$" }, { type: "null" }],
+            anyOf: [{ type: 'string', pattern: '\\.zip$' }, { type: 'null' }],
             default: null,
-            description: "Optional ZIP file path.",
+            description: 'Optional ZIP file path.',
           },
         },
         required: ['optionalZipFile'],
         additionalProperties: false,
       });
-      let content = 'optionalZipF|i|le:';
-      let result = await parseSetup(content);
+      const content = 'optionalZipF|i|le:';
+      const result = await parseSetup(content);
 
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
@@ -806,7 +806,7 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
                 $ref: '#/definitions/SecondChoice',
               },
             ],
-            description: "The parent description."
+            description: 'The parent description.',
           },
         },
         required: ['child'],
@@ -851,15 +851,15 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
         },
       });
 
-      let content = 'ch|i|ld:';
-      let result = await parseSetup(content);
+      const content = 'ch|i|ld:';
+      const result = await parseSetup(content);
       assert.strictEqual(MarkupContent.is(result.contents), true);
       assert.strictEqual(
         (result.contents as MarkupContent).value,
         `#### FirstChoice || SecondChoice\n\nThe parent description.\nThe first choice || The second choice\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
       expect(telemetry.messages).to.be.empty;
-    })
+    });
   });
 
   describe('Bug fixes', () => {


### PR DESCRIPTION
### What does this PR do?

Currently, descriptions directly associated with anyOf fields are not shown when hovering. This PR ensures that descriptions for anyOf fields do not only show the descriptions of their children but also the parent description.

### What issues does this PR fix or reference?

fixes https://github.com/redhat-developer/yaml-language-server/issues/952


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Yes, please see the modified unit test files.
