### PR TITLE
k8s: update schema to 1.32.1

### DIFF
--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -6,7 +6,7 @@ import { isBoolean } from './objects';
 import { isRelativePath, relativeToAbsolutePath } from './paths';
 
 export const KUBERNETES_SCHEMA_URL =
-  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json';
+  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json';
 export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';
 
 export function checkSchemaURI(

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -28,7 +28,7 @@ describe('Auto Completion Fix Tests', () => {
   let schemaProvider: TestCustomSchemaProvider;
   before(() => {
     languageSettingsSetup = new ServiceSetup().withCompletion().withSchemaFileMatch({
-      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json',
+      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json',
       fileMatch: [SCHEMA_ID],
     });
     const {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -18,7 +18,7 @@ describe('Kubernetes Integration Tests', () => {
   let yamlSettings: SettingsState;
 
   before(() => {
-    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.4-standalone-strict/all.json';
+    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json';
     const fileMatch = ['*.yml', '*.yaml'];
     languageSettingsSetup = new ServiceSetup()
       .withHover()
@@ -123,7 +123,7 @@ describe('Kubernetes Integration Tests', () => {
         });
 
         it('Type Object does not error on valid node', (done) => {
-          const content = 'metadata:\n  clusterName: tes';
+          const content = 'metadata:\n  name: tes';
           const validator = parseSetup(content);
           validator
             .then(function (result) {
@@ -265,8 +265,8 @@ describe('Kubernetes Integration Tests', () => {
       });
 
       it('Autocomplete on boolean value (without value content)', (done) => {
-        const content = 'spec:\n  allowPrivilegeEscalation: ';
-        const completion = parseSetup(content, 38);
+        const content = 'apiVersion: apps/v1\nkind: Deployment\nspec:\n  paused: ';
+        const completion = parseSetup(content, content.length);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 2);
@@ -275,8 +275,8 @@ describe('Kubernetes Integration Tests', () => {
       });
 
       it('Autocomplete on boolean value (with value content)', (done) => {
-        const content = 'spec:\n  allowPrivilegeEscalation: fal';
-        const completion = parseSetup(content, 43);
+        const content = 'apiVersion: apps/v1\nkind: Deployment\nspec:\n  paused: fal';
+        const completion = parseSetup(content, content.length);
         completion
           .then(function (result) {
             assert.equal(result.items.length, 2);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -533,14 +533,14 @@ describe('JSON Schema', () => {
 
     await service.addContent({
       action: MODIFICATION_ACTIONS.add,
-      path: 'oneOf/1/properties/kind',
-      key: 'enum',
-      content: ['v2', 'v3'],
+      path: '/oneOf/1/properties',
+      key: 'foobar',
+      content: ['hello', 'world'],
       schema: KUBERNETES_SCHEMA_URL,
     });
 
     const fs = await service.getResolvedSchema(KUBERNETES_SCHEMA_URL);
-    assert.deepEqual(fs.schema.oneOf[1].properties['kind']['enum'], ['v2', 'v3']);
+    assert.deepEqual(fs.schema.oneOf[1].properties['foobar'], ['hello', 'world']);
   });
 
   it('Deleting schema works with Kubernetes resolution', async () => {
@@ -549,13 +549,13 @@ describe('JSON Schema', () => {
 
     await service.deleteContent({
       action: MODIFICATION_ACTIONS.delete,
-      path: 'oneOf/1/properties/kind',
-      key: 'enum',
+      path: 'oneOf/1',
+      key: 'properties',
       schema: KUBERNETES_SCHEMA_URL,
     });
 
     const fs = await service.getResolvedSchema(KUBERNETES_SCHEMA_URL);
-    assert.equal(fs.schema.oneOf[1].properties['kind']['enum'], undefined);
+    assert.equal(fs.schema.oneOf[1].properties, undefined);
   });
 
   it('Adding a brand new schema', async () => {


### PR DESCRIPTION
### What does this PR do?

updates the bundled kubernetes json schema to 1.32.1, fixing some tests that relied on the 1.22.4 schema.

### What issues does this PR fix or reference?

none

### Is it tested? How?

integration tests pass.