### PR TITLE
Fix bool enums

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -876,7 +876,7 @@ function validate(
       const val = getNodeValue(node);
       let enumValueMatch = false;
       for (const e of schema.enum) {
-        if (val === e || isAutoCompleteEqualMaybe(callFromAutoComplete, node, val, e)) {
+        if (equals(val, e, node.type) || isAutoCompleteEqualMaybe(callFromAutoComplete, node, val, e)) {
           enumValueMatch = true;
           break;
         }

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -189,6 +189,42 @@ describe('Validation Tests', () => {
         })
         .then(done, done);
     });
+
+    it('Test that boolean value can be used in enum', (done) => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          analytics: {
+            enum: [true, false],
+          },
+        },
+      });
+      const content = 'analytics: true';
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          assert.deepStrictEqual(result, []);
+        })
+        .then(done, done);
+    });
+
+    it('Test that boolean value can be used in const', (done) => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          analytics: {
+            const: true,
+          },
+        },
+      });
+      const content = 'analytics: true';
+      const validator = parseSetup(content);
+      validator
+        .then(function (result) {
+          assert.deepStrictEqual(result, []);
+        })
+        .then(done, done);
+    });
   });
 
   describe('String tests', () => {


### PR DESCRIPTION
### What does this PR do?

schema validation is failing for `boolean` `enum` values:

schema:
```yaml
type: object
properties:
  test_value:
    enum: [true, false]
```

test:
```yaml
test_value: true # fails validation
```

### What issues does this PR fix or reference?

fix for: https://github.com/redhat-developer/yaml-language-server/issues/1078

this is the same fix as applied to `const` values here: https://github.com/redhat-developer/yaml-language-server/commit/e6165e4cf2b1c53ad800434031bdd30d4f00f6e2

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

The first commit in this PR just introduces a failing unit test show casing the issue.

The test is failing with:
```json
[
  {
    "code": 1,
    "data": {
      "schemaUri": [ "file:///default_schema_id.yaml" ],
      "values": [ true, false ]
    },
    "message": "Value is not accepted. Valid values: true, false.",
    "range": {
      "end": { "character": 15, "line": 0 },
      "start": { "character": 11, "line": 0 }
    },
    "severity": 1,
    "source": "yaml-schema: file:///default_schema_id.yaml"
  }
]
```

The second commit is fixing the issue and all tests are passing.
