### PR TITLE
Fix schema resolution when `$id` base URI differs from the loaded schema URI

### DIFF
--- a/src/languageservice/jsonSchema.ts
+++ b/src/languageservice/jsonSchema.ts
@@ -17,7 +17,8 @@ export enum SchemaDialect {
 export interface JSONSchema {
   // for internal use
   _dialect?: SchemaDialect;
-  _baseUrl?: string;
+  _baseUri?: string;
+  _sourceUri?: string;
   _$ref?: string;
 
   id?: string;

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -63,7 +63,8 @@ const REF_SIBLING_NONCONSTRAINT_KEYS = new Set([
   '$schema',
   '$id',
   'id',
-  '_baseUrl',
+  '_baseUri',
+  '_sourceUri',
   '_dialect',
   '$anchor',
   '$dynamicAnchor',
@@ -216,8 +217,13 @@ export class YAMLSchemaService extends JSONSchemaService {
       return new ResolvedSchema({}, resolveErrors);
     }
 
+    const _setSourceUri = (node: JSONSchema, sourceUri: string | undefined): void => {
+      if (!node || typeof node !== 'object' || !sourceUri) return;
+      node._sourceUri = sourceUri;
+    };
+
     const _cloneSchema = (
-      value: unknown,
+      value: JSONSchema,
       seen: Map<object, unknown>,
       stopCondition?: (val: unknown, seenSize: number) => unknown | undefined
     ): unknown => {
@@ -243,11 +249,12 @@ export class YAMLSchemaService extends JSONSchemaService {
       }
 
       // clone objects
-      const result = {};
+      const result: JSONSchema = {};
       seen.set(value, result);
       for (const prop in value) {
         result[prop] = _cloneSchema(value[prop], seen, stopCondition);
       }
+      _setSourceUri(result, value._sourceUri);
       return result;
     };
 
@@ -331,7 +338,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         if (!entryItem.dynamic) continue;
 
         const current = result?.get(name) ?? [];
-        if (current.some((existing) => existing._baseUrl === resourceUri)) continue;
+        if (current.some((existing) => existing._baseUri === resourceUri)) continue;
 
         // clone map on first modification
         if (result === scope) result = scope ? new Map(scope) : new Map<string, JSONSchema[]>();
@@ -347,28 +354,9 @@ export class YAMLSchemaService extends JSONSchemaService {
       return this.normalizeId(ref);
     };
 
-    const _preferLocalBaseForRemoteId = async (currentBase: string, id: string): Promise<string> => {
-      try {
-        const currentBaseUri = URI.parse(currentBase);
-        if (currentBaseUri.scheme !== 'file') {
-          return _resolveAgainstBase(currentBase, id);
-        }
-        const idUri = URI.parse(id);
-        const localFileName = path.posix.basename(idUri.path);
-        const localDir = path.posix.dirname(currentBaseUri.path);
-        const localPath = path.posix.join(localDir, localFileName);
-        const localUriStr = currentBaseUri.with({ path: localPath, query: idUri.query, fragment: idUri.fragment }).toString();
-        if (localUriStr === currentBase) return localUriStr;
-        const content = await this.requestService(localUriStr);
-        return content ? localUriStr : _resolveAgainstBase(currentBase, id);
-      } catch {
-        return _resolveAgainstBase(currentBase, id);
-      }
-    };
-
     const _indexSchemaResources = async (root: JSONSchema, initialBaseUri: string): Promise<void> => {
-      type WorkItem = { node: JSONSchema; baseUri: string };
-      const preOrderStack: WorkItem[] = [{ node: root, baseUri: initialBaseUri }];
+      type WorkItem = { node: JSONSchema; baseUri: string; sourceUri: string };
+      const preOrderStack: WorkItem[] = [{ node: root, baseUri: initialBaseUri, sourceUri: initialBaseUri }];
       const postOrderStack: JSONSchema[] = [];
       const childListByNode = new WeakMap<JSONSchema, JSONSchema[]>();
 
@@ -382,19 +370,20 @@ export class YAMLSchemaService extends JSONSchemaService {
         seen.add(node);
 
         let baseUri = current.baseUri;
+        _setSourceUri(node, current.sourceUri);
         const id = node.$id || node.id;
         if (id) {
-          const preferredBaseUri = await _preferLocalBaseForRemoteId(baseUri, id);
-          node._baseUrl = preferredBaseUri;
-          const hashIndex = preferredBaseUri.indexOf('#');
-          if (hashIndex !== -1 && hashIndex < preferredBaseUri.length - 1) {
+          const resolvedBaseUri = _resolveAgainstBase(baseUri, id);
+          node._baseUri = resolvedBaseUri;
+          const hashIndex = resolvedBaseUri.indexOf('#');
+          if (hashIndex !== -1 && hashIndex < resolvedBaseUri.length - 1) {
             // Draft-07 and earlier: $id with fragment defines a plain-name anchor scoped to the resolved base
-            const frag = preferredBaseUri.slice(hashIndex + 1);
+            const frag = resolvedBaseUri.slice(hashIndex + 1);
             _getResourceIndex(baseUri).fragments.set(frag, { node });
           } else {
             // $id without fragment creates a new embedded resource scope
-            baseUri = preferredBaseUri;
-            const entry = _getResourceIndex(preferredBaseUri);
+            baseUri = resolvedBaseUri;
+            const entry = _getResourceIndex(resolvedBaseUri);
             if (!entry.root) {
               entry.root = node;
             }
@@ -406,7 +395,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         }
         // Draft 2020-12+: $dynamicAnchor keyword
         if (node.$dynamicAnchor) {
-          node._baseUrl = baseUri;
+          node._baseUri = baseUri;
           _getResourceIndex(baseUri).fragments.set(node.$dynamicAnchor, { node, dynamic: true });
         }
 
@@ -417,7 +406,7 @@ export class YAMLSchemaService extends JSONSchemaService {
         this.collectSchemaNodes(
           (entry) => {
             children.push(entry);
-            preOrderStack.push({ node: entry, baseUri });
+            preOrderStack.push({ node: entry, baseUri, sourceUri: current.sourceUri });
           },
           node.not,
           node.if,
@@ -497,6 +486,7 @@ export class YAMLSchemaService extends JSONSchemaService {
             target[key] = source[key];
           }
         }
+        _setSourceUri(target, source._sourceUri);
         return;
       } else {
         resolveErrors.push(l10n.t("$ref '{0}' in '{1}' cannot be resolved.", refPath, sourceURI));
@@ -537,7 +527,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       uri: string,
       linkPath: string,
       parentSchemaURL: string,
-      fallbackBaseURL: string,
+      parentSchemaSourceUri: string,
       parentSchemaDependencies: SchemaDependencies,
       resolutionStack: Set<string>,
       recursiveAnchorBase: string,
@@ -558,7 +548,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       ): Promise<any> => {
         parentSchemaDependencies[schemaUri] = true;
         _merge(node, schemaRoot, schemaUri, linkPath, !!inheritedDynamicScope || !!recursiveAnchorBase);
-        if (!recursiveAnchorBase || !node._baseUrl) node._baseUrl = schemaUri;
+        if (!recursiveAnchorBase || !node._baseUri) node._baseUri = schemaUri;
         node.url = schemaUri;
 
         const nextStack = new Set(resolutionStack);
@@ -623,8 +613,8 @@ export class YAMLSchemaService extends JSONSchemaService {
       };
 
       const resolvedUri = _resolveRefUri(parentSchemaURL, uri);
-      const hasEmbeddedTarget = !!resourceIndexByUri.get(resolvedUri)?.root;
-      const localSiblingUri = hasEmbeddedTarget ? undefined : _resolveLocalSiblingFromRemoteUri(fallbackBaseURL, resolvedUri);
+      const embeddedTarget = resourceIndexByUri.get(resolvedUri)?.root;
+      const localSiblingUri = embeddedTarget ? undefined : _resolveLocalSiblingFromRemoteUri(parentSchemaSourceUri, resolvedUri);
       const targetUris = localSiblingUri && localSiblingUri !== resolvedUri ? [localSiblingUri, resolvedUri] : [resolvedUri];
       return _resolveByUri(targetUris);
     };
@@ -646,44 +636,45 @@ export class YAMLSchemaService extends JSONSchemaService {
       // track nodes with their base URL for $id resolution
       type WalkItem = {
         node: JSONSchema;
-        baseURL?: string;
-        fallbackBaseURL?: string;
+        baseUri?: string;
+        sourceUri?: string;
         dialect?: SchemaDialect;
         recursiveAnchorBase?: string;
         inheritedDynamicScope?: Map<string, JSONSchema[]>;
         siblingRefCycleKeys?: Set<string>;
       };
       const toWalk: WalkItem[] = [
-        { node, baseURL: parentSchemaURL, fallbackBaseURL: parentSchemaURL, recursiveAnchorBase, inheritedDynamicScope },
+        {
+          node,
+          baseUri: parentSchemaURL,
+          sourceUri: node._sourceUri ?? parentSchemaURL,
+          recursiveAnchorBase,
+          inheritedDynamicScope,
+        },
       ];
       const seen = new WeakSet<JSONSchema>(); // prevents re-walking the same schema object graph
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const openPromises: Promise<any>[] = [];
 
-      const _getChildFallbackBaseURL = (entry: JSONSchema, currentFallbackBaseURL: string): string => {
-        const resourceUri = entry?._baseUrl;
-        return resourceUri && resourceIndexByUri.get(resourceUri)?.root === entry ? resourceUri : currentFallbackBaseURL;
-      };
-
       // handle $ref with siblings based on dialect
       const _handleRef = (
         next: JSONSchema,
-        nodeBaseURL: string,
-        fallbackBaseURL: string,
+        nodeBaseUri: string,
+        nodeSourceUri: string,
         nodeDialect: SchemaDialect,
         recursiveAnchorBase?: string,
         inheritedDynamicScope?: Map<string, JSONSchema[]>,
         siblingRefCycleKeys?: Set<string>
       ): void => {
-        const currentDynamicScope = _addResourceDynamicAnchors(inheritedDynamicScope, nodeBaseURL);
+        const currentDynamicScope = _addResourceDynamicAnchors(inheritedDynamicScope, nodeBaseUri);
 
         this.collectSchemaNodes(
           (entry) =>
             toWalk.push({
               node: entry,
-              baseURL: nodeBaseURL,
-              fallbackBaseURL: _getChildFallbackBaseURL(entry, fallbackBaseURL),
+              baseUri: nodeBaseUri,
+              sourceUri: nodeSourceUri,
               recursiveAnchorBase,
               inheritedDynamicScope: currentDynamicScope,
             }),
@@ -757,7 +748,7 @@ export class YAMLSchemaService extends JSONSchemaService {
           const segments = ref.split('#', 2);
           const baseUri = segments[0];
           const frag = segments.length > 1 ? segments[1] : '';
-          const resolvedRefKey = `${baseUri ? _resolveAgainstBase(nodeBaseURL, baseUri) : nodeBaseURL}#${frag}`;
+          const resolvedRefKey = `${baseUri ? _resolveAgainstBase(nodeBaseUri, baseUri) : nodeBaseUri}#${frag}`;
 
           if (_hasRefSiblings(next)) {
             // Draft-07 and earlier: ignore siblings
@@ -779,8 +770,8 @@ export class YAMLSchemaService extends JSONSchemaService {
                     }
                     toWalk.push({
                       node: entry as JSONSchema,
-                      baseURL: nodeBaseURL,
-                      fallbackBaseURL: _getChildFallbackBaseURL(entry as JSONSchema, fallbackBaseURL),
+                      baseUri: nodeBaseUri,
+                      sourceUri: nodeSourceUri,
                       recursiveAnchorBase,
                       inheritedDynamicScope: currentDynamicScope,
                       siblingRefCycleKeys: nextSiblingRefCycleKeys,
@@ -798,11 +789,11 @@ export class YAMLSchemaService extends JSONSchemaService {
 
           // Draft-2019+: $recursiveRef
           if (isRecursiveRef && (ref === '#' || ref === '')) {
-            const targetRoot = resourceIndexByUri.get(nodeBaseURL)?.root;
-            const recursiveBase = targetRoot?.$recursiveAnchor && recursiveAnchorBase ? recursiveAnchorBase : nodeBaseURL;
+            const targetRoot = resourceIndexByUri.get(nodeBaseUri)?.root;
+            const recursiveBase = targetRoot?.$recursiveAnchor && recursiveAnchorBase ? recursiveAnchorBase : nodeBaseUri;
 
             if (recursiveBase.length > 0) {
-              if (resolutionStack?.has(recursiveBase) || recursiveBase === nodeBaseURL) {
+              if (resolutionStack?.has(recursiveBase) || recursiveBase === nodeBaseUri) {
                 const sourceRoot = resourceIndexByUri.get(recursiveBase)?.root ?? parentSchema;
                 if (!seenRefs.has(ref)) {
                   _merge(next, sourceRoot, recursiveBase, '', false);
@@ -815,8 +806,8 @@ export class YAMLSchemaService extends JSONSchemaService {
                   next,
                   recursiveBase,
                   '',
-                  nodeBaseURL,
-                  fallbackBaseURL,
+                  nodeBaseUri,
+                  nodeSourceUri,
                   parentSchemaDependencies,
                   resolutionStack,
                   recursiveAnchorBase,
@@ -830,13 +821,13 @@ export class YAMLSchemaService extends JSONSchemaService {
 
           // Draft-2020+: $dynamicRef
           else if (isDynamicRef) {
-            const targetResource = baseUri.length > 0 ? _resolveAgainstBase(nodeBaseURL, baseUri) : nodeBaseURL;
+            const targetResource = baseUri.length > 0 ? _resolveAgainstBase(nodeBaseUri, baseUri) : nodeBaseUri;
             const targetFragments = resourceIndexByUri.get(targetResource)?.fragments;
             const targetHasDynamicAnchor = frag.length > 0 && targetFragments?.get(frag)?.dynamic;
             const dynamicTarget = targetHasDynamicAnchor ? currentDynamicScope?.get(frag)?.[0] : undefined;
-            const resolveResource = dynamicTarget ? dynamicTarget._baseUrl : targetResource;
+            const resolveResource = dynamicTarget ? dynamicTarget._baseUri : targetResource;
 
-            if (dynamicTarget && (resolveResource === nodeBaseURL || resolutionStack.has(resolveResource))) {
+            if (dynamicTarget && (resolveResource === nodeBaseUri || resolutionStack.has(resolveResource))) {
               if (!seenRefs.has(ref)) {
                 _merge(next, dynamicTarget, resolveResource, '', false);
                 seenRefs.add(ref);
@@ -851,8 +842,8 @@ export class YAMLSchemaService extends JSONSchemaService {
                   next,
                   resolveResource,
                   frag,
-                  nodeBaseURL,
-                  fallbackBaseURL,
+                  nodeBaseUri,
+                  nodeSourceUri,
                   parentSchemaDependencies,
                   resolutionStack,
                   recursiveAnchorBase,
@@ -864,7 +855,7 @@ export class YAMLSchemaService extends JSONSchemaService {
           }
           // normal $ref with external baseUri
           else if (baseUri.length > 0) {
-            const resolvedBaseUri = _resolveAgainstBase(nodeBaseURL, baseUri);
+            const resolvedBaseUri = _resolveAgainstBase(nodeBaseUri, baseUri);
             if (_mergeIfResourceAlreadyInResolutionStack(ref, resolvedBaseUri, frag)) continue;
             // resolve relative to this node's base URL
             openPromises.push(
@@ -872,8 +863,8 @@ export class YAMLSchemaService extends JSONSchemaService {
                 next,
                 baseUri,
                 frag,
-                nodeBaseURL,
-                fallbackBaseURL,
+                nodeBaseUri,
+                nodeSourceUri,
                 parentSchemaDependencies,
                 resolutionStack,
                 recursiveAnchorBase,
@@ -885,7 +876,7 @@ export class YAMLSchemaService extends JSONSchemaService {
 
           // local $ref or $dynamicRef
           if (!seenRefs.has(ref)) {
-            _merge(next, parentSchema, nodeBaseURL, frag, isDynamicRef && !!currentDynamicScope);
+            _merge(next, parentSchema, nodeBaseUri, frag, isDynamicRef && !!currentDynamicScope);
             seenRefs.add(ref);
           }
         }
@@ -895,8 +886,8 @@ export class YAMLSchemaService extends JSONSchemaService {
           (entry) =>
             toWalk.push({
               node: entry,
-              baseURL: next._baseUrl || nodeBaseURL,
-              fallbackBaseURL: _getChildFallbackBaseURL(entry, fallbackBaseURL),
+              baseUri: next._baseUri || nodeBaseUri,
+              sourceUri: next._sourceUri || nodeSourceUri,
               dialect: nodeDialect,
               recursiveAnchorBase,
               inheritedDynamicScope: currentDynamicScope,
@@ -932,7 +923,7 @@ export class YAMLSchemaService extends JSONSchemaService {
             segments[0],
             segments[1],
             parentSchemaURL,
-            parentSchemaURL,
+            schema._sourceUri ?? parentSchemaURL,
             parentSchemaDependencies,
             resolutionStack,
             recursiveAnchorBase,
@@ -953,16 +944,16 @@ export class YAMLSchemaService extends JSONSchemaService {
       while (toWalk.length) {
         const item = toWalk.pop();
         const next = item.node;
-        const nodeBaseURL = next._baseUrl || item.baseURL;
-        const fallbackBaseURL = item.fallbackBaseURL || item.baseURL;
+        const nodeBaseUri = next._baseUri || item.baseUri;
+        const nodeSourceUri = next._sourceUri || nodeBaseUri;
         const nodeDialect = next._dialect || item.dialect;
-        const nodeRecursiveAnchorBase = item.recursiveAnchorBase ?? (next.$recursiveAnchor ? nodeBaseURL : undefined);
+        const nodeRecursiveAnchorBase = item.recursiveAnchorBase ?? (next.$recursiveAnchor ? nodeBaseUri : undefined);
         if (seen.has(next)) continue;
         seen.add(next);
         _handleRef(
           next,
-          nodeBaseURL,
-          fallbackBaseURL,
+          nodeBaseUri,
+          nodeSourceUri,
           nodeDialect,
           nodeRecursiveAnchorBase,
           item.inheritedDynamicScope,
@@ -973,7 +964,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     };
 
     const resolutionStack = new Set<string>(); // prevents $ref/$recursiveRef/$dynamicRef loops across schema URIs
-    const rootResource = schema._baseUrl || schemaURL;
+    const rootResource = schema._baseUri || schemaURL;
     if (rootResource) resolutionStack.add(rootResource);
     await resolveRefs(schema, schema, schemaURL, dependencies, resolutionStack);
     return new ResolvedSchema(schema, resolveErrors);

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -93,7 +93,8 @@ describe('JSON Schema', () => {
           description: 'Test description',
           _$ref: 'https://myschemastore/child',
           url: 'https://myschemastore/child',
-          _baseUrl: 'https://myschemastore/child',
+          _baseUri: 'https://myschemastore/child',
+          _sourceUri: 'https://myschemastore/child',
         });
       })
       .then(
@@ -139,8 +140,14 @@ describe('JSON Schema', () => {
         assert.deepEqual(fs.schema.properties['responseValue'], {
           type: 'object',
           required: ['$ref'],
-          properties: { $ref: { type: 'string' } },
+          properties: {
+            $ref: {
+              type: 'string',
+              _sourceUri: 'https://json.schemastore.org/swagger-2.0',
+            },
+          },
           _$ref: '#/definitions/jsonReference',
+          _sourceUri: 'https://json.schemastore.org/swagger-2.0',
         });
       })
       .then(
@@ -191,21 +198,24 @@ describe('JSON Schema', () => {
           type: 'string',
           enum: ['object'],
           _$ref: 'schema2.json#/definitions/hello',
-          _baseUrl: 'https://myschemastore/main/schema2.json',
+          _baseUri: 'https://myschemastore/main/schema2.json',
+          _sourceUri: 'https://myschemastore/main/schema2.json',
           url: 'https://myschemastore/main/schema2.json',
         });
         assert.deepEqual(fs.schema.properties['p2'], {
           type: 'string',
           enum: ['object'],
           _$ref: './schema2.json#/definitions/hello',
-          _baseUrl: 'https://myschemastore/main/schema2.json',
+          _baseUri: 'https://myschemastore/main/schema2.json',
+          _sourceUri: 'https://myschemastore/main/schema2.json',
           url: 'https://myschemastore/main/schema2.json',
         });
         assert.deepEqual(fs.schema.properties['p3'], {
           type: 'string',
           enum: ['object'],
           _$ref: '/main/schema2.json#/definitions/hello',
-          _baseUrl: 'https://myschemastore/main/schema2.json',
+          _baseUri: 'https://myschemastore/main/schema2.json',
+          _sourceUri: 'https://myschemastore/main/schema2.json',
           url: 'https://myschemastore/main/schema2.json',
         });
       })
@@ -249,7 +259,8 @@ describe('JSON Schema', () => {
           enum: ['alice', 'bob'],
           description: 'Allowed names.',
           _$ref: '/main/schema2.json',
-          _baseUrl: 'file:///main/schema2.json',
+          _baseUri: 'file:///main/schema2.json',
+          _sourceUri: 'file:///main/schema2.json',
           url: 'file:///main/schema2.json',
         });
       })
@@ -851,10 +862,12 @@ address:
     assert.deepEqual(fs.schema.properties['apiVersion'], {
       type: 'string',
       enum: ['v2', 'v3'],
+      _sourceUri: 'https://myschemastore/main/schema1.json',
     });
     assert.deepEqual(fs.schema.properties['kind'], {
       type: 'string',
       enum: ['Pod'],
+      _sourceUri: 'https://myschemastore/main/schema1.json',
     });
   });
 
@@ -894,6 +907,7 @@ address:
     assert.deepEqual(fs.schema.properties['kind'], {
       type: 'string',
       enum: ['Pod'],
+      _sourceUri: 'https://myschemastore/main/schema1.json',
     });
   });
 

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -2103,6 +2103,121 @@ pkg: 123
         expect(result).to.not.be.empty;
         expect(result.some((d) => /Problems loading reference/i.test(d.message) && /No content/i.test(d.message))).to.eq(true);
       });
+
+      it('root $id ending in the loaded schema filename should not break embedded resource refs', async () => {
+        const root: JSONSchema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/test_schema.json',
+          type: 'object',
+          properties: {
+            option: { $ref: 'subschema/schema.json' },
+          },
+          $defs: {
+            'https://example.com/subschema/schema.json': {
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
+              $id: 'https://example.com/subschema/schema.json',
+              type: 'object',
+              properties: {
+                suboption: { $ref: '#/$defs/sub_options' },
+              },
+              $defs: {
+                sub_options: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        };
+
+        schemaProvider.addSchemaWithUri(SCHEMA_ID, 'file:///test_schema.json', root);
+        const yaml = `# yaml-language-server: $schema=file:///test_schema.json
+option:
+  suboption: 1
+`;
+        const result = await parseSetup(yaml, 'file:///validated.yaml');
+        expect(result.some((d) => /\$ref '\/\$defs\/sub_options'/.test(d.message))).to.eq(false);
+        expect(result).to.have.length(1);
+        expect(result[0].message).to.include('Incorrect type. Expected "string".');
+      });
+
+      it('local sibling fallback preserves source URI for internal refs in the loaded schema', async () => {
+        const primaryUri = 'file:///schemas/primary.json';
+        const secondaryUri = 'file:///schemas/secondary.json';
+        const primary: JSONSchema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/schemas/primary.json',
+          type: 'object',
+          properties: {
+            option: { $ref: 'secondary.json' },
+          },
+          required: ['option'],
+        };
+        const secondary: JSONSchema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/schemas/secondary.json',
+          type: 'object',
+          properties: {
+            suboption: { $ref: '#/$defs/sub_options' },
+          },
+          required: ['suboption'],
+          $defs: {
+            sub_options: {
+              type: 'string',
+            },
+          },
+        };
+
+        schemaProvider.addSchemaWithUri(SCHEMA_ID, primaryUri, primary);
+        schemaProvider.addSchemaWithUri(SCHEMA_ID, secondaryUri, secondary);
+
+        const yaml = `# yaml-language-server: $schema=${primaryUri}
+option:
+  suboption: 1
+`;
+        const result = await parseSetup(yaml, 'file:///validated-local-sibling.yaml');
+        expect(result.some((d) => /Problems loading reference/i.test(d.message))).to.eq(false);
+        expect(result.some((d) => /\$ref '\/\$defs\/sub_options'/.test(d.message))).to.eq(false);
+        expect(result).to.have.length(1);
+        expect(result[0].message).to.include('Incorrect type. Expected "string".');
+      });
+
+      it('embedded resource resolution takes precedence over same-name local sibling schema files', async () => {
+        const primaryUri = 'file:///schemas/primary-with-embedded.json';
+        const localSiblingUri = 'file:///schemas/secondary.json';
+        const primary: JSONSchema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/schemas/primary-with-embedded.json',
+          type: 'object',
+          properties: {
+            option: { $ref: 'secondary.json' },
+          },
+          required: ['option'],
+          $defs: {
+            'https://example.com/schemas/secondary.json': {
+              $schema: 'https://json-schema.org/draft/2020-12/schema',
+              $id: 'https://example.com/schemas/secondary.json',
+              type: 'string',
+              enum: ['embedded'],
+            },
+          },
+        };
+        const localSibling: JSONSchema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          type: 'string',
+          enum: ['local'],
+        };
+
+        schemaProvider.addSchemaWithUri(SCHEMA_ID, primaryUri, primary);
+        schemaProvider.addSchemaWithUri(SCHEMA_ID, localSiblingUri, localSibling);
+
+        const yaml = `# yaml-language-server: $schema=${primaryUri}
+option: local
+`;
+        const result = await parseSetup(yaml, 'file:///validated-embedded-precedence.yaml');
+        expect(result.some((d) => /Problems loading reference/i.test(d.message))).to.eq(false);
+        expect(result).to.have.length(1);
+        expect(result[0].message).to.include('embedded');
+      });
     });
 
     it('Resolving $refs: should ignore sibling keywords next to $ref', async () => {


### PR DESCRIPTION
### What does this PR do?

The regression was introduced in https://github.com/redhat-developer/yaml-language-server/pull/1186, where the added `_preferLocalBaseForRemoteId` sets a schema node’s baseUri to the local file path when a schema is loaded from a local file whose root `$id` ends with the same filename. In this case, the resolver effectively treated the local file URI as the base for resolving relative references.
This behavior caused problems for embedded resource resolution. Because the resolver used the local file URI as the effective base, relative references could resolve against the wrong location. In particular, embedded resource references failed because `resourceIndexByUri` stores embedded resources under their original `$id`, not under a locally rewritten URI. As a result, internal references such as `#/$defs/...` could not find a corresponding item in `resourceIndexByUri` and thus could no longer be resolved correctly.

The fix separates the schema’s logical resolution base from the source URI it was loaded from. This removes the behavior that preferred a same-named local file as the effective base for a remote `$id`. Instead, the resolver now keeps these concerns distinct and only uses the source URI as a fallback when resolving external references to local sibling files. Now, we have:
- `_baseUri`: the logical resource URI derived from the schema’s `$id`
- `_sourceUri`: the URI of the file the schema was loaded from
This separation ensures that logical resolution remains consistent with the schema’s `$id`, while still allowing the source URI to be used for local file resolution.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1236

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] Manual test from https://github.com/redhat-developer/yaml-language-server/issues/1236
- [x] Automated tests