### PR TITLE
Add support for $schema: shorthand format in modeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ or absolute path:
 # yaml-language-server: $schema=/absolute/path/to/schema
 ```
 
+or IntelliJ compatible format:
+
+```yaml
+# $schema: <urlOrPathToTheSchema>
+```
+
 ### Schema priority
 
 The following is the priority of schema association in highest to lowest priority:

--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -17,14 +17,14 @@ export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): s
       return isModeline(lineComment);
     });
     if (yamlLanguageServerModeline != undefined) {
-      const schemaMatchs = yamlLanguageServerModeline.match(/\$schema=\S+/g);
+      const schemaMatchs = yamlLanguageServerModeline.match(/\$schema(?:=|:\s*)(\S+)/);
       if (schemaMatchs !== null && schemaMatchs.length >= 1) {
         if (schemaMatchs.length >= 2) {
           console.log(
             'Several $schema attributes have been found on the yaml-language-server modeline. The first one will be picked.'
           );
         }
-        return schemaMatchs[0].substring('$schema='.length);
+        return schemaMatchs[1];
       }
     }
   }
@@ -32,6 +32,6 @@ export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): s
 }
 
 export function isModeline(lineText: string): boolean {
-  const matchModeline = lineText.match(/^#\s+yaml-language-server\s*:/g);
+  const matchModeline = lineText.match(/^#\s+(?:yaml-language-server\s*:|\$schema:)/g);
   return matchModeline !== null && matchModeline.length === 1;
 }

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -336,21 +336,24 @@ export class YamlCompletion {
       }
 
       if (isModeline(lineContent) || isInComment(doc.tokens, offset)) {
-        const schemaIndex = lineContent.indexOf('$schema=');
-        if (schemaIndex !== -1 && schemaIndex + '$schema='.length <= position.character) {
-          this.schemaService.getAllSchemas().forEach((schema) => {
-            const schemaIdCompletion: CompletionItem = {
-              kind: CompletionItemKind.Constant,
-              label: schema.name ?? schema.uri,
-              detail: schema.description,
-              insertText: schema.uri,
-              insertTextFormat: InsertTextFormat.PlainText,
-              insertTextMode: InsertTextMode.asIs,
-            };
-            result.items.push(schemaIdCompletion);
-          });
+        const schemaMatch = lineContent.match(/\$schema[=:]/);
+        if (schemaMatch) {
+          const schemaIndex = schemaMatch.index;
+          if (schemaIndex + schemaMatch[0].length <= position.character) {
+            this.schemaService.getAllSchemas().forEach((schema) => {
+              const schemaIdCompletion: CompletionItem = {
+                kind: CompletionItemKind.Constant,
+                label: schema.name ?? schema.uri,
+                detail: schema.description,
+                insertText: schema.uri,
+                insertTextFormat: InsertTextFormat.PlainText,
+                insertTextMode: InsertTextMode.asIs,
+              };
+              result.items.push(schemaIdCompletion);
+            });
+          }
+          return result;
         }
-        return result;
       }
 
       if (!schema || schema.errors.length) {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2022,6 +2022,16 @@ describe('Auto Completion Tests', () => {
         .then(done, done);
     });
 
+    it('Provide completion from schema declared in file with $schema: format', (done) => {
+      const content = `# $schema: ${uri}\n- `;
+      const completion = parseSetup(content, content.length);
+      completion
+        .then(function (result) {
+          assert.equal(result.items.length, 3);
+        })
+        .then(done, done);
+    });
+
     it('Provide completion from schema declared in file with several attributes', (done) => {
       const content = `# yaml-language-server: $schema=${uri} anothermodeline=value\n- `;
       const completion = parseSetup(content, content.length);


### PR DESCRIPTION
### What does this PR do?

Adds `# $schema: <url>` modeline format support as used by IntelliJ IDEs.
Cf. https://www.jetbrains.com/help/idea/yaml.html#use-schema-keyword

### What issues does this PR fix or reference?

Fixes #950

### Is it tested? How?

I duplicated an existing test case and replaced its content to use `# $schema: ${uri}\n- `.
Tests with `npm test` pass.

I also tested the modified build on one of my project with a custom Helix config to use it:
- `.helix/languages.toml`
```toml
[language-server]
yaml-language-server = { command = "node", args = ["/Users/nicolas/Developer/github.com/redhat-developer/yaml-language-server/out/server/src/server.js", "--stdio"] }
```
- `templates/run.yml` (this is a GitLab CI component)
```yaml
# $schema: https://gitlab.com/gitlab-org/gitlab/-/raw/master/app/assets/javascripts/editor/schema/ci.json
spec:
  inputs:
    [...]
```
Showing documentation on cursor (`<Space> k`) works, validation works, completion works.
