### PR TITLE
Fix corner case for 'flow sequence forbidden' quickfix

### DIFF
--- a/src/languageservice/services/validation/yaml-style.ts
+++ b/src/languageservice/services/validation/yaml-style.ts
@@ -42,6 +42,9 @@ export class YAMLStyleValidator implements AdditionalValidator {
   }
 
   private getRangeOf(document: TextDocument, node: FlowCollection): Range {
-    return Range.create(document.positionAt(node.start.offset), document.positionAt(node.end.pop().offset));
+    const endOffset = node.end[0].offset;
+    let endPosition = document.positionAt(endOffset);
+    endPosition = { character: endPosition.character + 1, line: endPosition.line };
+    return Range.create(document.positionAt(node.start.offset), endPosition);
   }
 }

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -142,7 +142,7 @@ animals: [dog , cat , mouse]  `;
       expect(result).not.to.be.empty;
       expect(result.length).to.be.equal(2);
       expect(result).to.include.deep.members([
-        createExpectedError('Flow style mapping is forbidden', 1, 12, 1, 42, DiagnosticSeverity.Error, 'YAML', 'flowMap'),
+        createExpectedError('Flow style mapping is forbidden', 1, 12, 1, 40, DiagnosticSeverity.Error, 'YAML', 'flowMap'),
         createExpectedError('Flow style sequence is forbidden', 2, 9, 2, 28, DiagnosticSeverity.Error, 'YAML', 'flowSeq'),
       ]);
     });
@@ -185,8 +185,8 @@ animals: [dog , cat , mouse]  `;
       expect(result).not.to.be.empty;
       expect(result.length).to.be.equal(2);
       expect(result).to.include.deep.members([
-        createExpectedError('Flow style mapping is forbidden', 0, 8, 0, 11, DiagnosticSeverity.Error, 'YAML', 'flowMap'),
-        createExpectedError('Flow style sequence is forbidden', 1, 9, 1, 10, DiagnosticSeverity.Error, 'YAML', 'flowSeq'),
+        createExpectedError('Flow style mapping is forbidden', 0, 8, 0, 10, DiagnosticSeverity.Error, 'YAML', 'flowMap'),
+        createExpectedError('Flow style sequence is forbidden', 1, 9, 1, 11, DiagnosticSeverity.Error, 'YAML', 'flowSeq'),
       ]);
     });
   });


### PR DESCRIPTION
### What does this PR do?
- Do not include any trailing spaces in the error range
  - This is a change in behaviour; it seems this behaviour was intentional based on the test cases, but I don't agree with it, since the error range should only cover the erroneous code.
- Fix a bug where `]` or `}` are not included in the error range if they're the last character in the document

### What issues does this PR fix or reference?
Fixes #1060

### Is it tested? How?
Updated the unit tests to reflect that trailing whitespaces are not included in the range. The corner case of a flow sequence at the end of the document was already covered in the suite, but the expected range of the diagnostic was wrong.
