### PR TITLE
feat: add errorMessage from schema when the property is missing

### DIFF
--- a/src/languageservice/parser/jsonParser07.ts
+++ b/src/languageservice/parser/jsonParser07.ts
@@ -1251,9 +1251,7 @@ function validate(
           validationResult.problems.push({
             location: location,
             severity: DiagnosticSeverity.Warning,
-            message:
-              getWarningMessage(ProblemType.missingRequiredPropWarning, [propertyName]) +
-              (schema.errorMessage ? ` ${schema.errorMessage}` : ''),
+            message: schema.errorMessage || getWarningMessage(ProblemType.missingRequiredPropWarning, [propertyName]),
             source: getSchemaSource(schema, originalSchema),
             schemaUri: getSchemaUri(schema, originalSchema),
             problemArgs: [propertyName],

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -1422,7 +1422,7 @@ obj:
       });
       const content = '';
       const result = await parseSetup(content);
-      expect(result[0].message).to.eq('Missing property "title".' + ' ' + 'Custom message');
+      expect(result[0].message).to.eq('Custom message');
     });
     it('should add errorMessage from sub-schema when the property is missing', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
@@ -1447,7 +1447,7 @@ obj:
       });
       const content = '';
       const result = await parseSetup(content);
-      expect(result[0].message).to.eq('Missing property "title".' + ' ' + 'At least one of `title` or `icon` must be defined.');
+      expect(result[0].message).to.eq('At least one of `title` or `icon` must be defined.');
     });
 
     describe('filePatternAssociation', () => {


### PR DESCRIPTION
### What does this PR do?
adds an errorMessage from the schema when the property is missing
allows customization of the errorMessage in more complicated scenarios, like 

```
anyOf: [
          {
            required: ['title'],
            errorMessage: 'At least one of `title` or `icon` must be defined.',
          },
          {
            required: ['icon'],
          },
        ],
```

### What issues does this PR fix or reference?


### Is it tested? How?
test