### PR TITLE
Support statically registering format support

### DIFF
--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -78,8 +78,8 @@ export class YAMLServerInit {
     );
     this.yamlSettings.clientDynamicRegisterSupport = !!(
       this.yamlSettings.capabilities.textDocument &&
-      this.yamlSettings.capabilities.textDocument.rangeFormatting &&
-      this.yamlSettings.capabilities.textDocument.rangeFormatting.dynamicRegistration
+      this.yamlSettings.capabilities.textDocument.formatting &&
+      this.yamlSettings.capabilities.textDocument.formatting.dynamicRegistration
     );
     this.yamlSettings.hasWorkspaceFolderCapability =
       this.yamlSettings.capabilities.workspace && !!this.yamlSettings.capabilities.workspace.workspaceFolders;
@@ -102,7 +102,7 @@ export class YAMLServerInit {
         completionProvider: { resolveProvider: false },
         hoverProvider: true,
         documentSymbolProvider: true,
-        documentFormattingProvider: false,
+        documentFormattingProvider: !this.yamlSettings.clientDynamicRegisterSupport,
         documentOnTypeFormattingProvider: {
           firstTriggerCharacter: '\n',
         },


### PR DESCRIPTION
### What does this PR do?
Some clients, like Neovim, do not support dynamic registration of formatting and range formatting. In this case, to tell the client that formatting is supported, the response to `initialized`, which contains the `ServerCapabilities`, should mark formatting and range formatting as supported.

### What issues does this PR fix or reference?
Fixes #1031

### Is it tested? How?
Tried it out in Neovim, it's working after this patch.
