### PR TITLE
Wrapping code action title with string

### DIFF
--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -352,7 +352,7 @@ export class YamlCodeActions {
         results.push(
           CodeAction.create(
             String(value),
-            createWorkspaceEdit(document.uri, [TextEdit.replace(diagnostic.range, value)]),
+            createWorkspaceEdit(document.uri, [TextEdit.replace(diagnostic.range, String(value))]),
             CodeActionKind.QuickFix
           )
         );

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -351,7 +351,7 @@ export class YamlCodeActions {
       for (const value of values) {
         results.push(
           CodeAction.create(
-            value,
+            String(value),
             createWorkspaceEdit(document.uri, [TextEdit.replace(diagnostic.range, value)]),
             CodeActionKind.QuickFix
           )

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -454,6 +454,7 @@ animals: [dog , cat , mouse]  `;
       const actions = new YamlCodeActions(clientCapabilities);
       const result = actions.getCodeAction(doc, params);
       expect(result.map((r) => r.title)).deep.equal(['5', '10']);
+      expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(0, 5, 0, 11), '5')]);
     });
   });
 });

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -431,5 +431,29 @@ animals: [dog , cat , mouse]  `;
       expect(result.map((r) => r.title)).deep.equal(['fooX', 'fooY']);
       expect(result[0].edit.changes[TEST_URI]).deep.equal([TextEdit.replace(Range.create(0, 0, 0, 3), 'fooX')]);
     });
+
+    it('should generate proper action for enum mismatch, title converted to string value', () => {
+      const doc = setupTextDocument('foo: value1');
+      const diagnostic = createDiagnosticWithData(
+        'message',
+        0,
+        5,
+        0,
+        11,
+        DiagnosticSeverity.Hint,
+        'YAML',
+        'schemaUri',
+        ErrorCode.EnumValueMismatch,
+        { values: [5, 10] }
+      );
+      const params: CodeActionParams = {
+        context: CodeActionContext.create([diagnostic]),
+        range: undefined,
+        textDocument: TextDocumentIdentifier.create(TEST_URI),
+      };
+      const actions = new YamlCodeActions(clientCapabilities);
+      const result = actions.getCodeAction(doc, params);
+      expect(result.map((r) => r.title)).deep.equal(['5', '10']);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Wrapping code action title and textedit value with string in yamlCodeActions.ts

### What issues does this PR fix or reference?
Fixes #1116 

### Is it tested? How?
Refer issue screenshots for the behavior before fix

After fixing the issue, behaviour is as follows in UI
Tested in UI
<img width="713" height="834" alt="image" src="https://github.com/user-attachments/assets/b04db722-dd4b-47dc-839f-50709bd8402b" />
<img width="642" height="836" alt="image" src="https://github.com/user-attachments/assets/8e4bc2ff-8fc0-40a2-b3fa-18ea65d8c804" />
