### PR TITLE
fix: skip local sibling probe for non-file:// schemas

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -350,6 +350,9 @@ export class YAMLSchemaService extends JSONSchemaService {
     const _preferLocalBaseForRemoteId = async (currentBase: string, id: string): Promise<string> => {
       try {
         const currentBaseUri = URI.parse(currentBase);
+        if (currentBaseUri.scheme !== 'file') {
+          return _resolveAgainstBase(currentBase, id);
+        }
         const idUri = URI.parse(id);
         const localFileName = path.posix.basename(idUri.path);
         const localDir = path.posix.dirname(currentBaseUri.path);

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -406,6 +406,51 @@ describe('YAML Schema Service', () => {
       expect(requestedSecondaryUrisAfterChange).to.have.length(2);
     });
 
+    it('should not probe local sibling paths when schema is loaded from https://', async () => {
+      const content = `# yaml-language-server: $schema=https://example.com/schemas/openapi-extensions.json\nopenapi: '3.1.0'\ninfo:\n  title: Test\n  version: '1.0'`;
+      const yamlDock = parse(content);
+
+      const extensionsSchema = {
+        $id: 'https://example.com/schemas/openapi-extensions.json',
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        allOf: [{ $ref: './openapi.v3.1.json' }],
+      };
+      const openapiSchema = {
+        $id: 'https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.1/schema.json',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          openapi: { type: 'string', pattern: '^3\\.1\\.\\d+(-.+)?$' },
+          info: {
+            type: 'object',
+            properties: { title: { type: 'string' }, version: { type: 'string' } },
+            required: ['title', 'version'],
+          },
+        },
+        required: ['openapi', 'info'],
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'https://example.com/schemas/openapi-extensions.json') {
+          return Promise.resolve(JSON.stringify(extensionsSchema));
+        }
+        if (uri === 'https://example.com/schemas/openapi.v3.1.json') {
+          return Promise.resolve(JSON.stringify(openapiSchema));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.include('https://example.com/schemas/openapi-extensions.json');
+      expect(requestedUris).to.include('https://example.com/schemas/openapi.v3.1.json');
+      // _preferLocalBaseForRemoteId should NOT probe for the $id basename as a local sibling
+      // when the parent schema was loaded from https:// (not file://)
+      expect(requestedUris).to.not.include('https://example.com/schemas/schema.json');
+    });
+
     it('should handle modeline schema comment in the middle of file', () => {
       const documentContent = `foo:\n  bar\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
       const content = `${documentContent}`;


### PR DESCRIPTION
## Summary

- `_preferLocalBaseForRemoteId` in `yamlSchemaService.ts` unconditionally probes for local sibling files by extracting the basename from a sub-schema's `$id` and resolving it relative to the parent schema's load location. When schemas are loaded from `https://` (e.g. via a VS Code YAML extension contributor), this generates spurious HTTP requests that fail with 404 errors.
- Added a `file://` scheme guard so the local sibling optimization only fires for local file schemas, matching the existing guard in the companion function `_resolveLocalSiblingFromRemoteUri`.
- Added a test that reproduces the issue: an `https://`-loaded schema with a sub-schema whose `$id` basename differs from the actual filename.

## Problem

When a schema contributor serves schemas from a remote host (e.g. `https://git.some-company.com/.../openapi/adsk.openapi.extensions.yaml`), the YAML language server resolves `$ref`s to sub-schemas like `openapi.v3.1.yaml`. That sub-schema has:

```yaml
$id: https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.1/schema.yaml
```

`_preferLocalBaseForRemoteId` extracts `schema.yaml` from this `$id` and probes `https://git.some-company.com/.../openapi/schema.yaml` — a file that doesn't exist. The same happens with `swagger.v2.0.json` (whose `id` is `http://swagger.io/v2/schema.json#`), producing a probe for `.../openapi/schema.json`.

These probes are harmless (the function falls back correctly), but they generate noisy error logs and waste network round-trips through the contributor's content handler.

## Fix

The companion function `_resolveLocalSiblingFromRemoteUri` already has a scheme guard:
```typescript
if (parentUri.scheme !== 'file') return undefined;
```

The same guard is now applied to `_preferLocalBaseForRemoteId`: if the current base URI is not `file://`, skip the local sibling probe entirely and fall through to standard `$id` resolution.

## Test plan

- [x] New test `should not probe local sibling paths when schema is loaded from https://` — fails before fix, passes after
- [x] Full test suite passes (1286 passing, 0 failing)

Made with [Cursor](https://cursor.com)