### PR TITLE
Update ajv to 8.18.0 to fix ReDoS vulnerability (CVE-2025-69873)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,9 +1202,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
Solves https://nvd.nist.gov/vuln/detail/CVE-2025-69873

Updated ajv from 8.17.1 to 8.18.0 to address Regular Expression Denial of Service (ReDoS) vulnerability when $data option is enabled. The vulnerability allowed attackers to inject malicious regex patterns causing catastrophic backtracking and complete denial of service.