### PR TITLE
[WIP] use ajv to validate YAML files

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
     {
       "label": "watch typescript",
       "type": "shell",
-      "command": "yarn run watch",
+      "command": "npm run watch",
       "presentation": {
         "reveal": "never"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vscode/l10n": "^0.0.18",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
         "lodash": "4.17.21",
         "prettier": "^3.5.0",
         "request-light": "^0.5.7",
@@ -1225,6 +1226,23 @@
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "ajv": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@vscode/l10n": "^0.0.18",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
+    "ajv-formats": "^3.0.1",
     "lodash": "4.17.21",
     "prettier": "^3.5.0",
     "request-light": "^0.5.7",


### PR DESCRIPTION
### What does this PR do?
Validate YAML against its schema with ajv instead of our validator.

This is a proof of concept. Many existing features are broken slightly, especially those related to validation specific to the VS Code extensions to JSON Schema. ajv provides human readable error messages and JSON Pointers to the invalid data out of the box, which makes it suitable to use to validate YAML, and slightly easier to use than `@hyperjump/json-schema`.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/yaml-language-server/issues/856

### Is it tested? How?
Existing tests (they are failing)
