### PR TITLE
Support disabling schema source URI in hovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following settings are supported:
 - `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid` 
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
 - `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
+- `yaml.showSchemaSource`: Enable/disable showing the schema source in hover tooltips. Default is `true`
 
 ## Suppressing diagnostics
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following settings are supported:
 - `yaml.style.flowMapping` : Forbids flow style mappings if set to `forbid` 
 - `yaml.style.flowSequence` : Forbids flow style sequences if set to `forbid`
 - `yaml.keyOrdering` : Enforces alphabetical ordering of keys in mappings when set to `true`. Default is `false`
-- `yaml.showSchemaSource`: Enable/disable showing the schema source in hover tooltips. Default is `true`
+- `yaml.hoverSchemaSource`: Enable/disable showing the schema source in hover tooltips. Default is `true`
 
 ## Suppressing diagnostics
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -77,8 +77,8 @@ export class SettingsHandler {
       if (Object.prototype.hasOwnProperty.call(settings.yaml, 'completion')) {
         this.yamlSettings.yamlShouldCompletion = settings.yaml.completion;
       }
-      if (Object.prototype.hasOwnProperty.call(settings.yaml, 'showSchemaSource')) {
-        this.yamlSettings.yamlShowSchemaSource = settings.yaml.showSchemaSource;
+      if (Object.prototype.hasOwnProperty.call(settings.yaml, 'hoverSchemaSource')) {
+        this.yamlSettings.yamlhoverSchemaSource = settings.yaml.hoverSchemaSource;
       }
       this.yamlSettings.customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
@@ -283,7 +283,7 @@ export class SettingsHandler {
       flowSequence: this.yamlSettings.style?.flowSequence,
       yamlVersion: this.yamlSettings.yamlVersion,
       keyOrdering: this.yamlSettings.keyOrdering,
-      showSchemaSource: this.yamlSettings.yamlShowSchemaSource,
+      hoverSchemaSource: this.yamlSettings.yamlhoverSchemaSource,
     };
 
     if (this.yamlSettings.schemaAssociations) {

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -77,6 +77,9 @@ export class SettingsHandler {
       if (Object.prototype.hasOwnProperty.call(settings.yaml, 'completion')) {
         this.yamlSettings.yamlShouldCompletion = settings.yaml.completion;
       }
+      if (Object.prototype.hasOwnProperty.call(settings.yaml, 'showSchemaSource')) {
+        this.yamlSettings.yamlShowSchemaSource = settings.yaml.showSchemaSource;
+      }
       this.yamlSettings.customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
       this.yamlSettings.maxItemsComputed = Math.trunc(Math.max(0, Number(settings.yaml.maxItemsComputed))) || 5000;
@@ -280,6 +283,7 @@ export class SettingsHandler {
       flowSequence: this.yamlSettings.style?.flowSequence,
       yamlVersion: this.yamlSettings.yamlVersion,
       keyOrdering: this.yamlSettings.keyOrdering,
+      showSchemaSource: this.yamlSettings.yamlShowSchemaSource,
     };
 
     if (this.yamlSettings.schemaAssociations) {

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -27,7 +27,7 @@ export class YAMLHover {
   private shouldHover: boolean;
   private shouldHoverAnchor: boolean;
   private indentation: string;
-  private showSchemaSource: boolean;
+  private hoverSchemaSource: boolean;
   private schemaService: YAMLSchemaService;
 
   constructor(
@@ -43,7 +43,7 @@ export class YAMLHover {
       this.shouldHover = languageSettings.hover;
       this.shouldHoverAnchor = languageSettings.hoverAnchor;
       this.indentation = languageSettings.indentation;
-      this.showSchemaSource = languageSettings.showSchemaSource ?? true;
+      this.hoverSchemaSource = languageSettings.hoverSchemaSource ?? true;
     }
   }
 
@@ -210,7 +210,7 @@ export class YAMLHover {
             result += `\`\`\`yaml\n${example}\`\`\`\n`;
           });
         }
-        if (result.length > 0 && schema.schema.url && this.showSchemaSource) {
+        if (result.length > 0 && schema.schema.url && this.hoverSchemaSource) {
           result = ensureLineBreak(result);
           result += l10n.t('Source: [{0}]({1})', getSchemaName(schema.schema), schema.schema.url);
         }

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -27,6 +27,7 @@ export class YAMLHover {
   private shouldHover: boolean;
   private shouldHoverAnchor: boolean;
   private indentation: string;
+  private showSchemaSource: boolean;
   private schemaService: YAMLSchemaService;
 
   constructor(
@@ -42,6 +43,7 @@ export class YAMLHover {
       this.shouldHover = languageSettings.hover;
       this.shouldHoverAnchor = languageSettings.hoverAnchor;
       this.indentation = languageSettings.indentation;
+      this.showSchemaSource = languageSettings.showSchemaSource ?? true;
     }
   }
 
@@ -208,7 +210,7 @@ export class YAMLHover {
             result += `\`\`\`yaml\n${example}\`\`\`\n`;
           });
         }
-        if (result.length > 0 && schema.schema.url) {
+        if (result.length > 0 && schema.schema.url && this.showSchemaSource) {
           result = ensureLineBreak(result);
           result += l10n.t('Source: [{0}]({1})', getSchemaName(schema.schema), schema.schema.url);
         }

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -125,6 +125,11 @@ export interface LanguageSettings {
    * If set enforce alphabetical ordering of keys in mappings.
    */
   keyOrdering?: boolean;
+
+  /**
+   * Show schema source URI in hover popups. Default is true.
+   */
+  showSchemaSource?: boolean;
 }
 
 export interface WorkspaceContextService {

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -129,7 +129,7 @@ export interface LanguageSettings {
   /**
    * Show schema source URI in hover popups. Default is true.
    */
-  showSchemaSource?: boolean;
+  hoverSchemaSource?: boolean;
 }
 
 export interface WorkspaceContextService {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -37,6 +37,7 @@ export interface Settings {
     keyOrdering: boolean;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
+    showSchemaSource: boolean;
   };
   http: {
     proxy: string;
@@ -80,6 +81,7 @@ export class SettingsState {
   yamlShouldHover = true;
   yamlShouldHoverAnchor = true;
   yamlShouldCompletion = true;
+  yamlShowSchemaSource = true;
   schemaStoreSettings = [];
   customTags = [];
   schemaStoreEnabled = true;

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -37,7 +37,7 @@ export interface Settings {
     keyOrdering: boolean;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
-    showSchemaSource: boolean;
+    hoverSchemaSource: boolean;
   };
   http: {
     proxy: string;
@@ -81,7 +81,7 @@ export class SettingsState {
   yamlShouldHover = true;
   yamlShouldHoverAnchor = true;
   yamlShouldCompletion = true;
-  yamlShowSchemaSource = true;
+  yamlhoverSchemaSource = true;
   schemaStoreSettings = [];
   customTags = [];
   schemaStoreEnabled = true;

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -1288,11 +1288,11 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
     });
   });
 
-  describe('showSchemaSource configuration', () => {
-    it('Hover should not show schema source when showSchemaSource is false', async () => {
+  describe('hoverSchemaSource configuration', () => {
+    it('Hover should not show schema source when hoverSchemaSource is false', async () => {
       const languageSettingsSetupWithoutSource = new ServiceSetup()
         .withHover()
-        .withShowSchemaSource(false)
+        .withhoverSchemaSource(false)
         .withSchemaFileMatch({
           uri: SCHEMA_ID,
           fileMatch: ['*.yaml'],

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -1287,4 +1287,76 @@ Source: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
       expect((result.contents as MarkupContent).value).to.include('Disabled flag');
     });
   });
+
+  describe('showSchemaSource configuration', () => {
+    it('Hover should not show schema source when showSchemaSource is false', async () => {
+      const languageSettingsSetupWithoutSource = new ServiceSetup()
+        .withHover()
+        .withShowSchemaSource(false)
+        .withSchemaFileMatch({
+          uri: SCHEMA_ID,
+          fileMatch: ['*.yaml'],
+        });
+      const {
+        languageHandler: langHandler,
+        yamlSettings: settings,
+        schemaProvider: testSchemaProvider,
+      } = setupLanguageService(languageSettingsSetupWithoutSource.languageSettings);
+
+      testSchemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          cwd: {
+            type: 'string',
+            description: 'The directory from which bower should run.',
+          },
+        },
+      });
+      const content = 'c|w|d: test';
+      const { content: parsedContent, position } = caretPosition(content);
+      const testTextDocument = setupSchemaIDTextDocument(parsedContent);
+      settings.documents = new TextDocumentTestManager();
+      (settings.documents as TextDocumentTestManager).set(testTextDocument);
+      const hover = await langHandler.hoverHandler({
+        position: testTextDocument.positionAt(position),
+        textDocument: testTextDocument,
+      });
+
+      assert.strictEqual(MarkupContent.is(hover.contents), true);
+      assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual((hover.contents as MarkupContent).value, 'The directory from which bower should run.');
+      assert.strictEqual((hover.contents as MarkupContent).value.includes('Source:'), false);
+
+      testSchemaProvider.deleteSchema(SCHEMA_ID);
+    });
+
+    it('Hover should show schema source by default', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          cwd: {
+            type: 'string',
+            description: 'The directory from which bower should run.',
+          },
+        },
+      });
+      const content = 'c|w|d: test';
+      const { content: parsedContent, position } = caretPosition(content);
+      const testTextDocument = setupSchemaIDTextDocument(parsedContent);
+      yamlSettings.documents = new TextDocumentTestManager();
+      (yamlSettings.documents as TextDocumentTestManager).set(testTextDocument);
+      const hover = await languageHandler.hoverHandler({
+        position: testTextDocument.positionAt(position),
+        textDocument: testTextDocument,
+      });
+
+      assert.strictEqual(MarkupContent.is(hover.contents), true);
+      assert.strictEqual((hover.contents as MarkupContent).kind, 'markdown');
+      assert.strictEqual((hover.contents as MarkupContent).value.includes('Source:'), true);
+      assert.strictEqual(
+        (hover.contents as MarkupContent).value,
+        `The directory from which bower should run.\n\nSource: [${SCHEMA_ID}](file:///${SCHEMA_ID})`
+      );
+    });
+  });
 });

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -22,7 +22,7 @@ export class ServiceSetup {
     yamlVersion: '1.2',
     flowMapping: 'allow',
     flowSequence: 'allow',
-    showSchemaSource: true,
+    hoverSchemaSource: true,
   };
 
   withValidate(): ServiceSetup {
@@ -83,8 +83,8 @@ export class ServiceSetup {
     return this;
   }
 
-  withShowSchemaSource(show: boolean): ServiceSetup {
-    this.languageSettings.showSchemaSource = show;
+  withhoverSchemaSource(show: boolean): ServiceSetup {
+    this.languageSettings.hoverSchemaSource = show;
     return this;
   }
 }

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -22,6 +22,7 @@ export class ServiceSetup {
     yamlVersion: '1.2',
     flowMapping: 'allow',
     flowSequence: 'allow',
+    showSchemaSource: true,
   };
 
   withValidate(): ServiceSetup {
@@ -79,6 +80,11 @@ export class ServiceSetup {
 
   withYamlVersion(version: YamlVersion): ServiceSetup {
     this.languageSettings.yamlVersion = version;
+    return this;
+  }
+
+  withShowSchemaSource(show: boolean): ServiceSetup {
+    this.languageSettings.showSchemaSource = show;
     return this;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Added the `yaml.hoverSchemaSource` configuration option to control whether the schema source is shown in hover tooltips. Defaults to `true`.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1120

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] Tested manually
- [x] Automated tests