### PR TITLE
fix enum values to be unique

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -131,10 +131,13 @@ export class YAMLHover {
                 if (typeof enumValue !== 'string') {
                   enumValue = JSON.stringify(enumValue);
                 }
-                markdownEnums.push({
-                  value: enumValue,
-                  description: markdownEnumDescriptions[idx],
-                });
+                //insert only if the value is not present yet (avoiding duplicates)
+                if (!markdownEnums.some((me) => me.value === enumValue)) {
+                  markdownEnums.push({
+                    value: enumValue,
+                    description: markdownEnumDescriptions[idx],
+                  });
+                }
               });
             }
             if (s.schema.anyOf && isAllSchemasMatched(node, matchingSchemas, s.schema)) {

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -587,6 +587,46 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
     });
 
+    it('Hover displays unique enum values', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            description: 'should return this description',
+            anyOf: [
+              {
+                enum: ['cat', 'dog', 'non'],
+                enumDescriptions: ['', 'Canis familiaris'],
+              },
+              {
+                enum: ['bird', 'fish', 'non'], // the second "non" from this enum should be filtered out
+                enumDescriptions: ['', 'Special fish'],
+              },
+            ],
+          },
+        },
+      });
+      const content = 'animal:\n  no|n|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Allowed Values:
+
+* \`cat\`
+* \`dog\`: Canis familiaris
+* \`non\`
+* \`bird\`
+* \`fish\`: Special fish
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('Hover works on examples', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?

fix enum values to be unique:

* when several schemas get combined (e.g., `oneOf`, `anyOf`) the available values for an `enum` could get merged
* this could lead to enum values present several time
* this PR only adds an enum values to the merged list, if its value is not present so far
* corresponding unit test is present as well

example:

schema:
```json
{
  "type": "object",
  "properties": {
    "animal": {
      "description": "should return this description",
      "anyOf": [
        {
          "enum": [ "cat", "dog", "non" ],
          "enumDescriptions": [ "", "Canis familiaris" ]
        },
        {
          "enum": [ "bird", "fish", "non" ],
          "enumDescriptions": [ "", "Special fish" ]
        }
      ]
    }
  }
}
```

Without the fix the `available value` list is: `[ cat, dog, non, bird, fish, non ]` with `non` being present twice.

With the fix the second `non` is removed, leaving only: `[ cat, dog, non, bird, fish ]`


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

I added a unit test case, which is failing without the fix and passing with the fix: `Hover displays unique enum values`