### PR TITLE
Allow graceful matching by parameter and repair null values matching

### DIFF
--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -156,7 +156,7 @@ export class LanguageHandlers {
    * Called when auto-complete is triggered in an editor
    * Returns a list of valid completion items
    */
-  completionHandler(textDocumentPosition: TextDocumentPositionParams): Promise<CompletionList> {
+  completionHandler(textDocumentPosition: TextDocumentPositionParams, gracefulMatches = false): Promise<CompletionList> {
     const textDocument = this.yamlSettings.documents.get(textDocumentPosition.textDocument.uri);
 
     const result: CompletionList = {
@@ -170,7 +170,9 @@ export class LanguageHandlers {
     return this.languageService.doComplete(
       textDocument,
       textDocumentPosition.position,
-      isKubernetesAssociatedDocument(textDocument, this.yamlSettings.specificValidatorPaths)
+      isKubernetesAssociatedDocument(textDocument, this.yamlSettings.specificValidatorPaths),
+      true,
+      gracefulMatches
     );
   }
 

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -81,6 +81,7 @@ export const ProblemTypeMessages: Record<ProblemType, string> = {
   [ProblemType.typeMismatchWarning]: 'Incorrect type. Expected "{0}".',
   [ProblemType.constWarning]: 'Value must be {0}.',
 };
+
 export interface IProblem {
   location: IRange;
   severity: DiagnosticSeverity;
@@ -158,6 +159,7 @@ export abstract class ASTNodeImpl {
 export class NullASTNodeImpl extends ASTNodeImpl implements NullASTNode {
   public type: 'null' = 'null' as const;
   public value = null;
+
   constructor(parent: ASTNode, internalNode: Node, offset: number, length?: number) {
     super(parent, internalNode, offset, length);
   }
@@ -278,27 +280,36 @@ export enum EnumMatch {
 
 export interface ISchemaCollector {
   schemas: IApplicableSchema[];
+
   add(schema: IApplicableSchema): void;
+
   merge(other: ISchemaCollector): void;
+
   include(node: ASTNode): boolean;
+
   newSub(): ISchemaCollector;
 }
 
 class SchemaCollector implements ISchemaCollector {
   schemas: IApplicableSchema[] = [];
+
   constructor(
     private focusOffset = -1,
     private exclude: ASTNode = null
   ) {}
+
   add(schema: IApplicableSchema): void {
     this.schemas.push(schema);
   }
+
   merge(other: ISchemaCollector): void {
     this.schemas.push(...other.schemas);
   }
+
   include(node: ASTNode): boolean {
     return (this.focusOffset === -1 || contains(node, this.focusOffset)) && node !== this.exclude;
   }
+
   newSub(): ISchemaCollector {
     return new SchemaCollector(-1, this.exclude);
   }
@@ -308,22 +319,27 @@ class NoOpSchemaCollector implements ISchemaCollector {
   private constructor() {
     // ignore
   }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get schemas(): any[] {
     return [];
   }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   add(schema: IApplicableSchema): void {
     // ignore
   }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   merge(other: ISchemaCollector): void {
     // ignore
   }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   include(node: ASTNode): boolean {
     return true;
   }
+
   newSub(): ISchemaCollector {
     return this;
   }
@@ -616,13 +632,15 @@ export class JSONDocument {
    * @param focusOffset  offsetValue
    * @param exclude excluded Node
    * @param didCallFromAutoComplete true if method called from AutoComplete
+   * @param gracefulMatches true if graceful matching should be done, meaning that if at least one property is validated in a sub schema, it's kept as a candidate
    * @returns array of applicable schemas
    */
   public getMatchingSchemas(
     schema: JSONSchema,
     focusOffset = -1,
     exclude: ASTNode = null,
-    didCallFromAutoComplete?: boolean
+    didCallFromAutoComplete?: boolean,
+    gracefulMatches?: boolean
   ): IApplicableSchema[] {
     const matchingSchemas = new SchemaCollector(focusOffset, exclude);
     if (this.root && schema) {
@@ -631,17 +649,21 @@ export class JSONDocument {
         disableAdditionalProperties: this.disableAdditionalProperties,
         uri: this.uri,
         callFromAutoComplete: didCallFromAutoComplete,
+        gracefulMatches: gracefulMatches,
       });
     }
     return matchingSchemas.schemas;
   }
 }
+
 interface Options {
   isKubernetes: boolean;
   disableAdditionalProperties: boolean;
   uri: string;
   callFromAutoComplete?: boolean;
+  gracefulMatches?: boolean;
 }
+
 function validate(
   node: ASTNode,
   schema: JSONSchema,
@@ -651,7 +673,7 @@ function validate(
   options: Options
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
-  const { isKubernetes, callFromAutoComplete } = options;
+  const { isKubernetes, callFromAutoComplete, gracefulMatches } = options;
   if (!node) {
     return;
   }
@@ -942,6 +964,7 @@ function validate(
         });
       }
     }
+
     function getExclusiveLimit(limit: number | undefined, exclusive: boolean | number | undefined): number | undefined {
       if (isNumber(exclusive)) {
         return exclusive;
@@ -951,12 +974,14 @@ function validate(
       }
       return undefined;
     }
+
     function getLimit(limit: number | undefined, exclusive: boolean | number | undefined): number | undefined {
       if (!isBoolean(exclusive) || !exclusive) {
         return limit;
       }
       return undefined;
     }
+
     const exclusiveMinimum = getExclusiveLimit(schema.minimum, schema.exclusiveMinimum);
     if (isNumber(exclusiveMinimum) && val <= exclusiveMinimum) {
       validationResult.problems.push({
@@ -1086,6 +1111,7 @@ function validate(
       }
     }
   }
+
   function _validateArrayNode(
     node: ArrayASTNode,
     schema: JSONSchema,
@@ -1247,7 +1273,12 @@ function validate(
       for (const propertyName of schema.required) {
         if (seenKeys[propertyName] === undefined) {
           const keyNode = node.parent && node.parent.type === 'property' && node.parent.keyNode;
-          const location = keyNode ? { offset: keyNode.offset, length: keyNode.length } : { offset: node.offset, length: 1 };
+          const location = keyNode
+            ? { offset: keyNode.offset, length: keyNode.length }
+            : {
+                offset: node.offset,
+                length: 1,
+              };
           validationResult.problems.push({
             location: location,
             severity: DiagnosticSeverity.Warning,
@@ -1490,10 +1521,14 @@ function validate(
     return bestMatch;
   }
 
+  function gracefulMatchFilter(maxOneMatch: boolean, propertiesValueMatches: number): boolean {
+    return gracefulMatches && !maxOneMatch && callFromAutoComplete && propertiesValueMatches > 0;
+  }
+
   //genericComparison tries to find the best matching schema using a generic comparison
   function genericComparison(
     node: ASTNode,
-    maxOneMatch,
+    maxOneMatch: boolean,
     subValidationResult: ValidationResult,
     bestMatch: IValidationMatch,
     subSchema,
@@ -1522,7 +1557,8 @@ function validate(
         };
       } else if (
         compareResult === 0 ||
-        ((node.value === null || node.type === 'null') && node.length === 0) // node with no value can match any schema potentially
+        ((node.value === null || node.type === 'null') && node.length === 0) || // node with no value can match any schema potentially
+        gracefulMatchFilter(maxOneMatch, subValidationResult.propertiesValueMatches)
       ) {
         // there's already a best matching but we are as good
         mergeValidationMatches(bestMatch, subMatchingSchemas, subValidationResult);

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -160,7 +160,13 @@ export interface CustomFormatterOptions {
 export interface LanguageService {
   configure: (settings: LanguageSettings) => void;
   registerCustomSchemaProvider: (schemaProvider: CustomSchemaProvider) => void;
-  doComplete: (document: TextDocument, position: Position, isKubernetes: boolean) => Promise<CompletionList>;
+  doComplete: (
+    document: TextDocument,
+    position: Position,
+    isKubernetes: boolean,
+    doComplete?: boolean,
+    gracefulMatches?: boolean
+  ) => Promise<CompletionList>;
   doValidation: (document: TextDocument, isKubernetes: boolean) => Promise<Diagnostic[]>;
   doHover: (document: TextDocument, position: Position) => Promise<Hover | null>;
   findDocumentSymbols: (document: TextDocument, context?: DocumentSymbolsContext) => SymbolInformation[];


### PR DESCRIPTION
### What does this PR do?
Allows passing a `gracefulMatches` parameter to the completion handler so that if any sub schema has at least one property value that is matching, it will be in the completions list.

It allows extending matching when there is an exact match already. That is, currently if there is a sub schema that matches exactly what's in the node, and one that **could** match but has some additional required properties next to it, the one with required properties will not be returned because it has a "problem" which is not having one of the required property. 

Also since the best match is initialized with the first of an anyOf regardless of if it has "problems" (due to callFromAutocomplete bypass), the outcomes is highly dependant of the order of the anyOf content. If the first element is a non-restrictive one, it will not have any "problems" and so only the ones without any will match.

When autocompleting I'd expect to have anything matched even if I haven't filled in the required properties yet.

Moreover, it also covers the case where you have, on the opposite, already filled some properties that are required in some `anyOf` elements but not on some others. In such case, if you have a less restrictive element, it should match, however with the previous behaviour it didn't because it had less "matchingPropertiesValues" so the compareTo was not in favor of it.

### What issues does this PR fix or reference?
fixes https://github.com/redhat-developer/yaml-language-server/issues/684
some duplicate changes of what's in https://github.com/redhat-developer/yaml-language-server/pull/1037

### Is it tested? How?
Unit tests + some visual testing on a [monaco-yaml editor](https://github.com/remcohaszing/monaco-yaml)
