### PR TITLE
Add `ajv-i18n` support for localized schema validation messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vscode/l10n": "^0.0.18",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
+        "ajv-i18n": "^4.2.0",
         "request-light": "^0.5.7",
         "vscode-json-languageservice": "4.1.8",
         "vscode-languageserver": "^9.0.0",
@@ -1204,6 +1205,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@vscode/l10n": "^0.0.18",
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
+    "ajv-i18n": "^4.2.0",
     "request-light": "^0.5.7",
     "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^9.0.0",

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -61,7 +61,7 @@ const schemaDialectInFlight = new Map<string, Promise<SchemaDialect>>();
 
 const AJV_LOCALE_ALIASES = new Map<string, string>([
   ['zh-cn', 'zh'],
-  ['zh-tw', 'zh-TW']
+  ['zh-tw', 'zh-TW'],
 ]);
 
 // metadata/keywords that don't add constraints and thus don't count as $ref siblings
@@ -1449,9 +1449,7 @@ function getAjvLocalizer(locale?: string): Localize | undefined {
   const lowerLocale = locale.trim().toLowerCase();
   const aliasedLocale = AJV_LOCALE_ALIASES.get(lowerLocale);
 
-  return ajvLocalizers[locale]
-    || ajvLocalizers[lowerLocale]
-    || (aliasedLocale ? ajvLocalizers[aliasedLocale] : undefined);
+  return ajvLocalizers[locale] || ajvLocalizers[lowerLocale] || (aliasedLocale ? ajvLocalizers[aliasedLocale] : undefined);
 }
 
 function localizeAjvErrors(errors: ErrorObject[] | null | undefined, locale?: string): void {

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -25,10 +25,11 @@ import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { SchemaVersions } from '../yamlTypes';
 import { getSchemaFromModeline } from './modelineUtil';
 
-import Ajv, { DefinedError, type AnySchemaObject, type ValidateFunction } from 'ajv';
+import Ajv, { DefinedError, type AnySchemaObject, type ErrorObject, type ValidateFunction } from 'ajv';
 import Ajv4 from 'ajv-draft-04';
 import Ajv2019 from 'ajv/dist/2019';
 import Ajv2020 from 'ajv/dist/2020';
+import type { Localize } from 'ajv-i18n/localize/types';
 import * as Json from 'jsonc-parser';
 import { parse } from 'yaml';
 import { CRD_CATALOG_URL, KUBERNETES_SCHEMA_URL } from '../utils/schemaUrls';
@@ -47,6 +48,8 @@ const jsonSchema07 = require('ajv/dist/refs/json-schema-draft-07.json');
 const jsonSchema2019 = require('ajv/dist/refs/json-schema-2019-09/schema.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const jsonSchema2020 = require('ajv/dist/refs/json-schema-2020-12/schema.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ajvLocalizers: Record<string, Localize> = require('ajv-i18n');
 
 const schema04Validator = ajv4.compile(jsonSchema04);
 const schema07Validator = ajv7.compile(jsonSchema07);
@@ -55,6 +58,11 @@ const schema2020Validator = ajv2020.compile(jsonSchema2020);
 
 const schemaDialectCache = new Map<string, SchemaDialect>();
 const schemaDialectInFlight = new Map<string, Promise<SchemaDialect>>();
+
+const AJV_LOCALE_ALIASES = new Map<string, string>([
+  ['zh-cn', 'zh'],
+  ['zh-tw', 'zh-TW']
+]);
 
 // metadata/keywords that don't add constraints and thus don't count as $ref siblings
 const REF_SIBLING_NONCONSTRAINT_KEYS = new Set([
@@ -264,6 +272,7 @@ export class YAMLSchemaService extends JSONSchemaService {
      * ----------------------------
      */
     const _loadSchema = this.loadSchema.bind(this);
+    const ajvErrorLocale = this.yamlSettings?.locale;
     async function _metaValidateSchemaNode(node: JSONSchema, hasNestedSchema: boolean): Promise<void> {
       if (!node || typeof node !== 'object') return;
       const dialect = await pickSchemaDialect(node.$schema, _loadSchema);
@@ -283,6 +292,7 @@ export class YAMLSchemaService extends JSONSchemaService {
       }
 
       if (!validator(toValidate)) {
+        localizeAjvErrors(validator.errors, ajvErrorLocale);
         const errs: string[] = [];
         for (const err of validator.errors as DefinedError[]) {
           errs.push(`${err.instancePath} : ${err.message}`);
@@ -1431,6 +1441,22 @@ function knownDialectFromSchemaUri(schemaUri?: string): SchemaDialect {
   if (schemaUri === normalizeSchemaUri(ajv2019.defaultMeta())) return SchemaDialect.draft2019;
   if (schemaUri === normalizeSchemaUri(ajv2020.defaultMeta())) return SchemaDialect.draft2020;
   return undefined;
+}
+
+function getAjvLocalizer(locale?: string): Localize | undefined {
+  if (!locale) return undefined;
+
+  const lowerLocale = locale.trim().toLowerCase();
+  const aliasedLocale = AJV_LOCALE_ALIASES.get(lowerLocale);
+
+  return ajvLocalizers[locale]
+    || ajvLocalizers[lowerLocale]
+    || (aliasedLocale ? ajvLocalizers[aliasedLocale] : undefined);
+}
+
+function localizeAjvErrors(errors: ErrorObject[] | null | undefined, locale?: string): void {
+  const localizer = getAjvLocalizer(locale) || ajvLocalizers.en;
+  localizer(errors);
 }
 
 async function pickSchemaDialect(

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -57,6 +57,7 @@ export class YAMLServerInit {
 
   // public for test setup
   async connectionInitialized(params: InitializeParams): Promise<InitializeResult> {
+    this.yamlSettings.locale = params.locale || 'en';
     this.yamlSettings.capabilities = params.capabilities;
     this.languageService = getCustomLanguageService({
       schemaRequestService: this.schemaRequestService,

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -120,6 +120,7 @@ export class SettingsState {
   useSchemaSelectionRequests = false;
   hasWsChangeWatchedFileDynamicRegistration = false;
   fileExtensions: string[] = ['.yml', '.yaml'];
+  locale = 'en';
 }
 
 export class TextDocumentTestManager extends TextDocuments<TextDocument> {


### PR DESCRIPTION
### What does this PR do?
Added `ajv-i18n` support for localized schema validation messages

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1131

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested manually with the following steps:
1. set VS Code display language to a supported language (Command Palette > Configure Display Language)
2. create an invalid json schema file like the one provided below and test it in a yaml file:
    ```json
    {
      "$schema": "https://json-schema.org/draft/2020-12/schema",
      "type": [1, 2]
    }
    ```