### PR TITLE
Add option to remove trailing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "lodash": "4.17.21",
-    "prettier": "^3.0.0",
+    "prettier": "^3.5.0",
     "request-light": "^0.5.7",
     "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^9.0.0",

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -107,6 +107,10 @@ export class SettingsHandler {
           this.yamlSettings.yamlFormatterSettings.bracketSpacing = settings.yaml.format.bracketSpacing;
         }
 
+        if (settings.yaml.format.trailingComma !== undefined) {
+          this.yamlSettings.yamlFormatterSettings.trailingComma = settings.yaml.format.trailingComma;
+        }
+
         if (settings.yaml.format.enable !== undefined) {
           this.yamlSettings.yamlFormatterSettings.enable = settings.yaml.format.enable;
         }

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -7,7 +7,8 @@
 import { Range, Position, TextEdit, FormattingOptions } from 'vscode-languageserver-types';
 import { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
 import { Options } from 'prettier';
-import * as parser from 'prettier/plugins/yaml';
+import * as yamlPlugin from 'prettier/plugins/yaml';
+import * as estreePlugin from 'prettier/plugins/estree';
 import { format } from 'prettier/standalone';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -33,7 +34,7 @@ export class YAMLFormatter {
 
       const prettierOptions: Options = {
         parser: 'yaml',
-        plugins: [parser],
+        plugins: [yamlPlugin, estreePlugin],
 
         // --- FormattingOptions ---
         tabWidth: (options.tabWidth as number) || options.tabSize,
@@ -44,6 +45,7 @@ export class YAMLFormatter {
         // 'preserve' is the default for Options.proseWrap. See also server.ts
         proseWrap: 'always' === options.proseWrap ? 'always' : 'never' === options.proseWrap ? 'never' : 'preserve',
         printWidth: options.printWidth,
+        trailingComma: options.trailingComma === false ? 'none' : 'all',
       };
 
       const formatted = await format(text, prettierOptions);

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -151,6 +151,7 @@ export interface SchemaConfiguration {
 export interface CustomFormatterOptions {
   singleQuote?: boolean;
   bracketSpacing?: boolean;
+  trailingComma?: boolean;
   proseWrap?: string;
   printWidth?: number;
   enable?: boolean;

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -69,6 +69,7 @@ export class SettingsState {
     bracketSpacing: true,
     proseWrap: 'preserve',
     printWidth: 80,
+    trailingComma: true,
     enable: true,
   } as CustomFormatterOptions;
   yamlShouldHover = true;

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -2,12 +2,12 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import { ServiceSetup } from './utils/serviceSetup';
 import * as assert from 'assert';
 import { TextEdit } from 'vscode-languageserver-types';
-import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
+import { ServiceSetup } from './utils/serviceSetup';
+import { setupLanguageService, setupTextDocument } from './utils/testHelper';
 
 describe('Formatter Tests', () => {
   let languageHandler: LanguageHandlers;
@@ -58,6 +58,42 @@ describe('Formatter Tests', () => {
           proseWrap: 'always',
         });
         assert.equal(edits[0].newText, 'comments: >\n  test test test\n  test test test\n  test test test\n  test test test\n');
+      });
+
+      it('Formatting handles trailing commas (enabled)', async () => {
+        const content = `{
+  key: 'value',
+  food: 'raisins',
+  airport: 'YYZ',
+  lightened_bulb: 'illuminating',
+}
+`;
+        const edits = await parseSetup(content, { singleQuote: true });
+        assert.equal(edits[0].newText, content);
+      });
+
+      it('Formatting handles trailing commas (disabled)', async () => {
+        const content = `{
+  key: 'value',
+  food: 'raisins',
+  airport: 'YYZ',
+  lightened_bulb: 'illuminating',
+}
+`;
+        const edits = await parseSetup(content, {
+          singleQuote: true,
+          trailingComma: false,
+        });
+        assert.equal(
+          edits[0].newText,
+          `{
+  key: 'value',
+  food: 'raisins',
+  airport: 'YYZ',
+  lightened_bulb: 'illuminating'
+}
+`
+        );
       });
 
       it('Formatting uses tabSize', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,10 +2675,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.0.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.1.tgz#e68935518dd90bb7ec4821ba970e68f8de16e1ac"
-  integrity sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==
+prettier@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 process-on-spawn@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR do?
Adds the 'yaml.format.trailingComma' to the formatter.

This option is available in prettier so implementing it is trivial. Needs the 'estree' prettier plugin, which is responsible for formatting JSON. As a result, this might increase the size of the language server.

eg. in the following, when 'yaml.format.trailingComma` is set to `false`, the last comma should be removed:

```yaml
{
  key: 'value',
  food: 'raisins',
  airport: 'YYZ',
  lightened_bulb: 'illuminating',
}
```

### What issues does this PR fix or reference?
See redhat-developer/vscode-yaml#1112

### Is it tested? How?
Unit tests
