### PR TITLE
Drop global escaping of `-` in hover text

### DIFF
--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -339,7 +339,7 @@ export class YAMLHover {
   private toMarkdown(plain: string | undefined): string | undefined {
     if (plain) {
       let escaped = plain.replace(/([^\n\r])(\r?\n)([^\n\r])/gm, '$1\n\n$3'); // single new lines to \n\n (Markdown paragraph)
-      escaped = escaped.replace(/[\\`*_{}[\]#+\-!]/g, '\\$&'); // escape some of the markdown syntax tokens http://daringfireball.net/projects/markdown/syntax#backslash to avoid unintended formatting
+      escaped = escaped.replace(/[\\`*_{}[\]#+!]/g, '\\$&'); // escape some of the markdown syntax tokens http://daringfireball.net/projects/markdown/syntax#backslash to avoid unintended formatting
       if (this.indentation !== undefined) {
         // escape indentation whitespace to prevent it from being converted to markdown code blocks.
         const indentationMatchRegex = new RegExp(` {${this.indentation.length}}`, 'g');

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -920,7 +920,7 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
       assert.strictEqual(
         (hover.contents as MarkupContent).value,
-        `The YAML Language Server at https://github.com/redhat\\-developer/yaml\\-language\\-server\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+        `The YAML Language Server at https://github.com/redhat-developer/yaml-language-server\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
     });
 
@@ -942,7 +942,7 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
       assert.strictEqual(
         (hover.contents as MarkupContent).value,
-        `Yaml Language Server (https://github.com/redhat\\-developer/yaml\\-language\\-server)\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+        `Yaml Language Server (https://github.com/redhat-developer/yaml-language-server)\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
     });
   });


### PR DESCRIPTION
### What does this PR do?
Dropped global escaping of `-` in hover markdown text.

Escaping `-` everywhere turns urls with hyphens into something like `yaml\-language\-server` on Windows (because Windows usually shows backslash literally) and makes links not usable. 
Dropping global escaping of `-` should be safe because `-` is only special in markdown in list items and horizontal rules like `---`.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1151

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Existing automated tests.