### PR TITLE
Add tests for bugs in reverted formatter changes

### DIFF
--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -49,6 +49,9 @@ export class YAMLFormatter {
       };
 
       const formatted = await format(text, prettierOptions);
+      if (formatted === text) {
+        return [];
+      }
 
       return [TextEdit.replace(Range.create(Position.create(0, 0), document.positionAt(text.length)), formatted)];
     } catch (error) {

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { TextEdit } from 'vscode-languageserver-types';
+import { FormattingOptions, TextEdit } from 'vscode-languageserver-types';
+import { CustomFormatterOptions } from '../src';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
@@ -38,13 +39,16 @@ describe('Formatter Tests', () => {
   describe('Formatter', function () {
     describe('Test that formatter works with custom tags', function () {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      function parseSetup(content: string, options: any = {}): Promise<TextEdit[]> {
+      function parseSetup(
+        content: string,
+        options: Partial<FormattingOptions | CustomFormatterOptions> = {}
+      ): Promise<TextEdit[]> {
         const testTextDocument = setupTextDocument(content);
         yamlSettings.documents = new TextDocumentTestManager();
         (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
-        yamlSettings.yamlFormatterSettings = options;
+        yamlSettings.yamlFormatterSettings = options as CustomFormatterOptions;
         return languageHandler.formatterHandler({
-          options,
+          options: options as FormattingOptions,
           textDocument: testTextDocument,
         });
       }
@@ -98,7 +102,7 @@ describe('Formatter Tests', () => {
 }
 `;
         const edits = await parseSetup(content, { singleQuote: true });
-        assert.equal(edits[0].newText, content);
+        assert.equal(edits.length, 0);
       });
 
       it('Formatting handles trailing commas (disabled)', async () => {
@@ -193,6 +197,82 @@ list:
      - item2
 `;
         assert.equal(edits[0].newText, expected);
+      });
+
+      it("Formatting doesn't replace escaped newlines with real ones", async () => {
+        const content = `- name: Example task
+  set_fact:
+    my_var: "{{ content | regex_replace('\\\\\\\\n', '\\n') }}"
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
+      });
+      it("Formatting doesn't strip trailing zeros of floats", async () => {
+        const content = `value: 1.0e+4
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
+      });
+      it("Formatting doesn't convert long integers to floats", async () => {
+        const content = `value: 12345678901234567890
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
+      });
+      it("Formatting respects 'no prose wrap' setting", async () => {
+        const content = `value: aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+          proseWrap: 'never',
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
+
+        const edits2 = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+          proseWrap: 'preserve',
+        });
+
+        assert.equal(edits2.length, 0, `Edits: ${JSON.stringify(edits)}`);
+      });
+      it('Formatting keeps comments on the same line', async () => {
+        const content = `0002-https-from-avdpool-to-server: # Allow HTTPS access from AVD Pool 2 to Qlik server
+  name: 0002-https-from-avdpool-to-server
+  source_addresses:
+    - 1.2.3.4/32
+  protocols:
+    - TCP
+  destination_ports:
+    - "443"
+  destination_addresses:
+    - 4.5.6.7/32
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?
- Readd the fix that doesn't return any text edits if the formatter changes nothing
- Add a bunch of tests for the cases where the new formatter was failing

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Unit tests of the formatter
