### PR TITLE
More regression tests for formatter

### DIFF
--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -274,6 +274,35 @@ list:
 
         assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
       });
+      it('Formatting converts quotations', async () => {
+        const content = `root:
+  - it: "should include default selector"
+`;
+        const expected = `root:
+  - it: 'should include default selector'
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+          singleQuote: true,
+        });
+
+        assert.equal(edits[0].newText, expected);
+      });
+      it("Formatting empty doc doesn't do anything", async () => {
+        const content = `
+`;
+        const expected = ``;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+          singleQuote: true,
+        });
+
+        assert.equal(edits[0].newText, expected);
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds more regression tests for the formatter

### What issues does this PR fix or reference?
- See https://github.com/redhat-developer/yaml-language-server/pull/1240#issuecomment-4353862546
- See https://github.com/redhat-developer/vscode-yaml/issues/1241

### Is it tested? How?
Yes, these are regression tests
