### PR TITLE
Update Kubernetes schema to 1.33

### DIFF
--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -6,7 +6,7 @@ import { isBoolean } from './objects';
 import { isRelativePath, relativeToAbsolutePath } from './paths';
 
 export const KUBERNETES_SCHEMA_URL =
-  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json';
+  'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.9-standalone-strict/all.json';
 export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';
 export const CRD_CATALOG_URL = 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main';
 

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -28,7 +28,7 @@ describe('Auto Completion Fix Tests', () => {
   let schemaProvider: TestCustomSchemaProvider;
   before(() => {
     languageSettingsSetup = new ServiceSetup().withCompletion().withSchemaFileMatch({
-      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json',
+      uri: 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.9-standalone-strict/all.json',
       fileMatch: [SCHEMA_ID],
     });
     const {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -18,7 +18,7 @@ describe('Kubernetes Integration Tests', () => {
   let yamlSettings: SettingsState;
 
   before(() => {
-    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1-standalone-strict/all.json';
+    const uri = 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.33.9-standalone-strict/all.json';
     const fileMatch = ['*.yml', '*.yaml'];
     languageSettingsSetup = new ServiceSetup()
       .withHover()


### PR DESCRIPTION
### What does this PR do?
The oldest supported Kubernetes version is 1.33, so I've updated the referenced schema to 1.33.

### What issues does this PR fix or reference?


### Is it tested? How?
uhhhh
