### PR TITLE
Fix recursion bug in ast-conversion

### DIFF
--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import { expect } from 'chai';
 import { ArrayASTNode, ObjectASTNode, PropertyASTNode } from '../src/languageservice/jsonASTTypes';
-import { parse } from './../src/languageservice/parser/yamlParser07';
+import { parse, YAMLDocument } from './../src/languageservice/parser/yamlParser07';
 import { aliasDepth } from '../src/languageservice/parser/ast-converter';
 
 describe('YAML parser', () => {
@@ -248,8 +248,10 @@ describe('YAML parser', () => {
     it('parse aliases up to a depth', () => {
       // If maxRefCount is set to 1, it will only resolve one layer of aliases, which means
       // `b` below will inherit `a`, but `c` will not inherit `a`.
-      aliasDepth.maxRefCount = 1;
-      const parsedDocument = parse(`
+      let parsedDocument: YAMLDocument;
+      try {
+        aliasDepth.maxRefCount = 1;
+        parsedDocument = parse(`
 a: &a
   foo: "web"
 b: &b
@@ -257,7 +259,9 @@ b: &b
 c: &c
   <<: *b
 `);
-      aliasDepth.maxRefCount = 1000;
+      } finally {
+        aliasDepth.maxRefCount = 1000;
+      }
 
       const anode: ObjectASTNode = (parsedDocument.documents[0].root.children[0] as PropertyASTNode).valueNode as ObjectASTNode;
       const aval = anode.properties[0].valueNode;
@@ -278,8 +282,10 @@ c: &c
     it('parse aliases up to a depth for multiple objects', () => {
       // In the below configuration, `c` will not inherit `a` because of depth issues
       // but the following object `o` will still resolve correctly.
-      aliasDepth.maxRefCount = 1;
-      const parsedDocument = parse(`
+      let parsedDocument: YAMLDocument;
+      try {
+        aliasDepth.maxRefCount = 1;
+        parsedDocument = parse(`
 a: &a
   foo: "web"
 b: &b
@@ -290,7 +296,9 @@ c: &c
 o: &o
   <<: *a
 `);
-      aliasDepth.maxRefCount = 1000;
+      } finally {
+        aliasDepth.maxRefCount = 1000;
+      }
 
       const onode: ObjectASTNode = (parsedDocument.documents[0].root.children[3] as PropertyASTNode).valueNode as ObjectASTNode;
       const ovalprops: PropertyASTNode = (onode.properties[0].valueNode as ObjectASTNode).properties[0];

--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import { ArrayASTNode, ObjectASTNode, PropertyASTNode } from '../src/languageservice/jsonASTTypes';
 import { parse } from './../src/languageservice/parser/yamlParser07';
+import { aliasDepth } from '../src/languageservice/parser/ast-converter';
 
 describe('YAML parser', () => {
   describe('YAML parser', function () {
@@ -242,6 +243,65 @@ describe('YAML parser', () => {
         `1 document should be available but there are ${parsedDocument.documents.length}`
       );
       assert(parsedDocument.documents[0].errors.length === 0, JSON.stringify(parsedDocument.documents[0].errors));
+    });
+
+    it('parse aliases up to a depth', () => {
+      // If maxRefCount is set to 1, it will only resolve one layer of aliases, which means
+      // `b` below will inherit `a`, but `c` will not inherit `a`.
+      aliasDepth.maxRefCount = 1;
+      const parsedDocument = parse(`
+a: &a
+  foo: "web"
+b: &b
+  <<: *a
+c: &c
+  <<: *b
+`);
+      aliasDepth.maxRefCount = 1000;
+
+      const anode: ObjectASTNode = (parsedDocument.documents[0].root.children[0] as PropertyASTNode).valueNode as ObjectASTNode;
+      const aval = anode.properties[0].valueNode;
+
+      const bnode: ObjectASTNode = (parsedDocument.documents[0].root.children[1] as PropertyASTNode).valueNode as ObjectASTNode;
+      const bvalprops: PropertyASTNode = (bnode.properties[0].valueNode as ObjectASTNode).properties[0];
+      const bval = bvalprops.valueNode;
+
+      const cnode: ObjectASTNode = (parsedDocument.documents[0].root.children[2] as PropertyASTNode).valueNode as ObjectASTNode;
+      const cvalprops: PropertyASTNode = (cnode.properties[0].valueNode as ObjectASTNode).properties[0];
+      const cval = cvalprops.valueNode;
+
+      assert(aval?.value === 'web');
+      assert(bval?.value === 'web');
+      assert(cval?.value === undefined);
+    });
+
+    it('parse aliases up to a depth for multiple objects', () => {
+      // In the below configuration, `c` will not inherit `a` because of depth issues
+      // but the following object `o` will still resolve correctly.
+      aliasDepth.maxRefCount = 1;
+      const parsedDocument = parse(`
+a: &a
+  foo: "web"
+b: &b
+  <<: *a
+c: &c
+  <<: *b
+
+o: &o
+  <<: *a
+`);
+      aliasDepth.maxRefCount = 1000;
+
+      const onode: ObjectASTNode = (parsedDocument.documents[0].root.children[3] as PropertyASTNode).valueNode as ObjectASTNode;
+      const ovalprops: PropertyASTNode = (onode.properties[0].valueNode as ObjectASTNode).properties[0];
+      const oval = ovalprops.valueNode;
+
+      const cnode: ObjectASTNode = (parsedDocument.documents[0].root.children[2] as PropertyASTNode).valueNode as ObjectASTNode;
+      const cvalprops: PropertyASTNode = (cnode.properties[0].valueNode as ObjectASTNode).properties[0];
+      const cval = cvalprops.valueNode;
+
+      assert(cval?.value === undefined);
+      assert(oval?.value === 'web');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Currently, the code to convert AST nodes (in particular, resolve aliases) uses a recursive bit of code that will traverse through YAML aliases to resolve properties. For example:
```yaml
a: &a
  name: "foo"
b: 
  <<: *a
```

Parsing this code will produce two objects `a` and `b` that both have `name: "foo"`. The code that implements this alias resolution will only traverse to a depth of 1000, meaning it will give up on resolving aliases once it's traversed a really really long way down a path. This 1000 is very unlikely in human readable yaml files.

However, if you have a very large yaml files with many aliases, none of which come close to the `depth>1000` case, you can still experience errors due to a bug in the recursion. 

Internally we use the https://github.com/redhat-developer/vscode-yaml VSCode extension and we experienced this bug in a very large yaml file where all aliases in the file after the 1000th alias would report incorrect errors for missing properties. 

This boils down to the recursion correctly calling `refDepth++` to keep track of depth in the algorithm, but **not ever** calling `refDepth--`. Meaning regardless of depth, things fail after so many aliases are observed. 

This PR address the issue and adds some unit tests to validate things. 

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/1075

### Is it tested? How?
- [x] Added unit test for the depth case
- [x] Added unit test to check that the recursion works correctly
- [x] Tested locally via https://github.com/redhat-developer/vscode-yaml on our very large yaml files. 
