### PR TITLE
Import Prettier from prettier/standalone

### DIFF
--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -6,8 +6,9 @@
 
 import { Range, Position, TextEdit, FormattingOptions } from 'vscode-languageserver-types';
 import { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
-import { format, Options } from 'prettier';
+import { Options } from 'prettier';
 import * as parser from 'prettier/plugins/yaml';
+import { format } from 'prettier/standalone';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 export class YAMLFormatter {


### PR DESCRIPTION
### What does this PR do?

The import from `prettier` includes support for all languages supported by Prettier. The `prettier/standalone` import only includes the core. The `prettier` export also points to `prettier/standalone` for the `browser` export condition.

This means that with this change `yaml-language-server` has to load less code, leading to faster startup time. And depending on configuration, it may lead to smaller bundle sizes.

### What issues does this PR fix or reference?

This PR is an improvement, but I would strongly prefer #983.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

`npm test`