### PR TITLE
Fix release GitHub Action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,9 +35,10 @@ jobs:
 
       # Set up Node
       - name: Use Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       # Run install dependencies
       - name: Install dependencies
@@ -69,6 +70,7 @@ jobs:
 
         # Run Coveralls
       - name: Coveralls
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@c7885c00cb7ec0b8f9f5ff3f53cddb980f7a4412 # v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,13 +78,9 @@ jobs:
       - name: Publish
         if: ${{ success() && runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: |
-          {
-            echo "registry=https://registry.npmjs.com"
-            echo "//registry.npmjs.com/:_authToken=${NPM_TOKEN}"
-          } > .npmrc
           npm publish --tag next --no-git-tag-version --prepatch --preid "$(git rev-parse --short HEAD)"
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
         # Setup QEMU as requirement for docker
       - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
 
       # Set up Node
     - name: Use Node 20
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 20
         registry-url: 'https://registry.npmjs.org'
@@ -45,19 +45,11 @@ jobs:
     - name: Run Check Dependencies
       run: npm run check-dependencies
 
-      # Config .npmrc
-    - name: Config .npmrc
-      run: |
-        {
-          echo "registry=https://registry.npmjs.com"
-          echo "//registry.npmjs.com/:_authToken=${NPM_TOKEN}"
-        } > .npmrc
-
     # Publish to npm
     - name: Publish to npm
       run: npm publish --access public
       env:
-        NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       # Get the current package.json version so we can tag the image correctly
     - name: Get current package.json version


### PR DESCRIPTION
### What does this PR do?
- setup-node@v5 creates a .npmrc if you provide a registry, so there should be no need to do that separately
- after setup-node@v5 is run, `npm publish` expects the token to be accessible from the environment variable `NODE_AUTH_TOKEN`
- also fix coveralls so that it only publishes results on ubuntu. If results are published from multiple platforms, then the 2nd and 3rd publish attempts will fail.

See https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm

### What issues does this PR fix or reference?
This should fix the release GitHub Action (as well as the prereleases)

### Is it tested? How?
No, I don't think there's a good way to test it without merging first.