### PR TITLE
Fix "Open Schema" CodeLens for schemas with URI without `//`

### DIFF
--- a/src/languageservice/services/yamlCommands.ts
+++ b/src/languageservice/services/yamlCommands.ts
@@ -15,7 +15,7 @@ export function registerCommands(commandExecutor: CommandExecutor, connection: C
     }
     const wsFolders = await connection.workspace.getWorkspaceFolders();
 
-    if (uri.indexOf('://') < 0 && !uri.startsWith('/')) {
+    if (uri.indexOf(':') < 0 && !uri.startsWith('/')) {
       if (wsFolders.length === 1) {
         const wsUri = URI.parse(wsFolders[0].uri);
         uri = wsUri.with({ path: wsUri.path + uri }).toString();


### PR DESCRIPTION
### What does this PR do?
In the "Open file from CodeLens" logic, there's a check for `://` in an attempt to differentiate relative paths and URIs. I didn't realize that the `//` after the colon isn't a requirement for a URI, only the colon.

### What issues does this PR fix or reference?
Fixes redhat-developer/vscode-yaml#1220

### Is it tested? How?
Manually (created the example extension, tested against that)
