### PR TITLE
Fixed broken link to JSON schema website

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following settings are supported:
 - `yaml.hover`: Enable/disable hover
 - `yaml.completion`: Enable/disable autocompletion
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
-- `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org/json/)
+- `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org)
 - `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
 - `yaml.maxItemsComputed`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).


### PR DESCRIPTION
### What does this PR do?

This PR fixes a broken link in the README.
The previous link to https://www.schemastore.org/json/ is no longer valid (returns 404).

Updated with the correct working URLs:
- https://json.schemastore.org/
- https://schemastore.org/api/json/catalog.json

Both links are valid and point to the full JSON Schema catalog used by the YAML language server.
Let me know if you'd prefer just one of them in the README, or if it makes sense to include both.