### PR TITLE
Fix 'go to schema' CodeLens on web

### DIFF
--- a/src/languageservice/services/yamlCommands.ts
+++ b/src/languageservice/services/yamlCommands.ts
@@ -13,8 +13,19 @@ export function registerCommands(commandExecutor: CommandExecutor, connection: C
     if (!uri) {
       return;
     }
-    // if uri points to local file of its a windows path
-    if (!uri.startsWith('file') && !/^[a-z]:[\\/]/i.test(uri)) {
+    const wsFolders = await connection.workspace.getWorkspaceFolders();
+
+    if (uri.indexOf('://') < 0 && !uri.startsWith('/')) {
+      if (wsFolders.length === 1) {
+        const wsUri = URI.parse(wsFolders[0].uri);
+        uri = wsUri.with({ path: wsUri.path + uri }).toString();
+      }
+    } else if (uri.startsWith('file://') && wsFolders.length === 1 && URI.parse(wsFolders[0].uri).scheme != 'file') {
+      const wsUri = URI.parse(wsFolders[0].uri);
+      const pathFromUri = URI.parse(uri).path;
+      uri = wsUri.with({ path: pathFromUri }).toString();
+    } else if (!uri.startsWith('file') && !/^[a-z]:[\\/]/i.test(uri)) {
+      // if uri points to local file of its a windows path
       const origUri = URI.parse(uri);
       const customUri = URI.from({
         scheme: 'json-schema',

--- a/test/yamlCommands.test.ts
+++ b/test/yamlCommands.test.ts
@@ -35,9 +35,13 @@ describe('Yaml Commands', () => {
 
   it('JumpToSchema handler should call "showDocument"', async () => {
     const showDocumentStub = sandbox.stub();
+    const getWorkspaceFoldersStub = sandbox.stub().returns(Promise.resolve([]));
     const connection = {
       window: {
         showDocument: showDocumentStub,
+      },
+      workspace: {
+        getWorkspaceFolders: getWorkspaceFoldersStub,
       },
     } as unknown as Connection;
     showDocumentStub.resolves(true);
@@ -49,9 +53,13 @@ describe('Yaml Commands', () => {
 
   it('JumpToSchema handler should call "showDocument" with plain win path', async () => {
     const showDocumentStub = sandbox.stub();
+    const getWorkspaceFoldersStub = sandbox.stub().returns(Promise.resolve([]));
     const connection = {
       window: {
         showDocument: showDocumentStub,
+      },
+      workspace: {
+        getWorkspaceFolders: getWorkspaceFoldersStub,
       },
     } as unknown as Connection;
     showDocumentStub.resolves(true);
@@ -60,6 +68,28 @@ describe('Yaml Commands', () => {
     await arg[1]('a:\\some\\path\\to\\schema.json');
     expect(showDocumentStub).to.have.been.calledWith({
       uri: URI.file('a:\\some\\path\\to\\schema.json').toString(),
+      external: false,
+      takeFocus: true,
+    });
+  });
+
+  it('JumpToSchema handler should call "showDocument" with custom web schema', async () => {
+    const showDocumentStub = sandbox.stub();
+    const getWorkspaceFoldersStub = sandbox.stub().returns(Promise.resolve([{ uri: 'vscode-test:///root/' }]));
+    const connection = {
+      window: {
+        showDocument: showDocumentStub,
+      },
+      workspace: {
+        getWorkspaceFolders: getWorkspaceFoldersStub,
+      },
+    } as unknown as Connection;
+    showDocumentStub.resolves(true);
+    registerCommands(commandExecutor, connection);
+    const arg = commandExecutorStub.args[0];
+    await arg[1]('my-file.json');
+    expect(showDocumentStub).to.have.been.calledWith({
+      uri: URI.parse('vscode-test:///root/my-file.json').toString(),
       external: false,
       takeFocus: true,
     });


### PR DESCRIPTION
### What does this PR do?
Clicking on the CodeLens used to not work on web (eg. GitLab IDE).

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1195

### Is it tested? How?
- [x] Unit tests
