### PR TITLE
fix unset schemaStore.url not using the default

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -83,7 +83,7 @@ export class SettingsHandler {
 
       if (settings.yaml.schemaStore) {
         this.yamlSettings.schemaStoreEnabled = settings.yaml.schemaStore.enable;
-        if (settings.yaml.schemaStore.url?.length !== 0) {
+        if (settings.yaml.schemaStore.url) {
           this.yamlSettings.schemaStoreUrl = settings.yaml.schemaStore.url;
         }
       }
@@ -200,12 +200,7 @@ export class SettingsHandler {
    */
   private async setSchemaStoreSettingsIfNotSet(): Promise<void> {
     const schemaStoreIsSet = this.yamlSettings.schemaStoreSettings.length !== 0;
-    let schemaStoreUrl = '';
-    if (this.yamlSettings.schemaStoreUrl?.length !== 0) {
-      schemaStoreUrl = this.yamlSettings.schemaStoreUrl;
-    } else {
-      schemaStoreUrl = JSON_SCHEMASTORE_URL;
-    }
+    const schemaStoreUrl = this.yamlSettings.schemaStoreUrl || JSON_SCHEMASTORE_URL;
 
     if (this.yamlSettings.schemaStoreEnabled && !schemaStoreIsSet) {
       try {


### PR DESCRIPTION
### What does this PR do?

Prior to this commit, enabling schema store (via `schemaStore.enable`) required also setting `schemaStore.url`, either to an empty string or to a valid URL.

When the setting was unset, the value of the url was undefined, and the checks were not properly catching the case.

This commit makes it so an unset `schemaStore.url` acts the same as an empty string and uses the default URL.

### What issues does this PR fix or reference?

See above.

### Is it tested? How?

I ran `npm run compile`, pointed my LSP client to `node $path_to_project/out/server/src/server.js --stdio` and commented out `yaml.schemaStore.url` and opened a yml file. It was able to fetch its schema.

Unit tests are also passing.