### PR TITLE
Support draft-04 schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "ajv": "^8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "lodash": "4.17.21",
     "prettier": "^3.5.0",
     "request-light": "^0.5.7",

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -2151,4 +2151,66 @@ obj:
     result = await parseSetup(content);
     expect(result.length).to.eq(0);
   });
+
+  it('draft-04 schema', async () => {
+    const schema: JSONSchema = {
+      $schema: 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+      properties: {
+        myProperty: {
+          $ref: '#/definitions/Interface%3Ctype%3E',
+        },
+      },
+      definitions: {
+        'Interface<type>': {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+            },
+            multipleOf: {
+              type: 'number',
+              minimum: 0,
+              exclusiveMinimum: true,
+            },
+          },
+        },
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const content = `myProperty:\n  foo: bar\n  multipleOf: 1`;
+    const result = await parseSetup(content);
+    assert.equal(result.length, 0);
+  });
+
+  it('draft-04 schema with https in metaschema URI', async () => {
+    const schema: JSONSchema = {
+      $schema: 'https://json-schema.org/draft-04/schema#',
+      type: 'object',
+      properties: {
+        myProperty: {
+          $ref: '#/definitions/Interface%3Ctype%3E',
+        },
+      },
+      definitions: {
+        'Interface<type>': {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+            },
+            multipleOf: {
+              type: 'number',
+              minimum: 0,
+              exclusiveMinimum: true,
+            },
+          },
+        },
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const content = `myProperty:\n  foo: bar\n  multipleOf: 1`;
+    const result = await parseSetup(content);
+    assert.equal(result.length, 0);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,11 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+ajv-draft-04@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz#3b64761b268ba0b9e668f0b41ba53fce0ad77fc8"
+  integrity sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==
+
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"


### PR DESCRIPTION
### What does this PR do?
This helps to support the schema for openapi 3.0.0, among others, that use an older draft of JSON schema that has some type differences that make it incompatible with JSON schema draft 07.

See #1006 , the root cause for the issues that PR caused is that some schemas reference the metaschema using `https`, eg. `https://json-schema.org/draft-07/schema#`, which is invalid according to the spec. This PR suppresses this error, because in practice many schemas use `https` for the metaschema reference, and that shouldn't prevent validation of the YAML document.

~~- [ ] __TODO:__  Instead, we should provide a warning letting the user know about the `https` issue in the schema so they can fix the schema or file an issue to get the schema fixed.~~ I feel like we should do this in a separate PR, later, since it's complex (see https://github.com/redhat-developer/yaml-language-server/pull/1065#issuecomment-2852424881).

### What issues does this PR fix or reference?
Fixes #780, Fixes #752

(and many, many duplicates we'll have to find and clean up)

### Is it tested? How?
Unit test
