### PR TITLE
fix/improve enum value descriptions for merged enum lists

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -133,11 +133,15 @@ export class YAMLHover {
                   enumValue = JSON.stringify(enumValue);
                 }
                 //insert only if the value is not present yet (avoiding duplicates)
-                if (!markdownEnums.some((me) => me.value === enumValue)) {
+                //but it also adds or keeps the description of the enum value
+                const foundIdx = markdownEnums.findIndex((me) => me.value === enumValue);
+                if (foundIdx < 0) {
                   markdownEnums.push({
                     value: enumValue,
                     description: markdownEnumDescriptions[idx],
                   });
+                } else {
+                  markdownEnums[foundIdx].description ||= markdownEnumDescriptions[idx];
                 }
               });
             }

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -627,6 +627,124 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
     });
 
+    it('Hover displays unique enum values with prroper description (1st case)', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            description: 'should return this description',
+            anyOf: [
+              {
+                enum: ['cat', 'dog', 'fish'],
+                enumDescriptions: ['1st cat', '1st dog', '1st fish'], // should use this description for "fish"
+              },
+              {
+                enum: ['bird', 'fish', 'ant'],
+              },
+            ],
+          },
+        },
+      });
+      const content = 'animal:\n  fis|n|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Allowed Values:
+
+* \`ant\`
+* \`cat\`: 1st cat
+* \`dog\`: 1st dog
+* \`fish\`: 1st fish
+* \`bird\`
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
+    it('Hover displays unique enum values with prroper description (2nd case)', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            description: 'should return this description',
+            anyOf: [
+              {
+                enum: ['cat', 'dog', 'fish'],
+              },
+              {
+                enum: ['bird', 'fish', 'ant'],
+                enumDescriptions: ['2nd bird', '2nd fish', '2nd ant'], // should use this description for "fish"
+              },
+            ],
+          },
+        },
+      });
+      const content = 'animal:\n  fis|n|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Allowed Values:
+
+* \`ant\`: 2nd ant
+* \`cat\`
+* \`dog\`
+* \`fish\`: 2nd fish
+* \`bird\`: 2nd bird
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
+    it('Hover displays unique enum values with prroper description (3rd case)', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          animal: {
+            description: 'should return this description',
+            anyOf: [
+              {
+                enum: ['cat', 'dog', 'fish'],
+                enumDescriptions: ['1st cat', '1st dog', '1st fish'], // should use this description for "fish"
+              },
+              {
+                enum: ['bird', 'fish', 'ant'],
+                enumDescriptions: ['2nd bird', '2nd fish', '2nd ant'],
+              },
+            ],
+          },
+        },
+      });
+      const content = 'animal:\n  fis|n|'; // len: 13, pos: 12
+      const result = await parseSetup(content);
+
+      assert.strictEqual(MarkupContent.is(result.contents), true);
+      assert.strictEqual((result.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual(
+        (result.contents as MarkupContent).value,
+        `should return this description
+
+Allowed Values:
+
+* \`ant\`: 2nd ant
+* \`cat\`: 1st cat
+* \`dog\`: 1st dog
+* \`fish\`: 1st fish
+* \`bird\`: 2nd bird
+
+Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+
     it('Hover works on examples', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?

fix/improve enum value descriptions for merged enum lists

This is a follow-up submission for #1028, which removes duplicate enum values in merged enum lists.

### What issues does this PR fix or reference?

This fix/improvement ensures that the first **non-empty** enum description is used for the corresponding enum value.

Before this fix: if the first non-unique enum value was not providing a description but the second one was, it was not picked up and the enum value description stayed empty.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

* added 3 additional unit test cases to the test suite, which ensure the correct/expected behavior
* `npm run test` is passing
