### PR TITLE
Fix prerelease publishing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,7 +78,8 @@ jobs:
       - name: Publish
         if: ${{ success() && runner.os == 'Linux' && github.event_name == 'push' && github.ref == 'refs/heads/main'}}
         run: |
-          npm publish --tag next --no-git-tag-version --prepatch --preid "$(git rev-parse --short HEAD)"
+          npm version prerelease --preid $(git rev-parse --short HEAD) --no-git-tag-version
+          npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?
The options that were being used in `npm publish` to modify the version to include the git hash at the end are intended to be used with the `npm version` command beforehand instead. I think this got messed up somewhere along the way while rewriting the GitHub Action.

### What issues does this PR fix or reference?
Fixes #1128

### Is it tested? How?
I tested the commands locally to ensure that they would work.
