### PR TITLE
Address 'no scope' warning

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -40,7 +40,7 @@ export class SettingsHandler {
     const config = await this.connection.workspace.getConfiguration([
       { section: 'yaml' },
       { section: 'http' },
-      { section: '[yaml]' },
+      { section: '[yaml]', scopeUri: 'null' },
       { section: 'editor' },
       { section: 'files' },
     ]);

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -369,7 +369,7 @@ describe('Settings Handlers Tests', () => {
       expect(workspaceStub.getConfiguration).calledOnceWith([
         { section: 'yaml' },
         { section: 'http' },
-        { section: '[yaml]' },
+        { section: '[yaml]', scopeUri: 'null' },
         { section: 'editor' },
         { section: 'files' },
       ]);
@@ -409,7 +409,7 @@ describe('Settings Handlers Tests', () => {
       expect(workspaceStub.getConfiguration).calledOnceWith([
         { section: 'yaml' },
         { section: 'http' },
-        { section: '[yaml]' },
+        { section: '[yaml]', scopeUri: 'null' },
         { section: 'editor' },
         { section: 'files' },
       ]);


### PR DESCRIPTION
### What does this PR do?
A scope should be provided when accessing `[yml]` settings, otherwise a warning is emitted. This change provides `file:///` as the scope.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/972

### Is it tested? How?
Yes; verified manually that the warning goes away in VS Code.
