### PR TITLE
Fix resolving schemas on web

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -60,7 +60,8 @@ const schemaRequestHandlerWrapper = (connection: Connection, uri: string): Promi
     yamlSettings.workspaceFolders,
     yamlSettings.workspaceRoot,
     yamlSettings.useVSCodeContentRequest,
-    fileSystem
+    fileSystem,
+    false
   );
 };
 

--- a/src/webworker/yamlServerMain.ts
+++ b/src/webworker/yamlServerMain.ts
@@ -41,7 +41,8 @@ self.onmessage = (e) => {
       yamlSettings.workspaceFolders,
       yamlSettings.workspaceRoot,
       yamlSettings.useVSCodeContentRequest,
-      fileSystem
+      fileSystem,
+      true
     );
   };
 

--- a/test/bundlel10n.test.ts
+++ b/test/bundlel10n.test.ts
@@ -32,7 +32,8 @@ describe('Bundle l10n Test', () => {
         yamlSettings.workspaceFolders,
         yamlSettings.workspaceRoot,
         yamlSettings.useVSCodeContentRequest,
-        testFileSystem
+        testFileSystem,
+        false
       );
     };
     const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);

--- a/test/schemaRequestHandler.test.ts
+++ b/test/schemaRequestHandler.test.ts
@@ -35,7 +35,8 @@ describe('Schema Request Handler Tests', () => {
         [],
         URI.parse(''),
         false,
-        testFileSystem
+        testFileSystem,
+        false
       );
       expect(readFileStub).calledOnceWith('c:\\some\\window\\path\\scheme.json');
       const result = await resultPromise;
@@ -44,7 +45,7 @@ describe('Schema Request Handler Tests', () => {
 
     it('UNIX URI should works', async () => {
       const connection = {} as Connection;
-      const resultPromise = schemaRequestHandler(connection, '/some/unix/path/', [], URI.parse(''), false, testFileSystem);
+      const resultPromise = schemaRequestHandler(connection, '/some/unix/path/', [], URI.parse(''), false, testFileSystem, false);
       const result = await resultPromise;
       expect(result).to.be.equal('{some: "json"}');
     });
@@ -57,7 +58,8 @@ describe('Schema Request Handler Tests', () => {
         [],
         URI.parse(''),
         false,
-        testFileSystem
+        testFileSystem,
+        false
       );
       expect(readFileStub).calledOnceWith(URI.file('a:/some/window/path/scheme.json').fsPath);
       const result = await resultPromise;

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -76,7 +76,8 @@ export function setupLanguageService(languageSettings: LanguageSettings): TestLa
       yamlSettings.workspaceFolders,
       yamlSettings.workspaceRoot,
       yamlSettings.useVSCodeContentRequest,
-      testFileSystem
+      testFileSystem,
+      false
     );
   };
   const schemaRequestService = schemaRequestHandlerWrapper.bind(this, connection);


### PR DESCRIPTION
### What does this PR do?
Use URI instead of filepath to retrieve schemas from workspace on web, since the web environment sometimes uses URIs with schemes other than `file://` for the workspace files

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1194

### Is it tested? How?
Manually, integration tests/smoke tests in vscode-yaml