### PR TITLE
Fix `propertyNames` keyword auto-completion

### DIFF
--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -1478,7 +1478,7 @@ test1:
 
     expect(completion.items.length).equal(1);
     expect(completion.items[0].insertText).to.be.equal('${1:property}: ');
-    expect(completion.items[0].documentation).to.deep.equal({ kind: 'markdown', value: 'Property Description' });
+    expect(completion.items[0].documentation).to.be.deep.equal({ kind: 'markdown', value: 'Property Description' });
   });
   it('should not suggest propertyNames with doNotSuggest', async () => {
     const schema: JSONSchema = {
@@ -1515,29 +1515,6 @@ test1:
     expect(completion.items[1].insertText).to.be.equal('"NO"');
   });
 
-  it('should suggest propertyNames candidates from const, enum, oneOf, anyOf, allOf', async () => {
-    const schema: JSONSchema = {
-      type: 'object',
-      propertyNames: {
-        allOf: [
-          { const: 'Event0' },
-          {
-            anyOf: [
-              { const: 'Event1' },
-              { enum: ['Event2', 'Event3'] },
-              {
-                oneOf: [{ const: 'Event4' }, { const: 'Event5' }],
-              },
-            ],
-          },
-        ],
-      },
-    };
-    schemaProvider.addSchema(SCHEMA_ID, schema);
-    const completion = await parseSetup('', 0, 0);
-    expect(completion.items.map((i) => i.label)).to.have.members(['Event0', 'Event1', 'Event2', 'Event3', 'Event4', 'Event5']);
-  });
-
   it('should suggest propertyNames keys from definitions $ref', async () => {
     const schema: JSONSchema = {
       definitions: {
@@ -1557,10 +1534,82 @@ test1:
       required: ['events'],
     };
     schemaProvider.addSchema(SCHEMA_ID, schema);
-    const content = `events:
-    | |`;
-    const completion = await parseCaret(content);
+    const completion = await parseSetup('events:\n  ', 1, 2);
     expect(completion.items.map((i) => i.label)).to.have.members(['None', 'Event1', 'Event2']);
+  });
+
+  it('should suggest propertyNames candidates from const', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      propertyNames: {
+        const: 'Event0',
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items.map((i) => i.label)).to.have.members(['Event0']);
+  });
+
+  it('should suggest propertyNames candidates from enum', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      additionalProperties: true,
+      propertyNames: {
+        enum: ['Event1', 'Event2', 'Event3'],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items.map((i) => i.label)).to.have.members(['Event1', 'Event2', 'Event3']);
+  });
+
+  it('should suggest propertyNames candidates from oneOf', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      propertyNames: {
+        oneOf: [{ const: 'Event1' }, { const: 'Event2' }],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items.map((i) => i.label)).to.have.members(['Event1', 'Event2']);
+  });
+
+  it('should suggest propertyNames candidates from anyOf', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      propertyNames: {
+        anyOf: [{ const: 'Event1' }, { enum: ['Event2', 'Event3'] }],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items.map((i) => i.label)).to.have.members(['Event1', 'Event2', 'Event3']);
+  });
+
+  it('should suggest only the intersected propertyNames candidate from allOf (const + enum)', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      propertyNames: {
+        allOf: [{ const: 'One' }, { enum: ['One', 'Two'] }],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items.map((i) => i.label)).to.have.members(['One']);
+    expect(completion.items.map((i) => i.label)).to.not.include('Two');
+  });
+
+  it('should not suggest any propertyNames when allOf makes keys impossible (const + const)', async () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      propertyNames: {
+        allOf: [{ const: 'One' }, { const: 'Two' }],
+      },
+    };
+    schemaProvider.addSchema(SCHEMA_ID, schema);
+    const completion = await parseSetup('', 0, 0);
+    expect(completion.items).to.be.empty;
   });
 
   describe('String scalar completion comprehensive tests', () => {


### PR DESCRIPTION
### What does this PR do?
Implementation for `propertyNames` keyword auto-completion was only providing the title of the `propertyNames` schema as completion and did not correctly handle schemas that used enum, const, oneOf, anyOf, and allOf, and definition via `$ref`.

This PR improves `propertyNames` keyword auto-completion to support definition via `$ref` and enum/const/oneOf/anyOf/allOf.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1141

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Manual test: test with the schema provided in https://github.com/redhat-developer/yaml-language-server/issues/1141.

- Automation test: added tests for `propertyNames` with `$ref` to definitions and `propertyNames` using enum/const/oneOf/ anyOf/allOf