### PR TITLE
Regression test for #1245

### DIFF
--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -303,6 +303,30 @@ list:
 
         assert.equal(edits[0].newText, expected);
       });
+
+      it('Comments separated by blank lines do not inherit indentation of previous lines', async () => {
+        const content = `# Section 1
+
+variables:
+  - "C"
+  - 1
+  - false
+  # four: true
+
+# Section 2
+
+more_variables:
+  - "A"
+  - 2
+`;
+
+        const edits = await parseSetup(content, {
+          tabSize: 1,
+          tabWidth: 2,
+        });
+
+        assert.equal(edits.length, 0, `Edits: ${JSON.stringify(edits)}`);
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds a regression test for a formatting bug introduced by the eemeli/yaml formatting implementation (which was reverted).

### What issues does this PR fix or reference?
#1245

### Is it tested? How?
Yes, it's tests.
