### PR TITLE
Fix indent on enter for nested maps

### DIFF
--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
-import { Position, Range, TextEdit } from 'vscode-languageserver-types';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position, Range, TextEdit } from 'vscode-languageserver-types';
 import { TextBuffer } from '../utils/textBuffer';
 
 export function doDocumentOnTypeFormatting(
@@ -16,29 +16,33 @@ export function doDocumentOnTypeFormatting(
   const tb = new TextBuffer(document);
   if (params.ch === '\n') {
     const previousLine = tb.getLineContent(position.line - 1);
-    if (previousLine.trimRight().endsWith(':')) {
-      const currentLine = tb.getLineContent(position.line);
-      const subLine = currentLine.substring(position.character, currentLine.length);
-      const isInArray = previousLine.indexOf(' - ') !== -1;
-      if (subLine.trimRight().length === 0) {
-        const indentationFix = position.character - (previousLine.length - previousLine.trimLeft().length);
-        if (indentationFix === params.options.tabSize && !isInArray) {
-          return; // skip if line already has proper formatting
-        }
-        const result = [];
-        if (currentLine.length > 0) {
-          result.push(TextEdit.del(Range.create(position, Position.create(position.line, currentLine.length - 1))));
-        }
-        result.push(TextEdit.insert(position, ' '.repeat(params.options.tabSize + (isInArray ? 2 - indentationFix : 0))));
-
-        return result;
+    if (previousLine.trimEnd().endsWith(':')) {
+      let expectedIndentationLength = previousLine.length - previousLine.trimStart().length + params.options.tabSize;
+      if (previousLine.trimStart().startsWith('-')) {
+        expectedIndentationLength += params.options.tabSize;
       }
-      if (isInArray) {
-        return [TextEdit.insert(position, ' '.repeat(params.options.tabSize))];
+      const currentLine = tb.getLineContent(position.line);
+      if (currentLine.trim().length !== 0) {
+        // non-space content, do nothing
+        return;
+      } else if (currentLine.length === expectedIndentationLength) {
+        // already right; do nothing
+        return;
+      } else if (currentLine.length < expectedIndentationLength) {
+        return [TextEdit.insert(position, ' '.repeat(expectedIndentationLength - currentLine.length))];
+      } else {
+        return [
+          TextEdit.del(
+            Range.create(
+              Position.create(position.line, 0),
+              Position.create(position.line, currentLine.length - expectedIndentationLength)
+            )
+          ),
+        ];
       }
     }
 
-    if (previousLine.trimRight().endsWith('|')) {
+    if (previousLine.trimEnd().endsWith('|')) {
       return [TextEdit.insert(position, ' '.repeat(params.options.tabSize))];
     }
 

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -48,12 +48,31 @@ describe('YAML On Type Formatter', () => {
     expect(result).to.deep.include(TextEdit.insert(pos, '    '));
   });
 
-  it('should replace all spaces in newline', () => {
+  it('should replace excess spaces in newline', () => {
     const doc = setupTextDocument('some:\n    ');
     const pos = Position.create(1, 0);
     const params = createParams(pos);
     const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result).to.deep.include.members([TextEdit.del(Range.create(pos, Position.create(1, 3))), TextEdit.insert(pos, '  ')]);
+    expect(result.length).to.equal(1);
+    expect(result[0]).to.deep.equal(TextEdit.del(Range.create(Position.create(1, 0), Position.create(1, 2))));
+  });
+
+  it('should handle nested maps', () => {
+    const doc = setupTextDocument('some:\n  BODY:\n  ');
+    const pos = Position.create(2, 2);
+    const params = createParams(pos);
+    const result = doDocumentOnTypeFormatting(doc, params);
+    expect(result).to.have.length(1);
+    expect(result[0]).to.deep.equal(TextEdit.insert(pos, '  '));
+  });
+
+  it('should handle nested arrays', () => {
+    const doc = setupTextDocument('some:\n  - BODY:\n  ');
+    const pos = Position.create(2, 2);
+    const params = createParams(pos);
+    const result = doDocumentOnTypeFormatting(doc, params);
+    expect(result).to.have.length(1);
+    expect(result[0]).to.deep.equal(TextEdit.insert(pos, '    '));
   });
 
   it('should keep all non white spaces characters in newline', () => {


### PR DESCRIPTION
### What does this PR do?
- Fixes indent on enter for nested maps
- Simplify code so that it adds or removes spaces based on what's already present instead of completely replacing it

### What issues does this PR fix or reference?
Fixes redhat-developer/vscode-yaml#1226

### Is it tested? How?
Modified existing unit tests and added new ones for the nested cases