### PR TITLE
added docker compose and GITHUB actions in setting handler

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -163,7 +163,12 @@ export class SettingsHandler {
       if (enableFormatter) {
         if (!this.yamlSettings.formatterRegistration) {
           this.yamlSettings.formatterRegistration = this.connection.client.register(DocumentFormattingRequest.type, {
-            documentSelector: [{ language: 'yaml' }],
+            documentSelector: [
+              { language: 'yaml' },
+              { language: 'dockercompose' },
+              { language: 'github-actions-workflow' },
+              { pattern: '*.y(a)ml' },
+            ],
           });
         }
       } else if (this.yamlSettings.formatterRegistration) {


### PR DESCRIPTION
### What does this PR do?
This PR will make `vscode-yaml` as  default formatter for `docker compose` and `github actions`. Will do one more PR on client side as well

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/1071

### Is it tested? How?
Yes with existing case
