### PR TITLE
Update to latest vscode-json-languageservice

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "4.17.21",
     "prettier": "^3.5.0",
     "request-light": "^0.5.7",
-    "vscode-json-languageservice": "4.1.8",
+    "vscode-json-languageservice": "5.5.0",
     "vscode-languageserver": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-languageserver-types": "^3.16.0",

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -12,7 +12,6 @@ import {
   JSONSchemaService,
   SchemaDependencies,
   ISchemaContributions,
-  SchemaHandle,
 } from 'vscode-json-languageservice/lib/umd/services/jsonSchemaService';
 
 import { URI } from 'vscode-uri';
@@ -29,6 +28,7 @@ import { SchemaVersions } from '../yamlTypes';
 
 import Ajv, { DefinedError } from 'ajv';
 import { getSchemaTitle } from '../utils/schemaUtils';
+import { SchemaConfiguration } from 'vscode-json-languageservice';
 
 const ajv = new Ajv();
 
@@ -155,11 +155,9 @@ export class YAMLSchemaService extends JSONSchemaService {
     return result;
   }
 
-  async resolveSchemaContent(
-    schemaToResolve: UnresolvedSchema,
-    schemaURL: string,
-    dependencies: SchemaDependencies
-  ): Promise<ResolvedSchema> {
+  async resolveSchemaContent(schemaToResolve: UnresolvedSchema, schemaHandle: SchemaHandle): Promise<ResolvedSchema> {
+    const schemaURL: string = normalizeId(schemaHandle.uri);
+    const dependencies: SchemaDependencies = schemaHandle.dependencies;
     const resolveErrors: string[] = schemaToResolve.errors.slice(0);
     let schema: JSONSchema = schemaToResolve.schema;
     const contextService = this.contextService;
@@ -374,7 +372,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       const schemaHandle = super.createCombinedSchema(resource, schemas);
       return schemaHandle.getResolvedSchema().then((schema) => {
         if (schema.schema && typeof schema.schema === 'object') {
-          schema.schema.url = schemaHandle.url;
+          schema.schema.url = schemaHandle.uri;
         }
 
         if (
@@ -431,6 +429,7 @@ export class YAMLSchemaService extends JSONSchemaService {
               (schemas) => {
                 return {
                   errors: [],
+                  warnings: [],
                   schema: {
                     allOf: schemas.map((schemaObj) => {
                       return schemaObj.schema;
@@ -503,7 +502,7 @@ export class YAMLSchemaService extends JSONSchemaService {
 
   private async resolveCustomSchema(schemaUri, doc): ResolvedSchema {
     const unresolvedSchema = await this.loadSchema(schemaUri);
-    const schema = await this.resolveSchemaContent(unresolvedSchema, schemaUri, []);
+    const schema = await this.resolveSchemaContent(unresolvedSchema, new SchemaHandle(this, schemaUri));
     if (schema.schema && typeof schema.schema === 'object') {
       schema.schema.url = schemaUri;
     }
@@ -614,8 +613,18 @@ export class YAMLSchemaService extends JSONSchemaService {
 
   normalizeId(id: string): string {
     // The parent's `super.normalizeId(id)` isn't visible, so duplicated the code here
+    if (!id.includes(':')) {
+      return id;
+    }
     try {
-      return URI.parse(id).toString();
+      const uri = URI.parse(id);
+      if (!id.includes('#')) {
+        return uri.toString();
+      }
+      // fragment should be verbatim, but vscode-uri converts `/` to the escaped version (annoyingly, needlessly)
+      const [first, second] = uri.toString().split('#', 2);
+      const secondCleaned = second.replace('%2F', '/');
+      return first + '#' + secondCleaned;
     } catch (e) {
       return id;
     }
@@ -684,17 +693,22 @@ export class YAMLSchemaService extends JSONSchemaService {
   }
 
   registerExternalSchema(
-    uri: string,
-    filePatterns?: string[],
-    unresolvedSchema?: JSONSchema,
+    schemaConfig: SchemaConfiguration,
     name?: string,
     description?: string,
     versions?: SchemaVersions
   ): SchemaHandle {
     if (name || description) {
-      this.schemaUriToNameAndDescription.set(uri, { name, description, versions });
+      this.schemaUriToNameAndDescription.set(schemaConfig.uri, { name, description, versions });
     }
-    return super.registerExternalSchema(uri, filePatterns, unresolvedSchema);
+    this.registeredSchemasIds[schemaConfig.uri] = true;
+    this.cachedSchemaForResource = undefined;
+    if (schemaConfig.fileMatch && schemaConfig.fileMatch.length) {
+      this.addFilePatternAssociation(schemaConfig.fileMatch, schemaConfig.folderUri, [schemaConfig.uri]);
+    }
+    return schemaConfig.schema
+      ? this.addSchemaHandle(schemaConfig.uri, schemaConfig.schema)
+      : this.getOrAddSchemaHandle(schemaConfig.uri);
   }
 
   clearExternalSchemas(): void {
@@ -702,7 +716,21 @@ export class YAMLSchemaService extends JSONSchemaService {
   }
 
   setSchemaContributions(schemaContributions: ISchemaContributions): void {
-    super.setSchemaContributions(schemaContributions);
+    if (schemaContributions.schemas) {
+      const schemas = schemaContributions.schemas;
+      for (const id in schemas) {
+        const normalizedId = normalizeId(id);
+        this.contributionSchemas[normalizedId] = this.addSchemaHandle(normalizedId, schemas[id]);
+      }
+    }
+    if (Array.isArray(schemaContributions.schemaAssociations)) {
+      const schemaAssociations = schemaContributions.schemaAssociations;
+      for (const schemaAssociation of schemaAssociations) {
+        const uris = schemaAssociation.uris.map(normalizeId);
+        const association = this.addFilePatternAssociation(schemaAssociation.pattern, schemaAssociation.folderUri, uris);
+        this.contributionAssociations.push(association);
+      }
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -711,12 +739,60 @@ export class YAMLSchemaService extends JSONSchemaService {
   }
 
   getResolvedSchema(schemaId: string): Promise<ResolvedSchema> {
-    return super.getResolvedSchema(schemaId);
+    const id = normalizeId(schemaId);
+    const schemaHandle = this.schemasById[id];
+    if (schemaHandle) {
+      return schemaHandle.getResolvedSchema();
+    }
+    return this.promise.resolve(undefined);
   }
 
   onResourceChange(uri: string): boolean {
-    return super.onResourceChange(uri);
+    // always clear this local cache when a resource changes
+    this.cachedSchemaForResource = undefined;
+    let hasChanges = false;
+    uri = normalizeId(uri);
+    const toWalk = [uri];
+    const all = Object.keys(this.schemasById).map((key) => this.schemasById[key]);
+    while (toWalk.length) {
+      const curr = toWalk.pop();
+      for (let i = 0; i < all.length; i++) {
+        const handle = all[i];
+        if (handle && (handle.uri === curr || handle.dependencies.has(curr))) {
+          if (handle.uri !== curr) {
+            toWalk.push(handle.uri);
+          }
+          if (handle.clearSchema()) {
+            hasChanges = true;
+          }
+          all[i] = undefined;
+        }
+      }
+    }
+    return hasChanges;
   }
+}
+
+/**
+ * Our version of normalize id, which doesn't prepend `file:///` to anything without a scheme.
+ *
+ * @param id the id to normalize
+ * @returns the normalized id.
+ */
+function normalizeId(id: string): string {
+  if (id.includes(':')) {
+    try {
+      if (id.includes('#')) {
+        const [mostOfIt, fragment] = id.split('#', 2);
+        return URI.parse(mostOfIt) + '#' + fragment;
+      } else {
+        return URI.parse(id).toString();
+      }
+    } catch {
+      return id;
+    }
+  }
+  return id;
 }
 
 function toDisplayString(url: string): string {
@@ -729,4 +805,48 @@ function toDisplayString(url: string): string {
     // ignore
   }
   return url;
+}
+
+class SchemaHandle {
+  public readonly uri: string;
+  public readonly dependencies: SchemaDependencies;
+  public anchors: Map<string, JSONSchema> | undefined;
+  private resolvedSchema: Promise<ResolvedSchema> | undefined;
+  private unresolvedSchema: Promise<UnresolvedSchema> | undefined;
+  private readonly service: JSONSchemaService;
+
+  constructor(service: JSONSchemaService, uri: string, unresolvedSchemaContent?: JSONSchema) {
+    this.service = service;
+    this.uri = uri;
+    this.dependencies = new Set();
+    this.anchors = undefined;
+    if (unresolvedSchemaContent) {
+      this.unresolvedSchema = this.service.promise.resolve(new UnresolvedSchema(unresolvedSchemaContent));
+    }
+  }
+
+  public getUnresolvedSchema(): Promise<UnresolvedSchema> {
+    if (!this.unresolvedSchema) {
+      this.unresolvedSchema = this.service.loadSchema(this.uri);
+    }
+    return this.unresolvedSchema;
+  }
+
+  public getResolvedSchema(): Promise<ResolvedSchema> {
+    if (!this.resolvedSchema) {
+      this.resolvedSchema = this.getUnresolvedSchema().then((unresolved) => {
+        return this.service.resolveSchemaContent(unresolved, this);
+      });
+    }
+    return this.resolvedSchema;
+  }
+
+  public clearSchema(): boolean {
+    const hasChanges = !!this.unresolvedSchema;
+    this.resolvedSchema = undefined;
+    this.unresolvedSchema = undefined;
+    this.dependencies.clear();
+    this.anchors = undefined;
+    return hasChanges;
+  }
 }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -212,9 +212,11 @@ export function getLanguageService(params: {
           const currPriority = settings.priority ? settings.priority : 0;
           schemaService.addSchemaPriority(settings.uri, currPriority);
           schemaService.registerExternalSchema(
-            settings.uri,
-            settings.fileMatch,
-            settings.schema,
+            {
+              uri: settings.uri,
+              fileMatch: settings.fileMatch,
+              schema: settings.schema,
+            },
             settings.name,
             settings.description,
             settings.versions

--- a/test/jsonParser.test.ts
+++ b/test/jsonParser.test.ts
@@ -1421,6 +1421,7 @@ describe('JSON Parser', () => {
 
   it('items as array', function () {
     const schema: JsonSchema.JSONSchema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
       type: 'array',
       items: [
         {
@@ -1456,6 +1457,7 @@ describe('JSON Parser', () => {
 
   it('additionalItems', function () {
     let schema: JsonSchema.JSONSchema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
       type: 'array',
       items: [
         {
@@ -1483,6 +1485,7 @@ describe('JSON Parser', () => {
       assert.strictEqual(semanticErrors.length, 1);
     }
     schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
       type: 'array',
       items: [
         {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -337,7 +337,7 @@ describe('JSON Schema', () => {
       },
     };
 
-    service.registerExternalSchema(id, ['*.json'], schema);
+    service.registerExternalSchema({ uri: id, fileMatch: ['*.json'], schema });
 
     service
       .getSchemaForResource('test.json', undefined)
@@ -373,7 +373,7 @@ describe('JSON Schema', () => {
       },
     };
 
-    service.registerExternalSchema(id, ['*.json'], schema);
+    service.registerExternalSchema({ uri: id, fileMatch: ['*.json'], schema });
 
     const result = await service.getSchemaForResource('test.json', undefined);
 
@@ -419,11 +419,15 @@ describe('JSON Schema', () => {
   it('Schema with non uri registers correctly', function (testDone) {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     const non_uri = 'non_uri';
-    service.registerExternalSchema(non_uri, ['*.yml', '*.yaml'], {
-      properties: {
-        test_node: {
-          description: 'my test_node description',
-          enum: ['test 1', 'test 2'],
+    service.registerExternalSchema({
+      uri: non_uri,
+      fileMatch: ['*.yml', '*.yaml'],
+      schema: {
+        properties: {
+          test_node: {
+            description: 'my test_node description',
+            enum: ['test 1', 'test 2'],
+          },
         },
       },
     });
@@ -529,7 +533,7 @@ describe('JSON Schema', () => {
 
   it('Modifying schema works with kubernetes resolution', async () => {
     const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
-    service.registerExternalSchema(KUBERNETES_SCHEMA_URL);
+    service.registerExternalSchema({ uri: KUBERNETES_SCHEMA_URL });
 
     await service.addContent({
       action: MODIFICATION_ACTIONS.add,
@@ -545,7 +549,7 @@ describe('JSON Schema', () => {
 
   it('Deleting schema works with Kubernetes resolution', async () => {
     const service = new SchemaService.YAMLSchemaService(schemaRequestServiceForURL, workspaceContext);
-    service.registerExternalSchema(KUBERNETES_SCHEMA_URL);
+    service.registerExternalSchema({ uri: KUBERNETES_SCHEMA_URL });
 
     await service.deleteContent({
       action: MODIFICATION_ACTIONS.delete,

--- a/test/schemaSelectionHandlers.test.ts
+++ b/test/schemaSelectionHandlers.test.ts
@@ -40,7 +40,11 @@ describe('Schema Selection Handlers', () => {
   });
 
   it('getAllSchemas should return all schemas', async () => {
-    service.registerExternalSchema('https://some.com/some.json', ['foo.yaml'], undefined, 'Schema name', 'Schema description');
+    service.registerExternalSchema(
+      { uri: 'https://some.com/some.json', fileMatch: ['foo.yaml'] },
+      'Schema name',
+      'Schema description'
+    );
     const settings = new SettingsState();
     const testTextDocument = setupSchemaIDTextDocument('');
     settings.documents = new TextDocumentTestManager();
@@ -61,7 +65,11 @@ describe('Schema Selection Handlers', () => {
   });
 
   it('getAllSchemas should return all schemas and mark used for current file', async () => {
-    service.registerExternalSchema('https://some.com/some.json', [SCHEMA_ID], undefined, 'Schema name', 'Schema description');
+    service.registerExternalSchema(
+      { uri: 'https://some.com/some.json', fileMatch: [SCHEMA_ID] },
+      'Schema name',
+      'Schema description'
+    );
     const settings = new SettingsState();
     const testTextDocument = setupSchemaIDTextDocument('');
     settings.documents = new TextDocumentTestManager();
@@ -82,7 +90,11 @@ describe('Schema Selection Handlers', () => {
   });
 
   it('getSchemas should return all schemas', async () => {
-    service.registerExternalSchema('https://some.com/some.json', [SCHEMA_ID], undefined, 'Schema name', 'Schema description');
+    service.registerExternalSchema(
+      { uri: 'https://some.com/some.json', fileMatch: [SCHEMA_ID] },
+      'Schema name',
+      'Schema description'
+    );
     const settings = new SettingsState();
     const testTextDocument = setupSchemaIDTextDocument('');
     settings.documents = new TextDocumentTestManager();

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -33,7 +33,8 @@ describe('YAML Schema Service', () => {
       const service = new SchemaService.YAMLSchemaService(requestServiceMock);
       service.getSchemaForResource('', yamlDock.documents[0]);
 
-      expect(requestServiceMock).calledOnceWith('http://json-schema.org/draft-07/schema#');
+      // vscode-json-languageserver converts the http to https for all json schema URIs
+      expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });
 
     it('should handle inline schema https url', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,11 @@
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@vscode/l10n@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@vscode/l10n/-/l10n-0.0.18.tgz#916d3a5e960dbab47c1c56f58a7cb5087b135c95"
+  integrity sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -2198,10 +2203,10 @@ json5@^2.2.1:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
-jsonc-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz"
-  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+jsonc-parser@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3208,16 +3213,16 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-json-languageservice@4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz#397a39238d496e3e08a544a8b93df2cd13347d0c"
-  integrity sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==
+vscode-json-languageservice@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-5.5.0.tgz#0b98aed9c6a3eb4e560d0d5461a51782aaa39a11"
+  integrity sha512-JchBzp8ArzhCVpRS/LT4wzEEvwHXIUEdZD064cGTI4RVs34rNCZXPUguIYSfGBcHH1GV79ufPcfy3Pd8+ukbKw==
   dependencies:
-    jsonc-parser "^3.0.0"
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.16.0"
-    vscode-nls "^5.0.0"
-    vscode-uri "^3.0.2"
+    "@vscode/l10n" "^0.0.18"
+    jsonc-parser "^3.3.1"
+    vscode-languageserver-textdocument "^1.0.12"
+    vscode-languageserver-types "^3.17.5"
+    vscode-uri "^3.1.0"
 
 vscode-jsonrpc@8.2.0:
   version "8.2.0"
@@ -3237,7 +3242,12 @@ vscode-languageserver-textdocument@^1.0.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz#0822a000e7d4dc083312580d7575fe9e3ba2e2bf"
   integrity sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==
 
-vscode-languageserver-types@3.17.5, vscode-languageserver-types@^3.16.0:
+vscode-languageserver-textdocument@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz#457ee04271ab38998a093c68c2342f53f6e4a631"
+  integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
+
+vscode-languageserver-types@3.17.5, vscode-languageserver-types@^3.16.0, vscode-languageserver-types@^3.17.5:
   version "3.17.5"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
   integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
@@ -3258,6 +3268,11 @@ vscode-uri@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
   integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
+
+vscode-uri@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
+  integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### What does this PR do?
This PR updates vscode-json-languageservice to the latest version.

The primary motivation for doing this is to allow warnings to be reported on schemas. I would like to report warnings on schemas as a part of https://github.com/redhat-developer/yaml-language-server/pull/1065.

When updating the json language service, there were many API changes that I needed to adapt to, and some tests that I changed.

Notably, I needed to copy a lot of the implementation of `JSONSchemaService` into our subclass of `JSONSchemaService`. `JSONSchemaService` turns all schema identifiers into URIs and escapes all `/` in the fragment, and does this in the private `normalizeId` method that we can't override Combined, these behaviours cause many tests to fail.

### What issues does this PR fix or reference?
Closes #1069

### Is it tested? How?
Existing test suite.
