### PR TITLE
Handle default booleans and integers properly in required properties completion

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -1164,8 +1164,8 @@ export class YamlCompletion {
           case 'number':
           case 'integer':
           case 'anyOf': {
-            let value = propertySchema.default || propertySchema.const;
-            if (value) {
+            let value = propertySchema.default !== undefined ? propertySchema.default : propertySchema.const;
+            if (value !== undefined) {
               if (type === 'string') {
                 value = toYamlStringScalar(value);
               }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -3185,6 +3185,43 @@ describe('Auto Completion Tests', () => {
         })
       );
     });
+    it('object completion with default boolean and default integer', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          env: {
+            type: 'object',
+            properties: {
+              val: {
+                type: 'boolean',
+                default: false,
+              },
+            },
+            required: ['val'],
+          },
+          salad: {
+            type: 'integer',
+            default: 0,
+          },
+        },
+        required: ['env', 'salad'],
+      });
+
+      const content = '';
+      const result = await parseSetup(content, 0);
+
+      assert.equal(result.items.length, 3);
+      assert.deepEqual(
+        result.items[1],
+        createExpectedCompletion('object', 'env:\n  val: ${1:false}\nsalad: 0', 0, 0, 0, 0, 7, 2, {
+          sortText: '_object',
+          documentation: {
+            kind: 'markdown',
+            value: '```yaml\nenv:\n  val: false\nsalad: 0\n```',
+          },
+        })
+      );
+    });
     describe('Select parent skeleton first', () => {
       beforeEach(() => {
         const languageSettingsSetup = new ServiceSetup().withCompletion();


### PR DESCRIPTION
### What does this PR do?
Before, default values that were falsey would complete to the empty string (specifically when using the complete all required properties feature; single property completion was already working). Now, they should complete to the correct string value.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1205

### Is it tested? How?
New unit test