### PR TITLE
@vscode/l10n is a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/redhat-developer/yaml-language-server.git"
   },
   "dependencies": {
+    "@vscode/l10n": "^0.0.9",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "lodash": "4.17.21",
@@ -48,7 +49,6 @@
     "@types/sinon-chai": "^3.2.5",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
-    "@vscode/l10n": "^0.0.9",
     "@vscode/l10n-dev": "^0.0.35",
     "chai": "^4.2.0",
     "coveralls": "3.1.1",


### PR DESCRIPTION
### What does this PR do?

Moves @vscode/l10n to runtime dependencies.

### What issues does this PR fix or reference?

From my Neovim lsp.log:
```
[ERROR][2025-07-10 13:40:08] ...p/_transport.lua:36 "rpc" "yaml-language-server"  "stderr"  "node:internal/modules/cjs/loader:1404\n  throw err;\n  ^\n\nError: Cannot find module '@vscode/l10n'\nRequire stack:\n- /usr/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js\n- /usr/lib/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.js\n- /usr/lib/node_modules/yaml-language-server/out/server/src/yamlServerInit.js\n- /usr/lib/node_modules/yaml-language-server/out/server/src/server.js\n- /usr/lib/node_modules/yaml-language-server/bin/yaml-language-server\n    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)\n    at Function._load (node:internal/modules/cjs/loader:1211:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:322:14)\n    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)\n    at Module.require (node:internal/modules/cjs/loader:1487:12)\n    at require (node:internal/modules/helpers:135:16)\n    at Object.<anonymous> (/usr/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js:12:14)\n    at Module._compile (node:internal/modules/cjs/loader:1730:14) {\n  code: 'MODULE_NOT_FOUND',\n  requireStack: [\n    '/usr/lib/node_modules/yaml-language-server/out/server/src/languageservice/services/yamlSchemaService.js',\n    '/usr/lib/node_modules/yaml-language-server/out/server/src/languageservice/yamlLanguageService.js',\n    '/usr/lib/node_modules/yaml-language-server/out/server/src/yamlServerInit.js',\n    '/usr/lib/node_modules/yaml-language-server/out/server/src/server.js',\n    '/usr/lib/node_modules/yaml-language-server/bin/yaml-language-server'\n  ]\n}\n\nNode.js v22.17.0\n"
```

### Is it tested? How?
Applied in https://gitlab.archlinux.org/archlinux/packaging/packages/yaml-language-server/-/commit/5888f52cadeb012d6c6df73aaad4babd939212ff and tested on a `.gitlab-ci.yml` file.
