### PR TITLE
Allow .editorconfig for prettier

### DIFF
--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -35,6 +35,7 @@ export class YAMLFormatter {
       const prettierOptions: Options = {
         parser: 'yaml',
         plugins: [yamlPlugin, estreePlugin],
+        editorConfig: options.editorConfig,
 
         // --- FormattingOptions ---
         tabWidth: (options.tabWidth as number) || options.tabSize,

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -149,6 +149,7 @@ export interface SchemaConfiguration {
 }
 
 export interface CustomFormatterOptions {
+  editorConfig?: boolean;
   singleQuote?: boolean;
   bracketSpacing?: boolean;
   trailingComma?: boolean;


### PR DESCRIPTION
### What does this PR do?

`prettier` wasn't respecting my `.editorconfig`. This PR creates an option `format.editorConfig`, and when it's `true`, will pass that into `prettier`, respecting those settings if you opt in.

### What issues does this PR fix or reference?


### Is it tested? How?
Built locally, tested in neovim with `nvim-lspconfig`.

```lua
opts = {
  servers = {
    yamlls = {
      cmd = "path/to/local/yaml-language-server",
      settings = {
        yaml = {
          format = {
            enable = true,
            editorConfig = true,
          },
        },
      },
    },
  },
}
```
