### PR TITLE
Fix formatter registration pattern

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -169,7 +169,7 @@ export class SettingsHandler {
               { language: 'github-actions-workflow' },
               { language: 'yaml-textmate' },
               { language: 'yaml-tmlanguage' },
-              { pattern: '*.y(a)ml' },
+              { pattern: '**/*.{yaml,yml}' },
             ],
           });
         }


### PR DESCRIPTION
### What does this PR do?
The formatter should be registered for all files that end in `.yaml` or `.yml`. The old pattern didn't do this properly. This new pattern should work from my testing.

This should mean we don't need to add new entries for each language that's based on YAML (eg. dockercompose, ansible, etc.) in the future.

### What issues does this PR fix or reference?
Fixes #1147

### Is it tested? How?
Yes, manually:
1. Use this PR on vscode-yaml: https://github.com/redhat-developer/vscode-yaml/pull/1179
2. Add this config to settings.json:
```jsonc
{
// ...
"[ansible]": {
    "editor.defaultFormatter": "redhat.vscode-yaml",
// ...
}
```
3. Open up a Ansible document (make sure the language of the file is set to "Ansible")
4. Format the document

Without this PR, there will be an error popup, since the language server is not configured to format Ansible documents, and the pattern it's configured with to handle "all" YAML files is incorrect.
