### PR TITLE
small fix to shush static analyzers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ COPY . .
 RUN npm install && \
     npm run build
 
+USER node
+
 ENTRYPOINT [ "node", "./out/server/src/server.js" ]
 CMD [ "--stdio" ]


### PR DESCRIPTION
### What does this PR do?
Explicitly sets last USER to node (uid 1000 from node:lts) 
Prevents Trivy and Hadolint from freaking out.

https://avd.aquasec.com/misconfig/dockerfile/general/ds-0002/
https://github.com/hadolint/hadolint/wiki/DL3002

Also, I suspect you don't need root to run language server.

### Is it tested? How?
Run docker build, behaviour didn't change 
(except output of 
```
docker run -it --rm --entrypoint whoami <image name>
```
(was "root", now "node").