### PR TITLE
docs: Add yaml-schema-lint CLI to the Clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ This repository only contains the server implementation. Here are some known cli
 - [nova-yaml](https://github.com/robb-j/nova-yaml/) for Nova
 - [volar-service-yaml](https://github.com/volarjs/services/tree/master/packages/yaml) for Volar
 - [Kate](https://kate-editor.org/)
-- [yaml-schema-lint] A CLI for schema linting yaml files
+- [yaml-schema-lint](https://github.com/X-Guardian/yaml-schema-lint) A CLI for schema linting yaml files
 
 ## Developer Support
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ This repository only contains the server implementation. Here are some known cli
 - [nova-yaml](https://github.com/robb-j/nova-yaml/) for Nova
 - [volar-service-yaml](https://github.com/volarjs/services/tree/master/packages/yaml) for Volar
 - [Kate](https://kate-editor.org/)
+- [yaml-schema-lint] A CLI for schema linting yaml files
 
 ## Developer Support
 


### PR DESCRIPTION
### What does this PR do?

I have created a CLI that uses the `yaml-language-server` to lint yaml files. This PR adds the CLI to the Clients list.

### Details

- Repository: https://github.com/X-Guardian/yaml-schema-lint
- NPM Package: https://www.npmjs.com/package/yaml-schema-lint
- GitHub Action: https://github.com/marketplace/actions/yaml-schema-lint