### PR TITLE
Fix YAML JSON Schema files starting with %YAML 1.x

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -634,7 +634,12 @@ export class YAMLSchemaService extends JSONSchemaService {
     const requestService = this.requestService;
     return super.loadSchema(schemaUri).then((unresolvedJsonSchema: UnresolvedSchema) => {
       // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
-      if (unresolvedJsonSchema.errors && unresolvedJsonSchema.schema === undefined) {
+      // If the YAML file starts with %YAML 1.x or contains a comment with a number the schema will
+      // contain a number instead of being undefined, so we need to check for that too.
+      if (
+        unresolvedJsonSchema.errors &&
+        (unresolvedJsonSchema.schema === undefined || typeof unresolvedJsonSchema.schema === 'number')
+      ) {
         return requestService(schemaUri).then(
           (content) => {
             if (!content) {

--- a/test/yamlSchema.test.ts
+++ b/test/yamlSchema.test.ts
@@ -29,14 +29,15 @@ describe('YAML Schema', () => {
   });
 
   it('Loading yaml scheme', async () => {
-    requestServiceStub.resolves(`
-    properties:
-      fooBar:
-        items:
-          type: string
-        type: array
-    type: object
-    `);
+    requestServiceStub.resolves(`%YAML 1.2
+---
+properties:
+  fooBar:
+    items:
+      type: string
+    type: array
+type: object
+`);
     const service = new SchemaService.YAMLSchemaService(requestServiceStub, workspaceContext);
     const result = await service.loadSchema('fooScheme.yaml');
     expect(requestServiceStub.calledOnceWith('fooScheme.yaml'));


### PR DESCRIPTION
### What does this PR do?

Fix a bug where YAML files containing a JSON Schema that start with %YAML 1.x or a comment that contains a number would fail to to be parsed.

This is caused by the fact that the JSON Schema parser would contain the number, e.g. 1.2 as the value of `unresolvedJsonSchema.schema` and so the test for `=== undefined` would fail. This would cause the error from the JSON parser to be returned instead of trying to parse the file as a YAML file.

To work around this, also check if `unresolvedJsonSchema.schema` is a number. It if is, it clearly was not a JSON Schema and so we can safely try to parse the file as a YAML file.


### What issues does this PR fix or reference?

Fixes: https://github.com/redhat-developer/yaml-language-server/issues/922


### Is it tested? How?

The modified test failed before the code change and passes after.
