### PR TITLE
README.md: Mention kate as a Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ This repository only contains the server implementation. Here are some known cli
 - [Vim-EasyComplete](https://github.com/jayli/vim-easycomplete) for Vim/NeoVim
 - [nova-yaml](https://github.com/robb-j/nova-yaml/) for Nova
 - [volar-service-yaml](https://github.com/volarjs/services/tree/master/packages/yaml) for Volar
+- [Kate](https://kate-editor.org/)
 
 ## Developer Support
 


### PR DESCRIPTION
The `kate` editor has `yaml-language-server` as its default for the YAML format built-in (no plugins or manual configuration needed).

### What does this PR do?
Update the README.md to add a known client

### What issues does this PR fix or reference?
Fix a missing client in the README.md.

### Is it tested? How?
Not applicable, but review https://invent.kde.org/utilities/kate/-/blob/6dd9a8064c7044b22a5b881b8ce9f34a488bcc4d/addons/lspclient/settings.json#L332 if you want to confirm the configuration.
