### PR TITLE
fix: exclude not suggest properties from possible properties error

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1382,7 +1382,7 @@ function validate(
               if (seenKeys[key]) {
                 return false;
               }
-              // don't include properties that are not suggested
+              // don't include properties that are not suggested in completion
               if (property && typeof property === 'object' && (property.doNotSuggest || property.deprecationMessage)) {
                 return false;
               }

--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1374,7 +1374,21 @@ function validate(
       (schema.type === 'object' && schema.additionalProperties === undefined && options.disableAdditionalProperties === true)
     ) {
       if (unprocessedProperties.length > 0) {
-        const possibleProperties = schema.properties && Object.keys(schema.properties).filter((prop) => !seenKeys[prop]);
+        const possibleProperties =
+          schema.properties &&
+          Object.entries(schema.properties)
+            .filter(([key, property]) => {
+              // don't include existing properties
+              if (seenKeys[key]) {
+                return false;
+              }
+              // don't include properties that are not suggested
+              if (property && typeof property === 'object' && (property.doNotSuggest || property.deprecationMessage)) {
+                return false;
+              }
+              return true;
+            })
+            .map(([key]) => key);
 
         for (const propertyName of unprocessedProperties) {
           const child = seenKeys[propertyName];

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1686,6 +1686,42 @@ obj:
         ]);
       });
 
+      it('should return error with possible props', async () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            prop0: {
+              type: 'string',
+            },
+            prop1: {
+              type: 'string',
+            },
+            prop2: {
+              type: 'string',
+              doNotSuggest: true,
+            },
+            prop3: {
+              type: 'string',
+              deprecationMessage: 'prop3 is deprecated',
+            },
+          },
+        };
+        schemaProvider.addSchema(SCHEMA_ID, schema);
+        const content = `prop1: value1\npropX: you should not be there 'propX'`;
+        const result = await parseSetup(content);
+        expect(
+          result.map((r) => ({
+            message: r.message,
+            properties: (r.data as { properties: unknown })?.properties,
+          }))
+        ).to.deep.eq([
+          {
+            message: 'Property propX is not allowed.',
+            properties: ['prop0'],
+          },
+        ]);
+      });
+
       it('should allow additional props on object when additionalProp is true on object', async () => {
         const schema = {
           type: 'object',

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1690,16 +1690,20 @@ obj:
         const schema = {
           type: 'object',
           properties: {
+            // prop0 is missing, should be added as a possible prop
             prop0: {
               type: 'string',
             },
+            // prop1 is already defined in the yaml
             prop1: {
               type: 'string',
             },
+            // prop2 is not suggested
             prop2: {
               type: 'string',
               doNotSuggest: true,
             },
+            // prop3 is deprecated
             prop3: {
               type: 'string',
               deprecationMessage: 'prop3 is deprecated',


### PR DESCRIPTION
### What does this PR do?
suggested properties are filtered out if the schema contains doNotSuggest or  deprecationMessage
this PR does the same for `possibleProperties` in validation error

### What issues does this PR fix or reference?
no ref

### Is it tested? How?
adds unit test
