### PR TITLE
Fix absolute-path `$ref` resolution for schemas without a top-level `$id`

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -505,6 +505,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       if (!refUri.startsWith('/')) return resolvedAgainstParent;
       const parentResource = resourceIndexByUri.get(parentSchemaURL)?.root;
       const parentResourceId = parentResource?.$id || parentResource?.id;
+      if (!parentResourceId) return resolvedAgainstParent;
       const resolvedParentId = _resolveAgainstBase(parentSchemaURL, parentResourceId);
       if (!resolvedParentId.startsWith('http://') && !resolvedParentId.startsWith('https://')) return resolvedAgainstParent;
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -219,6 +219,47 @@ describe('JSON Schema', () => {
       );
   });
 
+  it('Resolving absolute-path $refs without top-level id', function (testDone) {
+    const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+    service.setSchemaContributions({
+      schemas: {
+        'file:///main/schema.yaml': {
+          type: 'object',
+          properties: {
+            name: {
+              $ref: '/main/schema2.yaml',
+            },
+          },
+        },
+        'file:///main/schema2.yaml': {
+          type: 'string',
+          description: 'Something.',
+        },
+      },
+    });
+
+    service
+      .getResolvedSchema('file:///main/schema.yaml')
+      .then((fs) => {
+        assert.deepEqual(fs.errors, []);
+        assert.deepEqual(fs.schema.properties['name'], {
+          type: 'string',
+          description: 'Something.',
+          _$ref: '/main/schema2.yaml',
+          _baseUrl: 'file:///main/schema2.yaml',
+          url: 'file:///main/schema2.yaml',
+        });
+      })
+      .then(
+        () => {
+          return testDone();
+        },
+        (error) => {
+          testDone(error);
+        }
+      );
+  });
+
   it('Preserves markdownDescription on $ref siblings', function (testDone) {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -223,31 +223,34 @@ describe('JSON Schema', () => {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
-        'file:///main/schema.yaml': {
+        'file:///main/schema.json': {
           type: 'object',
           properties: {
             name: {
-              $ref: '/main/schema2.yaml',
+              $ref: '/main/schema2.json',
             },
           },
+          required: ['name'],
         },
-        'file:///main/schema2.yaml': {
+        'file:///main/schema2.json': {
           type: 'string',
-          description: 'Something.',
+          enum: ['alice', 'bob'],
+          description: 'Allowed names.',
         },
       },
     });
 
     service
-      .getResolvedSchema('file:///main/schema.yaml')
+      .getResolvedSchema('file:///main/schema.json')
       .then((fs) => {
         assert.deepEqual(fs.errors, []);
         assert.deepEqual(fs.schema.properties['name'], {
           type: 'string',
-          description: 'Something.',
-          _$ref: '/main/schema2.yaml',
-          _baseUrl: 'file:///main/schema2.yaml',
-          url: 'file:///main/schema2.yaml',
+          enum: ['alice', 'bob'],
+          description: 'Allowed names.',
+          _$ref: '/main/schema2.json',
+          _baseUrl: 'file:///main/schema2.json',
+          url: 'file:///main/schema2.json',
         });
       })
       .then(


### PR DESCRIPTION
### What does this PR do?
For schemas without a top-level `$id`, absolute-path `$ref` failed to resolve in v1.20.0 and v1.21.0.
This PR fixes the issue.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1227

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated test
- [x] Test manually