### PR TITLE
Fix to preserve markdown description on $ref siblings

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -75,6 +75,7 @@ const REF_SIBLING_NONCONSTRAINT_KEYS = new Set([
   '$comment',
   'title',
   'description',
+  'markdownDescription',
   '$vocabulary',
   'examples',
   'default',

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -945,6 +945,39 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
         `Yaml Language Server (https://github.com/redhat-developer/yaml-language-server)\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       );
     });
+
+    it('Hover prefers markdownDescription for $ref siblings', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            title: 'foo title',
+            description: 'foo desc',
+            markdownDescription: 'foo md desc **bold** \n * line \n* another \n\n',
+          },
+          bar: {
+            $ref: '#/$defs/veggie',
+            title: 'bar title',
+            description: 'bar desc',
+            markdownDescription: 'bar md desc **bold** \n * line \n* another \n\n',
+          },
+        },
+        $defs: {
+          veggie: {
+            type: 'string',
+            enum: ['potato', 'carrot'],
+          },
+        },
+      });
+      const hover = await parseSetup('b|a|r: potato');
+      assert.strictEqual(MarkupContent.is(hover.contents), true);
+      assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
+      assert.ok((hover.contents as MarkupContent).value.includes('bar md desc **bold**'));
+      assert.ok((hover.contents as MarkupContent).value.includes('* another'));
+      assert.ok(!(hover.contents as MarkupContent).value.includes('bar desc'));
+    });
   });
 
   describe('Hover on anyOf', () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -219,6 +219,52 @@ describe('JSON Schema', () => {
       );
   });
 
+  it('Preserves markdownDescription on $ref siblings', function (testDone) {
+    const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+    service.setSchemaContributions({
+      schemas: {
+        'https://myschemastore/main/schema.json': {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          id: 'https://myschemastore/main/schema.json',
+          type: 'object',
+          properties: {
+            bar: {
+              $ref: '#/$defs/veggie',
+              title: 'bar title',
+              description: 'bar desc',
+              markdownDescription: 'bar md desc **bold** \n * line \n* another \n\n',
+            },
+          },
+          $defs: {
+            veggie: {
+              type: 'string',
+              enum: ['potato', 'carrot'],
+            },
+          },
+        },
+      },
+    });
+
+    service
+      .getResolvedSchema('https://myschemastore/main/schema.json')
+      .then((resolvedSchema) => {
+        assert.strictEqual(resolvedSchema.schema.properties['bar'].description, 'bar desc');
+        assert.strictEqual(
+          resolvedSchema.schema.properties['bar'].markdownDescription,
+          'bar md desc **bold** \n * line \n* another \n\n'
+        );
+        assert.deepStrictEqual(resolvedSchema.schema.properties['bar'].enum, ['potato', 'carrot']);
+      })
+      .then(
+        () => {
+          return testDone();
+        },
+        (error) => {
+          testDone(error);
+        }
+      );
+  });
+
   describe('Compound Schema Documents', () => {
     let validationHandler: ValidationHandler;
     let yamlSettings: SettingsState;


### PR DESCRIPTION
### What does this PR do?
Fix to preserve markdown description on $ref siblings

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1223

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
New automated tests + manually with the example in https://github.com/redhat-developer/vscode-yaml/issues/1223