### PR TITLE
Remove annoying log output related to modelines

### DIFF
--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -17,14 +17,9 @@ export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): s
       return isModeline(lineComment);
     });
     if (yamlLanguageServerModeline != undefined) {
-      const schemaMatchs = yamlLanguageServerModeline.match(/\$schema(?:=|:\s*)(\S+)/);
-      if (schemaMatchs !== null && schemaMatchs.length >= 1) {
-        if (schemaMatchs.length >= 2) {
-          console.log(
-            'Several $schema attributes have been found on the yaml-language-server modeline. The first one will be picked.'
-          );
-        }
-        return schemaMatchs[1];
+      const schemaMatches = yamlLanguageServerModeline.match(/\$schema(?:=|:\s*)(\S+)/);
+      if (schemaMatches !== null && schemaMatches.length === 2) {
+        return schemaMatches[1];
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?
Currently, a log entry is emitted whenever a modeline comment is parsed. This is because, in https://github.com/redhat-developer/yaml-language-server/pull/1193, the logic for how modelines were parsed was changed. On this line: https://github.com/redhat-developer/yaml-language-server/pull/1193/changes#diff-dc843f2ff5a3d197853464e616d6e413820becbc82e0e9a3aa6fc6d996976bb2L21 there is always 2 entries if a parsable modeline is present. This is because the index 0 entry contains the entire match, and the index 1 entry contains the group match (that contains the URI of the schema). This means that the `console.log()` will always run, incorrectly alerting the user that they tried to specify two schemas in the modeline.

Even if the message were accurate, I don't think logging is the best way to alert the user to this problem.
This should ideally be a warning or error instead. For now, I'm removing the `console.log()` entirely to address this.

### What issues does this PR fix or reference?
Fixes #1211

### Is it tested? How?
Manually