### PR TITLE
fix: do not suggest propertyNames if doNotSuggest is true

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -823,14 +823,16 @@ export class YamlCompletion {
 
         if (schema.schema.propertyNames && schema.schema.additionalProperties && schema.schema.type === 'object') {
           const propertyNameSchema = asSchema(schema.schema.propertyNames);
-          const label = propertyNameSchema.title || 'property';
-          collector.add({
-            kind: CompletionItemKind.Property,
-            label,
-            insertText: '$' + `{1:${label}}: `,
-            insertTextFormat: InsertTextFormat.Snippet,
-            documentation: this.fromMarkup(propertyNameSchema.markdownDescription) || propertyNameSchema.description || '',
-          });
+          if (!propertyNameSchema.deprecationMessage && !propertyNameSchema.doNotSuggest) {
+            const label = propertyNameSchema.title || 'property';
+            collector.add({
+              kind: CompletionItemKind.Property,
+              label,
+              insertText: '$' + `{1:${label}}: `,
+              insertTextFormat: InsertTextFormat.Snippet,
+              documentation: this.fromMarkup(propertyNameSchema.markdownDescription) || propertyNameSchema.description || '',
+            });
+          }
         }
       }
 

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1329,6 +1329,22 @@ test1:
     expect(completion.items[0].insertText).to.be.equal('${1:property}: ');
     expect(completion.items[0].documentation).to.be.equal('Property Description');
   });
+  it('should not suggest propertyNames with doNotSuggest', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      additionalProperties: true,
+      propertyNames: {
+        title: 'property',
+        doNotSuggest: true,
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const content = '';
+    const completion = await parseSetup(content, 0, content.length);
+
+    expect(completion.items.length).equal(0);
+  });
+
   it('should suggest enum based on type', async () => {
     const schema: JSONSchema = {
       type: 'object',


### PR DESCRIPTION
### What does this PR do?
Small fix/improvement of propertyNames suggestion if `doNotSuggest` or `deprecationMessage` is set.
This suggestion should be excluded.

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
Adds unit test