### PR TITLE
Prefer local sibling schema resolution for relative $ref before remote $id lookup

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -131,7 +131,6 @@ export class YAMLSchemaService extends JSONSchemaService {
   public schemaPriorityMapping: Map<string, Set<SchemaPriority>>;
 
   private schemaUriToNameAndDescription = new Map<string, SchemaStoreSchema>();
-  private schemaIdPrefixToLocalDir = new Map<string, string>();
 
   constructor(
     requestService: SchemaRequestService,
@@ -347,6 +346,22 @@ export class YAMLSchemaService extends JSONSchemaService {
       return this.normalizeId(ref);
     };
 
+    const _preferLocalBaseForRemoteId = async (currentBase: string, id: string): Promise<string> => {
+      try {
+        const currentBaseUri = URI.parse(currentBase);
+        const idUri = URI.parse(id);
+        const localFileName = path.posix.basename(idUri.path);
+        const localDir = path.posix.dirname(currentBaseUri.path);
+        const localPath = path.posix.join(localDir, localFileName);
+        const localUriStr = currentBaseUri.with({ path: localPath, query: idUri.query, fragment: idUri.fragment }).toString();
+        if (localUriStr === currentBase) return localUriStr;
+        const content = await this.requestService(localUriStr);
+        return content ? localUriStr : _resolveAgainstBase(currentBase, id);
+      } catch {
+        return _resolveAgainstBase(currentBase, id);
+      }
+    };
+
     const _indexSchemaResources = async (root: JSONSchema, initialBaseUri: string): Promise<void> => {
       type WorkItem = { node: JSONSchema; baseUri: string };
       const preOrderStack: WorkItem[] = [{ node: root, baseUri: initialBaseUri }];
@@ -365,17 +380,17 @@ export class YAMLSchemaService extends JSONSchemaService {
         let baseUri = current.baseUri;
         const id = node.$id || node.id;
         if (id) {
-          const normalizedId = _resolveAgainstBase(baseUri, id);
-          node._baseUrl = normalizedId;
-          const hashIndex = normalizedId.indexOf('#');
-          if (hashIndex !== -1 && hashIndex < normalizedId.length - 1) {
+          const preferredBaseUri = await _preferLocalBaseForRemoteId(baseUri, id);
+          node._baseUrl = preferredBaseUri;
+          const hashIndex = preferredBaseUri.indexOf('#');
+          if (hashIndex !== -1 && hashIndex < preferredBaseUri.length - 1) {
             // Draft-07 and earlier: $id with fragment defines a plain-name anchor scoped to the resolved base
-            const frag = normalizedId.slice(hashIndex + 1);
+            const frag = preferredBaseUri.slice(hashIndex + 1);
             _getResourceIndex(baseUri).fragments.set(frag, { node });
           } else {
             // $id without fragment creates a new embedded resource scope
-            baseUri = normalizedId;
-            const entry = _getResourceIndex(normalizedId);
+            baseUri = preferredBaseUri;
+            const entry = _getResourceIndex(preferredBaseUri);
             if (!entry.root) {
               entry.root = node;
             }
@@ -441,7 +456,8 @@ export class YAMLSchemaService extends JSONSchemaService {
     };
 
     let schema = raw as JSONSchema;
-    await _indexSchemaResources(schema, schemaURL);
+    const schemaBaseURL = schemaToResolve.uri ?? schemaURL;
+    await _indexSchemaResources(schema, schemaBaseURL);
 
     const _findSection = (schemaRoot: JSONSchema, refPath: string, sourceURI: string): JSONSchema => {
       if (!refPath) {
@@ -1159,133 +1175,76 @@ export class YAMLSchemaService extends JSONSchemaService {
     return super.getOrAddSchemaHandle(id, unresolvedSchemaContent);
   }
 
-  private trackSchemaIdPrefixMapping(requestedSchemaUri: string, unresolvedJsonSchema: UnresolvedSchema): void {
-    try {
-      const requestedUri = URI.parse(requestedSchemaUri);
-      if (requestedUri.scheme !== 'file') return;
-
-      const schemaId = unresolvedJsonSchema.schema.$id;
-      if (typeof schemaId !== 'string') return;
-
-      const idUri: URI = URI.parse(schemaId);
-      if ((idUri.scheme !== 'http' && idUri.scheme !== 'https') || !idUri.path) return;
-
-      const localDirPath = path.posix.dirname(requestedUri.path) + '/';
-      const fileDirUri = requestedUri.with({ path: localDirPath }).toString();
-      const idDirPath = path.posix.dirname(idUri.path) + '/';
-      const idPrefix = idUri.with({ path: idDirPath }).toString();
-
-      this.schemaIdPrefixToLocalDir.set(idPrefix, fileDirUri);
-    } catch {
-      return;
-    }
-  }
-
-  private resolveTrackedSchemaUri(schemaUri: string): string | undefined {
-    let targetUri: URI;
-    try {
-      targetUri = URI.parse(schemaUri);
-    } catch {
-      return undefined;
-    }
-
-    if (targetUri.scheme !== 'http' && targetUri.scheme !== 'https') return undefined;
-
-    const targetWithoutFragment = targetUri.with({ query: '', fragment: '' });
-    const targetDirPath = path.posix.dirname(targetWithoutFragment.path) + '/';
-    const targetPrefix = targetWithoutFragment.with({ path: targetDirPath }).toString();
-
-    const fileDirUri = this.schemaIdPrefixToLocalDir.get(targetPrefix);
-    if (!fileDirUri) return undefined;
-
-    const relativePath = targetWithoutFragment.toString().slice(targetPrefix.length);
-    const localDirUri = URI.parse(fileDirUri);
-    const localPath = path.posix.join(localDirUri.path, relativePath);
-    return localDirUri.with({ path: localPath, query: targetUri.query, fragment: targetUri.fragment }).toString();
-  }
-
   loadSchema(schemaUri: string): Promise<UnresolvedSchema> {
     const requestService = this.requestService;
-    const loadRequestedSchema = (requestedSchemaUri: string): Promise<UnresolvedSchema> => {
-      return super.loadSchema(requestedSchemaUri).then(async (unresolvedJsonSchema: UnresolvedSchema) => {
-        // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
-        // If the YAML file starts with %YAML 1.x or contains a comment with a number the schema will
-        // contain a number instead of being undefined, so we need to check for that too.
-        if (
-          unresolvedJsonSchema.errors &&
-          (unresolvedJsonSchema.schema === undefined || typeof unresolvedJsonSchema.schema === 'number')
-        ) {
-          return requestService(requestedSchemaUri).then(
-            (content) => {
-              if (!content) {
-                const errorMessage = l10n.t(
-                  "Unable to load schema from '{0}': No content. {1}",
-                  toDisplayString(schemaUri),
-                  unresolvedJsonSchema.errors
-                );
-                return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
-              }
-
-              try {
-                const schemaContent = parse(content);
-                return new UnresolvedSchema(schemaContent, []);
-              } catch (yamlError) {
-                const errorMessage = l10n.t("Unable to parse content from '{0}': {1}.", toDisplayString(schemaUri), yamlError);
-                return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
-              }
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (error: any) => {
-              let errorMessage = error.toString();
-              const errorSplit = error.toString().split('Error: ');
-              if (errorSplit.length > 1) {
-                // more concise error message, URL and context are attached by caller anyways
-                errorMessage = errorSplit[1];
-              }
+    return super.loadSchema(schemaUri).then(async (unresolvedJsonSchema: UnresolvedSchema) => {
+      // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
+      // If the YAML file starts with %YAML 1.x or contains a comment with a number the schema will
+      // contain a number instead of being undefined, so we need to check for that too.
+      if (
+        unresolvedJsonSchema.errors &&
+        (unresolvedJsonSchema.schema === undefined || typeof unresolvedJsonSchema.schema === 'number')
+      ) {
+        return requestService(schemaUri).then(
+          (content) => {
+            if (!content) {
+              const errorMessage = l10n.t(
+                "Unable to load schema from '{0}': No content. {1}",
+                toDisplayString(schemaUri),
+                unresolvedJsonSchema.errors
+              );
               return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
             }
-          );
-        }
-        unresolvedJsonSchema.uri = schemaUri;
-        if (this.schemaUriToNameAndDescription.has(schemaUri)) {
-          const { name, description, versions } = this.schemaUriToNameAndDescription.get(schemaUri);
-          unresolvedJsonSchema.schema.title = name ?? unresolvedJsonSchema.schema.title;
-          unresolvedJsonSchema.schema.description = description ?? unresolvedJsonSchema.schema.description;
-          unresolvedJsonSchema.schema.versions = versions ?? unresolvedJsonSchema.schema.versions;
-        } else if (unresolvedJsonSchema.errors && unresolvedJsonSchema.errors.length > 0) {
-          let errorMessage: string = unresolvedJsonSchema.errors[0];
-          if (errorMessage.toLowerCase().indexOf('load') !== -1) {
-            errorMessage = l10n.t("Unable to load schema from '{0}': No content.", toDisplayString(schemaUri));
-          } else if (errorMessage.toLowerCase().indexOf('parse') !== -1) {
-            const content = await requestService(requestedSchemaUri);
-            const jsonErrors: Json.ParseError[] = [];
-            const schemaContent = Json.parse(content, jsonErrors);
-            if (jsonErrors.length && schemaContent) {
-              const { offset } = jsonErrors[0];
-              const { line, column } = getLineAndColumnFromOffset(content, offset);
-              errorMessage = l10n.t(
-                "Unable to parse content from '{0}': Parse error at line: {1} column: {2}",
-                toDisplayString(schemaUri),
-                line,
-                column
-              );
+
+            try {
+              const schemaContent = parse(content);
+              return new UnresolvedSchema(schemaContent, []);
+            } catch (yamlError) {
+              const errorMessage = l10n.t("Unable to parse content from '{0}': {1}.", toDisplayString(schemaUri), yamlError);
+              return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
             }
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (error: any) => {
+            let errorMessage = error.toString();
+            const errorSplit = error.toString().split('Error: ');
+            if (errorSplit.length > 1) {
+              // more concise error message, URL and context are attached by caller anyways
+              errorMessage = errorSplit[1];
+            }
+            return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
           }
-          return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
+        );
+      }
+      unresolvedJsonSchema.uri = schemaUri;
+      if (this.schemaUriToNameAndDescription.has(schemaUri)) {
+        const { name, description, versions } = this.schemaUriToNameAndDescription.get(schemaUri);
+        unresolvedJsonSchema.schema.title = name ?? unresolvedJsonSchema.schema.title;
+        unresolvedJsonSchema.schema.description = description ?? unresolvedJsonSchema.schema.description;
+        unresolvedJsonSchema.schema.versions = versions ?? unresolvedJsonSchema.schema.versions;
+      } else if (unresolvedJsonSchema.errors && unresolvedJsonSchema.errors.length > 0) {
+        let errorMessage: string = unresolvedJsonSchema.errors[0];
+        if (errorMessage.toLowerCase().indexOf('load') !== -1) {
+          errorMessage = l10n.t("Unable to load schema from '{0}': No content.", toDisplayString(schemaUri));
+        } else if (errorMessage.toLowerCase().indexOf('parse') !== -1) {
+          const content = await requestService(schemaUri);
+          const jsonErrors: Json.ParseError[] = [];
+          const schemaContent = Json.parse(content, jsonErrors);
+          if (jsonErrors.length && schemaContent) {
+            const { offset } = jsonErrors[0];
+            const { line, column } = getLineAndColumnFromOffset(content, offset);
+            errorMessage = l10n.t(
+              "Unable to parse content from '{0}': Parse error at line: {1} column: {2}",
+              toDisplayString(schemaUri),
+              line,
+              column
+            );
+          }
         }
-        this.trackSchemaIdPrefixMapping(requestedSchemaUri, unresolvedJsonSchema);
-        return unresolvedJsonSchema;
-      });
-    };
-    const trackedSchemaUri = this.resolveTrackedSchemaUri(schemaUri);
-    if (!trackedSchemaUri || trackedSchemaUri === schemaUri) return loadRequestedSchema(schemaUri);
-    return loadRequestedSchema(trackedSchemaUri).then(
-      (trackedSchema) =>
-        trackedSchema.errors && trackedSchema.errors.some((error) => error.toLowerCase().includes('unable to load schema from'))
-          ? loadRequestedSchema(schemaUri)
-          : trackedSchema,
-      () => loadRequestedSchema(schemaUri)
-    );
+        return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
+      }
+      return unresolvedJsonSchema;
+    });
   }
 
   registerExternalSchema(
@@ -1303,7 +1262,6 @@ export class YAMLSchemaService extends JSONSchemaService {
   }
 
   clearExternalSchemas(): void {
-    this.schemaIdPrefixToLocalDir.clear();
     super.clearExternalSchemas();
   }
 

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -164,7 +164,7 @@ describe('YAML Schema Service', () => {
       expect(requestedUris).to.not.include('https://example.com/schemas/secondary.json');
     });
 
-    it('should use local schema path for absolute $ref before remote $id ref', async () => {
+    it('should resolve absolute $ref via remote base and mapped local sibling path', async () => {
       const content = `# yaml-language-server: $schema=file:///dir/primary.json\nname: John\nage: -1`;
       const yamlDock = parse(content);
 
@@ -186,7 +186,7 @@ describe('YAML Schema Service', () => {
         if (uri === 'file:///dir/primary.json') {
           return Promise.resolve(JSON.stringify(primarySchema));
         }
-        if (uri === 'file:///schemas/secondary.json') {
+        if (uri === 'file:///dir/secondary.json') {
           return Promise.resolve(JSON.stringify(secondarySchema));
         }
         return Promise.reject<string>(`Resource ${uri} not found.`);
@@ -197,8 +197,50 @@ describe('YAML Schema Service', () => {
 
       const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
       expect(requestedUris).to.include('file:///dir/primary.json');
-      expect(requestedUris).to.include('file:///schemas/secondary.json');
+      expect(requestedUris).to.include('file:///dir/secondary.json');
+      expect(requestedUris).to.not.include('file:///schemas/secondary.json');
       expect(requestedUris).to.not.include('https://example.com/schemas/secondary.json');
+    });
+
+    it('should fallback to remote $id target for absolute $ref when mapped local target is missing', async () => {
+      const content = `# yaml-language-server: $schema=file:///dir/primary.json\nname: John\nage: -1`;
+      const yamlDock = parse(content);
+
+      const primarySchema = {
+        $id: 'https://example.com/schemas/primary.json',
+        $ref: '/schemas/secondary.json',
+      };
+      const secondarySchema = {
+        $id: 'https://example.com/schemas/secondary.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer', minimum: 0 },
+        },
+        required: ['name', 'age'],
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'file:///dir/primary.json') {
+          return Promise.resolve(JSON.stringify(primarySchema));
+        }
+        if (uri === 'https://example.com/schemas/secondary.json') {
+          return Promise.resolve(JSON.stringify(secondarySchema));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.include('file:///dir/primary.json');
+      expect(requestedUris).to.include('file:///dir/secondary.json');
+      expect(requestedUris).to.include('https://example.com/schemas/secondary.json');
+      expect(requestedUris).to.not.include('file:///schemas/secondary.json');
+      expect(requestedUris.indexOf('file:///dir/secondary.json')).to.be.lessThan(
+        requestedUris.indexOf('https://example.com/schemas/secondary.json')
+      );
     });
 
     it('should reload local schema after local file change when resolving via local sibling path instead of remote $id', async () => {

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as path from 'path';
+import * as url from 'url';
 import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import { parse } from '../src/languageservice/parser/yamlParser07';
 import { SettingsState } from '../src/yamlSettings';
@@ -13,6 +14,11 @@ import { KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
 
 const expect = chai.expect;
 chai.use(sinonChai);
+const workspaceContext = {
+  resolveRelativePath: (relativePath: string, resource: string) => {
+    return url.resolve(resource, relativePath);
+  },
+};
 
 describe('YAML Schema Service', () => {
   const sandbox = sinon.createSandbox();
@@ -119,6 +125,43 @@ describe('YAML Schema Service', () => {
       }
 
       expect(schema.schema.type).eqls('array');
+    });
+
+    it('should use local sibling schema path before remote $id ref', async () => {
+      const content = `# yaml-language-server: $schema=file:///schemas/primary.json\nmode: stage`;
+      const yamlDock = parse(content);
+
+      const primarySchema = {
+        $id: 'https://example.com/schemas/primary.json',
+        type: 'object',
+        properties: {
+          mode: { $ref: 'secondary.json' },
+        },
+        required: ['mode'],
+      };
+      const secondarySchema = {
+        $id: 'https://example.com/schemas/secondary.json',
+        type: 'string',
+        enum: ['dev', 'prod'],
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'file:///schemas/primary.json') {
+          return Promise.resolve(JSON.stringify(primarySchema));
+        }
+        if (uri === 'file:///schemas/secondary.json') {
+          return Promise.resolve(JSON.stringify(secondarySchema));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.include('file:///schemas/primary.json');
+      expect(requestedUris).to.include('file:///schemas/secondary.json');
+      expect(requestedUris).to.not.include('https://example.com/schemas/secondary.json');
     });
 
     it('should handle modeline schema comment in the middle of file', () => {


### PR DESCRIPTION
### What does this PR do?
Resolves relative `$ref` using local sibling schema path before remote `$id` ref

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1184

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Manually and with automated tests.
```json
{
  "$id": "https://example.com/schemas/primary.json",
  "type": "object",
  "properties": {
    "mode": {
      "$ref": "secondary.json"
    }
  },
  "required": ["mode"],
  "additionalProperties": false
}
```
```json
{
  "$id": "https://example.com/schemas/secondary.json",
  "type": "string",
  "enum": ["dev", "prod"]
}
```
```yaml
# yaml-language-server: $schema=./primary.json
mode: stage
# expect 'Value is not accepted. Valid values: "dev", "prod".' instead of 'Unable to load ...'
```