### PR TITLE
Add setting to disable automatic schema detection for matching YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following settings are supported:
 - `yaml.hover`: Enable/disable hover
 - `yaml.completion`: Enable/disable autocompletion
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
-- `yaml.schemaDetectionDisableFor`: Disables automatically detected schemas for matching YAML files. Schemas explicitly configured with `yaml.schemas` or a modeline still apply.
+- `yaml.disableSchemaDetection`: Disables schema detection for matching YAML files. Modelines still apply.
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org)
 - `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.kubernetesCRDStore.enable`: When set to true the YAML language server will parse Kubernetes CRDs automatically and download them from the [CRD store](https://github.com/datreeio/CRDs-catalog).
@@ -297,29 +297,28 @@ or IntelliJ compatible format:
 
 ### Disabling automatic schema detection for specific files
 
-Use `yaml.schemaDetectionDisableFor` to disable automatically detected schemas for files matching a glob pattern. This applies to lower priority automatic schema sources such as Schema Store and schema association notifications.
+Use `yaml.disableSchemaDetection` to disable schema detection for files matching a glob pattern. For matching files, schemas from `yaml.schemas`, schema association notifications, and Schema Store are ignored. Modelines still apply.
 
 For one file pattern:
 
 ```yaml
-yaml.schemaDetectionDisableFor: ".github/workflows/*.yml"
+yaml.disableSchemaDetection: "**/.github/workflows/*.yaml"
 ```
 
 For multiple file patterns:
 
 ```yaml
-yaml.schemaDetectionDisableFor: ["some.yaml", ".github/workflows/*.yml"]
+yaml.disableSchemaDetection: ["some.yaml", "**/.github/workflows/*.yaml"]
 ```
 
-This setting does not disable schemas explicitly configured with `yaml.schemas` or with a modeline.
 
 ### Schema priority
 
 The following is the priority of schema association in highest to lowest priority:
 1. Modeline
 2. CustomSchemaProvider API
-3. `yaml.schemas`
-4. `yaml.schemaDetectionDisableFor`
+3. `yaml.disableSchemaDetection`
+4. `yaml.schemas`
 5. Schema association notification
 6. Schema Store
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following settings are supported:
 - `yaml.hover`: Enable/disable hover
 - `yaml.completion`: Enable/disable autocompletion
 - `yaml.schemas`: Helps you associate schemas with files in a glob pattern
+- `yaml.schemaDetectionDisableFor`: Disables automatically detected schemas for matching YAML files. Schemas explicitly configured with `yaml.schemas` or a modeline still apply.
 - `yaml.schemaStore.enable`: When set to true the YAML language server will pull in all available schemas from [JSON Schema Store](https://www.schemastore.org)
 - `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.kubernetesCRDStore.enable`: When set to true the YAML language server will parse Kubernetes CRDs automatically and download them from the [CRD store](https://github.com/datreeio/CRDs-catalog).
@@ -112,7 +113,7 @@ some_mapping: !Mapping-example
 
 ##### Associating a schema to a glob pattern via yaml.schemas:
 
-yaml.schemas applies a schema to a file. In other words, the schema (placed on the left) is applied to the glob pattern on the right. Your schema can be local or online. Your schema path must be relative to the project root and not an absolute path to the schema.
+`yaml.schemas` applies a schema to a file. In other words, the schema (placed on the left) is applied to the glob pattern on the right. Your schema can be local or online. Local schema paths can be relative to the project root or absolute paths.
 
 For example:
 If you have project structure
@@ -294,14 +295,33 @@ or IntelliJ compatible format:
 # $schema: <urlOrPathToTheSchema>
 ```
 
+### Disabling automatic schema detection for specific files
+
+Use `yaml.schemaDetectionDisableFor` to disable automatically detected schemas for files matching a glob pattern. This applies to lower priority automatic schema sources such as Schema Store and schema association notifications.
+
+For one file pattern:
+
+```yaml
+yaml.schemaDetectionDisableFor: ".github/workflows/*.yml"
+```
+
+For multiple file patterns:
+
+```yaml
+yaml.schemaDetectionDisableFor: ["some.yaml", ".github/workflows/*.yml"]
+```
+
+This setting does not disable schemas explicitly configured with `yaml.schemas` or with a modeline.
+
 ### Schema priority
 
 The following is the priority of schema association in highest to lowest priority:
 1. Modeline
 2. CustomSchemaProvider API
-3. yaml.settings
-4. Schema association notification
-5. Schema Store
+3. `yaml.schemas`
+4. `yaml.schemaDetectionDisableFor`
+5. Schema association notification
+6. Schema Store
 
 ## Containerized Language Server
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -85,10 +85,10 @@ export class SettingsHandler {
       if (Object.prototype.hasOwnProperty.call(settings.yaml, 'hoverSchemaSource')) {
         this.yamlSettings.yamlHoverSchemaSource = settings.yaml.hoverSchemaSource;
       }
-      this.yamlSettings.yamlSchemaDetectionDisableFor = Array.isArray(settings.yaml.schemaDetectionDisableFor)
-        ? settings.yaml.schemaDetectionDisableFor
-        : settings.yaml.schemaDetectionDisableFor
-          ? [settings.yaml.schemaDetectionDisableFor]
+      this.yamlSettings.yamlDisableSchemaDetection = Array.isArray(settings.yaml.disableSchemaDetection)
+        ? settings.yaml.disableSchemaDetection
+        : settings.yaml.disableSchemaDetection
+          ? [settings.yaml.disableSchemaDetection]
           : [];
       this.yamlSettings.customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
@@ -296,11 +296,11 @@ export class SettingsHandler {
       hoverSchemaSource: this.yamlSettings.yamlHoverSchemaSource,
     };
 
-    if (this.yamlSettings.yamlSchemaDetectionDisableFor) {
-      if (Array.isArray(this.yamlSettings.yamlSchemaDetectionDisableFor)) {
+    if (this.yamlSettings.yamlDisableSchemaDetection) {
+      if (Array.isArray(this.yamlSettings.yamlDisableSchemaDetection)) {
         languageSettings = this.configureSchemas(
           EMPTY_SCHEMA_URL,
-          this.yamlSettings.yamlSchemaDetectionDisableFor,
+          this.yamlSettings.yamlDisableSchemaDetection,
           true,
           languageSettings,
           SchemaPriority.SchemaDetectionDisabled

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -5,7 +5,12 @@
 import { configure as configureHttpRequests, xhr } from 'request-light';
 import { Connection, DidChangeConfigurationNotification, DocumentFormattingRequest } from 'vscode-languageserver';
 import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
-import { checkSchemaURI, JSON_SCHEMASTORE_URL, KUBERNETES_SCHEMA_URL } from '../../languageservice/utils/schemaUrls';
+import {
+  checkSchemaURI,
+  EMPTY_SCHEMA_URL,
+  JSON_SCHEMASTORE_URL,
+  KUBERNETES_SCHEMA_URL,
+} from '../../languageservice/utils/schemaUrls';
 import { LanguageService, LanguageSettings, SchemaPriority } from '../../languageservice/yamlLanguageService';
 import { SchemaSelectionRequests } from '../../requestTypes';
 import { Settings, SettingsState } from '../../yamlSettings';
@@ -78,8 +83,13 @@ export class SettingsHandler {
         this.yamlSettings.yamlShouldCompletion = settings.yaml.completion;
       }
       if (Object.prototype.hasOwnProperty.call(settings.yaml, 'hoverSchemaSource')) {
-        this.yamlSettings.yamlhoverSchemaSource = settings.yaml.hoverSchemaSource;
+        this.yamlSettings.yamlHoverSchemaSource = settings.yaml.hoverSchemaSource;
       }
+      this.yamlSettings.yamlSchemaDetectionDisableFor = Array.isArray(settings.yaml.schemaDetectionDisableFor)
+        ? settings.yaml.schemaDetectionDisableFor
+        : settings.yaml.schemaDetectionDisableFor
+          ? [settings.yaml.schemaDetectionDisableFor]
+          : [];
       this.yamlSettings.customTags = settings.yaml.customTags ? settings.yaml.customTags : [];
 
       this.yamlSettings.maxItemsComputed = Math.trunc(Math.max(0, Number(settings.yaml.maxItemsComputed))) || 5000;
@@ -283,8 +293,20 @@ export class SettingsHandler {
       flowSequence: this.yamlSettings.style?.flowSequence,
       yamlVersion: this.yamlSettings.yamlVersion,
       keyOrdering: this.yamlSettings.keyOrdering,
-      hoverSchemaSource: this.yamlSettings.yamlhoverSchemaSource,
+      hoverSchemaSource: this.yamlSettings.yamlHoverSchemaSource,
     };
+
+    if (this.yamlSettings.yamlSchemaDetectionDisableFor) {
+      if (Array.isArray(this.yamlSettings.yamlSchemaDetectionDisableFor)) {
+        languageSettings = this.configureSchemas(
+          EMPTY_SCHEMA_URL,
+          this.yamlSettings.yamlSchemaDetectionDisableFor,
+          true,
+          languageSettings,
+          SchemaPriority.SchemaDetectionDisabled
+        );
+      }
+    }
 
     if (this.yamlSettings.schemaAssociations) {
       if (Array.isArray(this.yamlSettings.schemaAssociations)) {

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -32,7 +32,7 @@ import Ajv2020 from 'ajv/dist/2020';
 import type { Localize } from 'ajv-i18n/localize/types';
 import * as Json from 'jsonc-parser';
 import { parse } from 'yaml';
-import { CRD_CATALOG_URL, KUBERNETES_SCHEMA_URL } from '../utils/schemaUrls';
+import { CRD_CATALOG_URL, EMPTY_SCHEMA_URL, KUBERNETES_SCHEMA_URL } from '../utils/schemaUrls';
 import { autoDetectKubernetesSchema } from './k8sSchemaUtil';
 
 const ajv4 = new Ajv4({ allErrors: true });
@@ -164,7 +164,7 @@ export class YAMLSchemaService extends JSONSchemaService {
     const schemaUris = new Set<string>();
     for (const filePattern of this.filePatternAssociations) {
       const schemaUri = filePattern.uris[0];
-      if (schemaUris.has(schemaUri)) {
+      if (schemaUri === EMPTY_SCHEMA_URL || schemaUris.has(schemaUri)) {
         continue;
       }
       schemaUris.add(schemaUri);

--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -10,6 +10,7 @@ export const BASE_KUBERNETES_SCHEMA_URL =
 export const KUBERNETES_SCHEMA_URL = BASE_KUBERNETES_SCHEMA_URL + 'all.json';
 export const JSON_SCHEMASTORE_URL = 'https://www.schemastore.org/api/json/catalog.json';
 export const CRD_CATALOG_URL = 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main';
+export const EMPTY_SCHEMA_URL = 'vscode://schemas/empty';
 
 export function checkSchemaURI(
   workspaceFolders: WorkspaceFolder[],

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -63,7 +63,8 @@ import { YamlRename } from './services/yamlRename';
 export enum SchemaPriority {
   SchemaStore = 1,
   SchemaAssociation = 2,
-  Settings = 3,
+  SchemaDetectionDisabled = 3,
+  Settings = 4,
 }
 
 export interface SchemasSettings {

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -63,8 +63,8 @@ import { YamlRename } from './services/yamlRename';
 export enum SchemaPriority {
   SchemaStore = 1,
   SchemaAssociation = 2,
-  SchemaDetectionDisabled = 3,
-  Settings = 4,
+  Settings = 3,
+  SchemaDetectionDisabled = 4,
 }
 
 export interface SchemasSettings {

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -38,6 +38,7 @@ export interface Settings {
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
     hoverSchemaSource: boolean;
+    schemaDetectionDisableFor: string | string[];
   };
   http: {
     proxy: string;
@@ -81,9 +82,10 @@ export class SettingsState {
   yamlShouldHover = true;
   yamlShouldHoverAnchor = true;
   yamlShouldCompletion = true;
-  yamlhoverSchemaSource = true;
+  yamlHoverSchemaSource = true;
+  yamlSchemaDetectionDisableFor: string[] = [];
   schemaStoreSettings = [];
-  customTags = [];
+  customTags: string[] = [];
   schemaStoreEnabled = true;
   schemaStoreUrl = JSON_SCHEMASTORE_URL;
   kubernetesCRDStoreEnabled = true;

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -38,7 +38,7 @@ export interface Settings {
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
     hoverSchemaSource: boolean;
-    schemaDetectionDisableFor: string | string[];
+    disableSchemaDetection: string | string[];
   };
   http: {
     proxy: string;
@@ -83,7 +83,7 @@ export class SettingsState {
   yamlShouldHoverAnchor = true;
   yamlShouldCompletion = true;
   yamlHoverSchemaSource = true;
-  yamlSchemaDetectionDisableFor: string[] = [];
+  yamlDisableSchemaDetection: string[] = [];
   schemaStoreSettings = [];
   customTags: string[] = [];
   schemaStoreEnabled = true;

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -992,7 +992,11 @@ address:
     const schemaModelineSample = path.join(__dirname, './fixtures/sample-modeline.json');
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const schemaDefaultSnippetSample = require(path.join(__dirname, './fixtures/defaultSnippets-const-if-else.json'));
-    const languageSettingsSetup = new ServiceSetup().withCompletion();
+    let languageSettingsSetup: ServiceSetup;
+
+    beforeEach(() => {
+      languageSettingsSetup = new ServiceSetup().withCompletion();
+    });
 
     it('Modeline Schema takes precendence over all other schema APIs', async () => {
       languageSettingsSetup
@@ -1047,6 +1051,21 @@ address:
           uri: TEST_URI,
           priority: SchemaPriority.Settings,
           schema: schemaSettingsSample,
+        });
+      languageService.configure(languageSettingsSetup.languageSettings);
+      const testTextDocument = setupTextDocument('');
+      const result = await languageService.doComplete(testTextDocument, Position.create(0, 0), false);
+      assert.strictEqual(result.items.length, 1);
+      assert.strictEqual(result.items[0].label, 'settings');
+    });
+
+    it('SchemaDetectionDisabled takes precedence over manually configured schemas', async () => {
+      languageSettingsSetup
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: TEST_URI,
+          priority: SchemaPriority.Settings,
+          schema: schemaSettingsSample,
         })
         .withSchemaFileMatch({
           fileMatch: ['test.yaml'],
@@ -1057,8 +1076,7 @@ address:
       languageService.configure(languageSettingsSetup.languageSettings);
       const testTextDocument = setupTextDocument('');
       const result = await languageService.doComplete(testTextDocument, Position.create(0, 0), false);
-      assert.strictEqual(result.items.length, 1);
-      assert.strictEqual(result.items[0].label, 'settings');
+      assert.strictEqual(result.items.length, 0);
     });
 
     it('SchemaAssociation takes precendence over SchemaStore', async () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -6,7 +6,7 @@ import * as url from 'url';
 import * as path from 'path';
 import { XHRResponse, xhr } from 'request-light';
 import { MODIFICATION_ACTIONS, SchemaDeletions } from '../src/languageservice/services/yamlSchemaService';
-import { KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
+import { EMPTY_SCHEMA_URL, KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
 import { expect } from 'chai';
 import { ServiceSetup } from './utils/serviceSetup';
 import {
@@ -1013,6 +1013,12 @@ address:
           uri: TEST_URI,
           priority: SchemaPriority.Settings,
           schema: schemaSettingsSample,
+        })
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: EMPTY_SCHEMA_URL,
+          priority: SchemaPriority.SchemaDetectionDisabled,
+          schema: true,
         });
       languageService.configure(languageSettingsSetup.languageSettings);
       languageService.registerCustomSchemaProvider((uri: string) => Promise.resolve(uri));
@@ -1041,6 +1047,12 @@ address:
           uri: TEST_URI,
           priority: SchemaPriority.Settings,
           schema: schemaSettingsSample,
+        })
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: EMPTY_SCHEMA_URL,
+          priority: SchemaPriority.SchemaDetectionDisabled,
+          schema: true,
         });
       languageService.configure(languageSettingsSetup.languageSettings);
       const testTextDocument = setupTextDocument('');
@@ -1068,6 +1080,52 @@ address:
       const result = await languageService.doComplete(testTextDocument, Position.create(0, 0), false);
       assert.strictEqual(result.items.length, 1);
       assert.strictEqual(result.items[0].label, 'association');
+    });
+
+    it('SchemaDetectionDisabled takes precedence over SchemaAssociation', async () => {
+      const schemaDetectionDisabledSetup = new ServiceSetup()
+        .withCompletion()
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: TEST_URI,
+          priority: SchemaPriority.SchemaAssociation,
+          schema: schemaAssociationSample,
+        })
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: EMPTY_SCHEMA_URL,
+          priority: SchemaPriority.SchemaDetectionDisabled,
+          schema: true,
+        });
+
+      languageService.configure(schemaDetectionDisabledSetup.languageSettings);
+      const testTextDocument = setupTextDocument('');
+      const result = await languageService.doComplete(testTextDocument, Position.create(0, 0), false);
+
+      assert.strictEqual(result.items.length, 0);
+    });
+
+    it('SchemaDetectionDisabled takes precedence over SchemaStore', async () => {
+      const schemaDetectionDisabledSetup = new ServiceSetup()
+        .withCompletion()
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: TEST_URI,
+          priority: SchemaPriority.SchemaStore,
+          schema: schemaStoreSample,
+        })
+        .withSchemaFileMatch({
+          fileMatch: ['test.yaml'],
+          uri: EMPTY_SCHEMA_URL,
+          priority: SchemaPriority.SchemaDetectionDisabled,
+          schema: true,
+        });
+
+      languageService.configure(schemaDetectionDisabledSetup.languageSettings);
+      const testTextDocument = setupTextDocument('');
+      const result = await languageService.doComplete(testTextDocument, Position.create(0, 0), false);
+
+      assert.strictEqual(result.items.length, 0);
     });
 
     it('SchemaStore is highest priority if nothing else is available', async () => {

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -11,9 +11,10 @@ import { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver
 import { LanguageService, LanguageSettings, SchemaConfiguration, SchemaPriority } from '../src';
 import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import { EMPTY_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
 import { Telemetry } from '../src/languageservice/telemetry';
 import { SettingsState } from '../src/yamlSettings';
-import { setupLanguageService } from './utils/testHelper';
+import { TestCustomSchemaProvider, setupLanguageService, setupSchemaIDTextDocument, setupTextDocument } from './utils/testHelper';
 import { TestWorkspace } from './utils/testsTypes';
 
 const expect = chai.expect;
@@ -308,6 +309,54 @@ describe('Settings Handlers Tests', () => {
       });
     });
 
+    it('SchemaDetectionDisabled should have a priority', async () => {
+      xhrStub.resolves({
+        responseText: `{"schemas": [
+      {
+        "name": ".adonisrc.json",
+        "description": "AdonisJS configuration file",
+        "fileMatch": [
+          ".adonisrc.yaml"
+        ],
+        "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
+      }]}`,
+      });
+      const disabledSchemaFileMatch = ['foo/*.yml'];
+      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: disabledSchemaFileMatch }, {}, {}, {}, {}]);
+      const configureSpy = await configureSchemaPriorityTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: EMPTY_SCHEMA_URL,
+        fileMatch: disabledSchemaFileMatch,
+        schema: true,
+        priority: SchemaPriority.SchemaDetectionDisabled,
+      });
+    });
+
+    it('SchemaDetectionDisabled should accept a single file match string', async () => {
+      xhrStub.resolves({
+        responseText: `{"schemas": [
+      {
+        "name": ".adonisrc.json",
+        "description": "AdonisJS configuration file",
+        "fileMatch": [
+          ".adonisrc.yaml"
+        ],
+        "url": "https://raw.githubusercontent.com/adonisjs/application/master/adonisrc.schema.json"
+      }]}`,
+      });
+      const disabledSchemaFileMatch = 'foo/*.yml';
+      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: disabledSchemaFileMatch }, {}, {}, {}, {}]);
+      const configureSpy = await configureSchemaPriorityTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: EMPTY_SCHEMA_URL,
+        fileMatch: [disabledSchemaFileMatch],
+        schema: true,
+        priority: SchemaPriority.SchemaDetectionDisabled,
+      });
+    });
+
     it('Schema Associations should have a priority when schema association is an array', async () => {
       xhrStub.resolves({
         responseText: `{"schemas": [
@@ -350,6 +399,112 @@ describe('Settings Handlers Tests', () => {
         fileMatch: testSchemaFileMatch,
         priority: SchemaPriority.SchemaAssociation,
       });
+    });
+  });
+
+  describe('Test schemaDetectionDisableFor validation behavior', () => {
+    const restrictiveSchema = {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        allowed: {
+          type: 'string',
+        },
+      },
+    };
+
+    it('schemaDetectionDisableFor should not suppress yaml.schemas validation because settings schemas have higher priority', async () => {
+      const schemaUri = 'file:///schemas/schema-detection-disable-settings.json';
+      const schemaProvider = TestCustomSchemaProvider.instance();
+      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-settings', schemaUri, restrictiveSchema);
+      xhrStub.resolves({ responseText: '{"schemas":[]}' });
+      const schemas = {};
+      schemas[schemaUri] = 'test.yaml';
+      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: ['test.yaml'], schemas }, {}, {}, {}, {}]);
+
+      try {
+        await new SettingsHandler(
+          connection,
+          languageService,
+          settingsState,
+          validationHandler as unknown as ValidationHandler,
+          {} as Telemetry
+        ).pullConfiguration();
+
+        const result = await languageService.doValidation(setupTextDocument('foo: bar'), false);
+
+        expect(result).length(1);
+        expect(result[0].message).to.equal('Property foo is not allowed.');
+      } finally {
+        schemaProvider.deleteSchema('schemaDetectionDisableFor-settings');
+      }
+    });
+
+    it('schemaDetectionDisableFor should suppress SchemaStore validation', async () => {
+      const schemaUri = 'file:///schemas/github-workflow.json';
+      const githubWorkflowFileMatch = ['.github/workflows/*.yml'];
+      const schemaProvider = TestCustomSchemaProvider.instance();
+      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-github-actions', schemaUri, restrictiveSchema);
+      xhrStub.resolves({
+        responseText: JSON.stringify({
+          schemas: [
+            {
+              name: 'GitHub Workflow',
+              description: 'GitHub Actions workflow schema',
+              fileMatch: githubWorkflowFileMatch,
+              url: schemaUri,
+            },
+          ],
+        }),
+      });
+      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: githubWorkflowFileMatch }, {}, {}, {}, {}]);
+
+      try {
+        await new SettingsHandler(
+          connection,
+          languageService,
+          settingsState,
+          validationHandler as unknown as ValidationHandler,
+          {} as Telemetry
+        ).pullConfiguration();
+
+        const result = await languageService.doValidation(
+          setupSchemaIDTextDocument('foo: bar', 'file:///workspace/.github/workflows/build.yml'),
+          false
+        );
+
+        expect(result).length(0);
+      } finally {
+        schemaProvider.deleteSchema('schemaDetectionDisableFor-github-actions');
+      }
+    });
+
+    it('schemaDetectionDisableFor should not suppress modeline validation', async () => {
+      const schemaUri = 'file:///schemas/schema-detection-disable-modeline.json';
+      const schemaProvider = TestCustomSchemaProvider.instance();
+      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-modeline', schemaUri, restrictiveSchema);
+      xhrStub.resolves({ responseText: '{"schemas":[]}' });
+      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: ['test.yaml'] }, {}, {}, {}, {}]);
+
+      try {
+        await new SettingsHandler(
+          connection,
+          languageService,
+          settingsState,
+          validationHandler as unknown as ValidationHandler,
+          {} as Telemetry
+        ).pullConfiguration();
+
+        const result = await languageService.doValidation(
+          setupTextDocument(`# yaml-language-server: $schema=${schemaUri}\nfoo: bar`),
+          false
+        );
+
+        expect(result).length(1);
+        expect(result[0].message).to.equal('Property foo is not allowed.');
+      } finally {
+        schemaProvider.deleteSchema('schemaDetectionDisableFor-modeline');
+      }
     });
   });
 

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -322,7 +322,7 @@ describe('Settings Handlers Tests', () => {
       }]}`,
       });
       const disabledSchemaFileMatch = ['foo/*.yml'];
-      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: disabledSchemaFileMatch }, {}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{ disableSchemaDetection: disabledSchemaFileMatch }, {}, {}, {}, {}]);
       const configureSpy = await configureSchemaPriorityTest();
 
       expect(configureSpy.schemas).deep.include({
@@ -346,7 +346,7 @@ describe('Settings Handlers Tests', () => {
       }]}`,
       });
       const disabledSchemaFileMatch = 'foo/*.yml';
-      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: disabledSchemaFileMatch }, {}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{ disableSchemaDetection: disabledSchemaFileMatch }, {}, {}, {}, {}]);
       const configureSpy = await configureSchemaPriorityTest();
 
       expect(configureSpy.schemas).deep.include({
@@ -402,7 +402,7 @@ describe('Settings Handlers Tests', () => {
     });
   });
 
-  describe('Test schemaDetectionDisableFor validation behavior', () => {
+  describe('Test disableSchemaDetection validation behavior', () => {
     const restrictiveSchema = {
       type: 'object',
       additionalProperties: false,
@@ -413,14 +413,14 @@ describe('Settings Handlers Tests', () => {
       },
     };
 
-    it('schemaDetectionDisableFor should not suppress yaml.schemas validation because settings schemas have higher priority', async () => {
+    it('disableSchemaDetection should suppress yaml.schemas validation', async () => {
       const schemaUri = 'file:///schemas/schema-detection-disable-settings.json';
       const schemaProvider = TestCustomSchemaProvider.instance();
-      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-settings', schemaUri, restrictiveSchema);
+      schemaProvider.addSchemaWithUri('disableSchemaDetection-settings', schemaUri, restrictiveSchema);
       xhrStub.resolves({ responseText: '{"schemas":[]}' });
       const schemas = {};
       schemas[schemaUri] = 'test.yaml';
-      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: ['test.yaml'], schemas }, {}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{ disableSchemaDetection: ['test.yaml'], schemas }, {}, {}, {}, {}]);
 
       try {
         await new SettingsHandler(
@@ -433,18 +433,17 @@ describe('Settings Handlers Tests', () => {
 
         const result = await languageService.doValidation(setupTextDocument('foo: bar'), false);
 
-        expect(result).length(1);
-        expect(result[0].message).to.equal('Property foo is not allowed.');
+        expect(result).length(0);
       } finally {
-        schemaProvider.deleteSchema('schemaDetectionDisableFor-settings');
+        schemaProvider.deleteSchema('disableSchemaDetection-settings');
       }
     });
 
-    it('schemaDetectionDisableFor should suppress SchemaStore validation', async () => {
+    it('disableSchemaDetection should suppress SchemaStore validation', async () => {
       const schemaUri = 'file:///schemas/github-workflow.json';
       const githubWorkflowFileMatch = ['.github/workflows/*.yml'];
       const schemaProvider = TestCustomSchemaProvider.instance();
-      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-github-actions', schemaUri, restrictiveSchema);
+      schemaProvider.addSchemaWithUri('disableSchemaDetection-github-actions', schemaUri, restrictiveSchema);
       xhrStub.resolves({
         responseText: JSON.stringify({
           schemas: [
@@ -457,7 +456,7 @@ describe('Settings Handlers Tests', () => {
           ],
         }),
       });
-      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: githubWorkflowFileMatch }, {}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{ disableSchemaDetection: githubWorkflowFileMatch }, {}, {}, {}, {}]);
 
       try {
         await new SettingsHandler(
@@ -475,16 +474,16 @@ describe('Settings Handlers Tests', () => {
 
         expect(result).length(0);
       } finally {
-        schemaProvider.deleteSchema('schemaDetectionDisableFor-github-actions');
+        schemaProvider.deleteSchema('disableSchemaDetection-github-actions');
       }
     });
 
-    it('schemaDetectionDisableFor should not suppress modeline validation', async () => {
+    it('disableSchemaDetection should not suppress modeline validation', async () => {
       const schemaUri = 'file:///schemas/schema-detection-disable-modeline.json';
       const schemaProvider = TestCustomSchemaProvider.instance();
-      schemaProvider.addSchemaWithUri('schemaDetectionDisableFor-modeline', schemaUri, restrictiveSchema);
+      schemaProvider.addSchemaWithUri('disableSchemaDetection-modeline', schemaUri, restrictiveSchema);
       xhrStub.resolves({ responseText: '{"schemas":[]}' });
-      workspaceStub.getConfiguration.resolves([{ schemaDetectionDisableFor: ['test.yaml'] }, {}, {}, {}, {}]);
+      workspaceStub.getConfiguration.resolves([{ disableSchemaDetection: ['test.yaml'] }, {}, {}, {}, {}]);
 
       try {
         await new SettingsHandler(
@@ -503,7 +502,7 @@ describe('Settings Handlers Tests', () => {
         expect(result).length(1);
         expect(result[0].message).to.equal('Property foo is not allowed.');
       } finally {
-        schemaProvider.deleteSchema('schemaDetectionDisableFor-modeline');
+        schemaProvider.deleteSchema('disableSchemaDetection-modeline');
       }
     });
   });


### PR DESCRIPTION
### What does this PR do?

Adds the `yaml.disableSchemaDetection` setting for disabling automatically detected schemas for specific YAML files by glob pattern. The expected value is a glob pattern or list of glob patterns.

This is intended for cases where schemas from Schema Store or schema association notifications are incorrectly applied to files with generic names. Explicit schemas still take precedence, so users can continue to opt into validation with the `yaml.schemas` setting or a modeline.

Also update https://github.com/redhat-developer/yaml-language-server/pull/1251/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116 because absolute paths in `yaml.schemas` does work fine.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/245

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing. Tried with the setting:
   ```json
   "yaml.disableSchemaDetection": ["*sam*"],
   ```
   or
   ```json
   "yaml.disableSchemaDetection": "*sam*",
   ```
   and a file named `some.sam.yml` with following content:
    ```yaml
    name: example
    version: 1
    enabled: true
    items:
      - one
      - two
    ```