### PR TITLE
Upversion to 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-### 1.19.0
-- Feat: Feat: Support formatting docker-compose.yml by default [#1071](https://github.com/redhat-developer/yaml-language-server/issues/1071)
+### 1.19.1
+- Feat: Support formatting docker-compose.yml by default [#1071](https://github.com/redhat-developer/yaml-language-server/issues/1071)
 - Feat: Support statically registering format support [#1062](https://github.com/redhat-developer/yaml-language-server/pull/1062)
 - Feat: Support localization in the YAML language server [#1081](https://github.com/redhat-developer/yaml-language-server/issues/1081)
 - Feat: Migrated to NPM [#1097](https://github.com/redhat-developer/yaml-language-server/issues/1097)
@@ -18,10 +18,12 @@
 - Fix: Error for missing anchor (unidentified alias) broken since 1.0 [#1098](https://github.com/redhat-developer/vscode-yaml/issues/1098)
 - Fix: Invalid tab indentation error [#1110](https://github.com/redhat-developer/vscode-yaml/issues/1110)
 - Fix: Validation shows false negative errors if using boolean with const [#1116](https://github.com/redhat-developer/vscode-yaml/issues/1116)
+- Fix: Broken link to JSON Schema website [#1113](https://github.com/redhat-developer/yaml-language-server/pull/1113)
+- Fix: GitHub Actions release process was broken [#1127](https://github.com/redhat-developer/yaml-language-server/pull/1127), [#1128](https://github.com/redhat-developer/yaml-language-server/issues/1128)
 - Bump: ajv version [#1067](https://github.com/redhat-developer/yaml-language-server/pull/1067)
 
 Thanks to [Trevor Dixon](https://github.com/trevordixon), [David Lechner](https://github.com/dlech), [pjsk-stripe](https://github.com/pjsk-stripe), [Lucy Dryaeva
-](https://github.com/ShadiestGoat) and [Kosta](https://github.com/Kosta-Github) for your contributions.
+](https://github.com/ShadiestGoat), [Kosta](https://github.com/Kosta-Github) and [August Johansson ](https://github.com/webdevred) for your contributions.
 
 ### 1.18.0
 - Feat: Do not suggest propertyNames if doNotSuggest is true [#1045](https://github.com/redhat-developer/yaml-language-server/pull/1045)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yaml-language-server",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yaml-language-server",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yaml-language-server",
   "description": "YAML language server",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "author": "Red Hat",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
### What does this PR do?
Upversion to 1.19.1. Update 1.19.0 CHANGELOG title to 1.19.1, since there will be no 1.19.0. Add entries for PRs merged but not yet in the CHANGELOG.

### What issues does this PR fix or reference?
We burned the 1.19.0 release by publishing a prerelease version labelled 1.19.0. In order to release, we'll need to use a different version number.

### Is it tested? How?
Existing tests.
