### PR TITLE
Fix "convert tabs to space" quickfix for "indentation cannot be tabs"

### DIFF
--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -97,7 +97,7 @@ export class YamlCodeActions {
     const textBuff = new TextBuffer(document);
     const processedLine: number[] = [];
     for (const diag of diagnostics) {
-      if (diag.message === 'Using tabs can lead to unpredictable results') {
+      if (diag.message === 'Tabs are not allowed as indentation') {
         if (processedLine.includes(diag.range.start.line)) {
           continue;
         }

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -107,7 +107,7 @@ describe('CodeActions Tests', () => {
   describe('Convert TAB to Spaces', () => {
     it('should add "Convert TAB to Spaces" CodeAction', () => {
       const doc = setupTextDocument('foo:\n\t- bar');
-      const diagnostics = [createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 1, 1, JSON_SCHEMA_LOCAL)];
+      const diagnostics = [createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 1, 1, JSON_SCHEMA_LOCAL)];
       const params: CodeActionParams = {
         context: CodeActionContext.create(diagnostics),
         range: undefined,
@@ -123,7 +123,7 @@ describe('CodeActions Tests', () => {
 
     it('should support current indentation chars settings', () => {
       const doc = setupTextDocument('foo:\n\t- bar');
-      const diagnostics = [createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 1, 1, JSON_SCHEMA_LOCAL)];
+      const diagnostics = [createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 1, 1, JSON_SCHEMA_LOCAL)];
       const params: CodeActionParams = {
         context: CodeActionContext.create(diagnostics),
         range: undefined,
@@ -139,7 +139,7 @@ describe('CodeActions Tests', () => {
 
     it('should provide "Convert all Tabs to Spaces"', () => {
       const doc = setupTextDocument('foo:\n\t\t\t- bar\n\t\t');
-      const diagnostics = [createExpectedError('Using tabs can lead to unpredictable results', 1, 0, 1, 3, 1, JSON_SCHEMA_LOCAL)];
+      const diagnostics = [createExpectedError('Tabs are not allowed as indentation', 1, 0, 1, 3, 1, JSON_SCHEMA_LOCAL)];
       const params: CodeActionParams = {
         context: CodeActionContext.create(diagnostics),
         range: undefined,
@@ -188,8 +188,8 @@ describe('CodeActions Tests', () => {
 
   describe('Convert to Block Style', () => {
     it(' should generate action to convert flow map to block map ', () => {
-      const yaml = `host: phl-42  
-datacenter: {location: canada , cab: 15}  
+      const yaml = `host: phl-42
+datacenter: {location: canada , cab: 15}
 animals: [dog , cat , mouse]  `;
       const doc = setupTextDocument(yaml);
       const diagnostics = [


### PR DESCRIPTION
### What does this PR do?
Fixes the error message that the code action provider expects so that the quickfix is generated once more. 

I think the error message changed when switching validators. There is nothing more concrete (such as a diagnostic code) to identify the "indentation cannot be tabs" diagnostics.

### What issues does this PR fix or reference?
Fixes #1052

### Is it tested? How?
I've updated the unit tests. Perhaps an integration test would be helpful to avoid something similar happening in the future? I'd like a second opinion in this.
