### PR TITLE
Support return types for `yaml.customTags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following settings are supported:
 - `yaml.schemaStore.url`: URL of a schema store catalog to use when downloading schemas.
 - `yaml.kubernetesCRDStore.enable`: When set to true the YAML language server will parse Kubernetes CRDs automatically and download them from the [CRD store](https://github.com/datreeio/CRDs-catalog).
 - `yaml.kubernetesCRDStore.url`: URL of a crd store catalog to use when downloading schemas. Defaults to `https://raw.githubusercontent.com/datreeio/CRDs-catalog/main`.
-- `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" and it will automatically map !Ref to scalar or you can specify the type of the object !Ref should be e.g. "!Ref sequence". The type of object can be either scalar (for strings and booleans), sequence (for arrays), map (for objects).
+- `yaml.customTags`: Array of custom tags that the parser will validate against. It has three ways to be used. A tag without a type, such as "!Ref", is treated as a scalar tag. A tag with a node type, such as "!Ref sequence", specifies the YAML node type that the tag is written on. A tag with a node type and return type, such as "!FindInMap sequence:string", also specifies the schema type that the tagged value evaluates to. Supported node types are scalar, sequence, and mapping. Supported return types are string, number, integer, boolean, null, array, and object. The return type aliases scalar, sequence, and mapping are accepted as string, array, and object.
 - `yaml.maxItemsComputed`: The maximum number of outline symbols and folding regions computed (limited for performance reasons).
 - `[yaml].editor.tabSize`: the number of spaces to use when autocompleting. Takes priority over editor.tabSize.
 - `editor.tabSize`: the number of spaces to use when autocompleting. Default is 2.
@@ -93,11 +93,13 @@ In order to use the custom tags in your YAML file you need to first specify the 
 "yaml.customTags": [
     "!Scalar-example scalar",
     "!Seq-example sequence",
-    "!Mapping-example mapping"
+    "!Mapping-example mapping",
+    "!Seq-as-string-example sequence:string"
 ]
 ```
 
-The !Scalar-example would map to a scalar custom tag, the !Seq-example would map to a sequence custom tag, the !Mapping-example would map to a mapping custom tag.
+The !Scalar-example would map to a scalar custom tag, the !Seq-example would map to a sequence custom tag, and the !Mapping-example would map to a mapping custom tag.
+The !Seq-as-string-example would map to a sequence custom tag, and the whole tagged value would be treated as a string during schema validation.
 
 We can then use the newly defined custom tags inside our YAML file:
 
@@ -109,6 +111,9 @@ some_sequence: !Seq-example
 some_mapping: !Mapping-example
   some_mapping_key_1: some_mapping_value_1
   some_mapping_key_2: some_mapping_value_2
+some_string: !Seq-as-string-example
+  - value_1
+  - value_2
 ```
 
 ##### Associating a schema to a glob pattern via yaml.schemas:

--- a/src/languageservice/jsonASTTypes.ts
+++ b/src/languageservice/jsonASTTypes.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Node, Pair } from 'yaml';
+import type { CustomTagReturnType } from './utils/customTags';
 
 export type YamlNode = Node | Pair;
 
@@ -25,6 +26,7 @@ export interface BaseASTNode {
   readonly value?: string | boolean | number | null;
   readonly internalNode: YamlNode;
   location: string;
+  customTagReturnType?: CustomTagReturnType;
   getNodeFromOffsetEndInclusive(offset: number): ASTNode;
 }
 export interface ObjectASTNode extends BaseASTNode {

--- a/src/languageservice/parser/ast-converter.ts
+++ b/src/languageservice/parser/ast-converter.ts
@@ -20,6 +20,7 @@ import {
   LineCounter,
 } from 'yaml';
 import { ASTNode, YamlNode } from '../jsonASTTypes';
+import { getCustomTagReturnType } from '../utils/customTags';
 import {
   NullASTNodeImpl,
   PropertyASTNodeImpl,
@@ -49,23 +50,25 @@ export function convertAST(parent: ASTNode, node: YamlNode, doc: Document, lineC
   if (!node) {
     return null;
   }
+
+  let result: ASTNode | undefined;
   if (isMap(node)) {
-    return convertMap(node, parent, doc, lineCounter);
+    result = convertMap(node, parent, doc, lineCounter);
+  } else if (isPair(node)) {
+    result = convertPair(node, parent, doc, lineCounter);
+  } else if (isSeq(node)) {
+    result = convertSeq(node, parent, doc, lineCounter);
+  } else if (isScalar(node)) {
+    result = convertScalar(node, parent);
+  } else if (isAlias(node) && aliasDepth.currentRefDepth < aliasDepth.maxRefCount) {
+    result = convertAlias(node, parent, doc, lineCounter);
   }
-  if (isPair(node)) {
-    return convertPair(node, parent, doc, lineCounter);
+
+  if (result && isNode(node)) {
+    result.customTagReturnType = getCustomTagReturnType(node);
   }
-  if (isSeq(node)) {
-    return convertSeq(node, parent, doc, lineCounter);
-  }
-  if (isScalar(node)) {
-    return convertScalar(node, parent);
-  }
-  if (isAlias(node) && aliasDepth.currentRefDepth < aliasDepth.maxRefCount) {
-    return convertAlias(node, parent, doc, lineCounter);
-  } else {
-    return;
-  }
+
+  return result;
 }
 
 function convertMap(node: YAMLMap<unknown, unknown>, parent: ASTNode, doc: Document, lineCounter: LineCounter): ASTNode {

--- a/src/languageservice/parser/custom-tag-provider.ts
+++ b/src/languageservice/parser/custom-tag-provider.ts
@@ -1,13 +1,15 @@
-import { Tags, isSeq, isMap, YAMLMap, YAMLSeq } from 'yaml';
-import { filterInvalidCustomTags } from '../utils/arrUtils';
+import { Tags, isSeq, isMap, YAMLMap, YAMLSeq, Scalar } from 'yaml';
+import { CustomTagInputType, CustomTagReturnType, parseCustomTag, setCustomTagReturnType } from '../utils/customTags';
 
 class CommonTagImpl {
   tag: string;
-  readonly type: string;
+  readonly type: CustomTagInputType;
+  readonly returnType?: CustomTagReturnType;
   default: never;
-  constructor(tag: string, type: string) {
+  constructor(tag: string, type: CustomTagInputType, returnType?: CustomTagReturnType) {
     this.tag = tag;
     this.type = type;
+    this.returnType = returnType;
   }
   get collection(): 'map' | 'seq' | never {
     if (this.type === 'mapping') {
@@ -19,16 +21,29 @@ class CommonTagImpl {
     return undefined;
   }
   identify?: (value: unknown) => boolean;
-  resolve(value: string | YAMLMap | YAMLSeq): string | YAMLMap | YAMLSeq {
+  resolve(value: string | YAMLMap | YAMLSeq): string | YAMLMap | YAMLSeq | Scalar {
     if (isMap(value) && this.type === 'mapping') {
-      return value;
+      return this.addReturnTypeMetadata(value);
     }
     if (isSeq(value) && this.type === 'sequence') {
-      return value;
+      return this.addReturnTypeMetadata(value);
     }
     if (typeof value === 'string' && this.type === 'scalar') {
+      return this.addReturnTypeMetadata(value);
+    }
+  }
+
+  private addReturnTypeMetadata(value: string | YAMLMap | YAMLSeq): string | YAMLMap | YAMLSeq | Scalar {
+    if (!this.returnType) {
       return value;
     }
+    if (typeof value === 'string') {
+      const scalar = new Scalar(value);
+      setCustomTagReturnType(scalar, this.returnType);
+      return scalar;
+    }
+    setCustomTagReturnType(value, this.returnType);
+    return value;
   }
 }
 
@@ -53,12 +68,11 @@ class IncludeTag {
  */
 export function getCustomTags(customTags: string[]): Tags {
   const tags = [];
-  const filteredTags = filterInvalidCustomTags(customTags);
-  for (const tag of filteredTags) {
-    const typeInfo = tag.split(' ');
-    const tagName = typeInfo[0];
-    const tagType = (typeInfo[1] && typeInfo[1].toLowerCase()) || 'scalar';
-    tags.push(new CommonTagImpl(tagName, tagType));
+  for (const tag of customTags ?? []) {
+    const parsedTag = parseCustomTag(tag);
+    if (parsedTag) {
+      tags.push(new CommonTagImpl(parsedTag.tag, parsedTag.inputType, parsedTag.returnType));
+    }
   }
   tags.push(new IncludeTag());
   return tags;

--- a/src/languageservice/parser/jsonDocument.ts
+++ b/src/languageservice/parser/jsonDocument.ts
@@ -15,6 +15,7 @@ import {
   PropertyASTNode,
   YamlNode,
 } from '../jsonASTTypes';
+import type { CustomTagReturnType } from '../utils/customTags';
 import { Diagnostic, Range } from 'vscode-languageserver-types';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Node, Pair } from 'yaml';
@@ -29,6 +30,7 @@ abstract class ASTNodeImpl {
   public length: number;
   public readonly parent: ASTNode;
   public location: string;
+  public customTagReturnType?: CustomTagReturnType;
   readonly internalNode: YamlNode;
 
   constructor(parent: ASTNode, internalNode: YamlNode, offset: number, length?: number) {

--- a/src/languageservice/parser/schemaValidation/baseValidator.ts
+++ b/src/languageservice/parser/schemaValidation/baseValidator.ts
@@ -428,6 +428,18 @@ export abstract class BaseValidator {
    */
   protected abstract getCurrentDialect(): SchemaDialect;
 
+  protected matchesSchemaType(node: ASTNode, schemaType: string): boolean {
+    const type = node.customTagReturnType ?? node.type;
+
+    if (schemaType === 'integer') {
+      return type === 'integer' || (type === 'number' && (node as NumberASTNode).isInteger);
+    }
+    if (schemaType === 'number') {
+      return type === 'number' || type === 'integer';
+    }
+    return type === schemaType;
+  }
+
   // ---------------- core traversal ----------------
   protected validateNode(
     node: ASTNode,
@@ -515,9 +527,7 @@ export abstract class BaseValidator {
   ): void {
     const { isKubernetes, callFromAutoComplete } = options;
 
-    const matchesType = (type: string): boolean => {
-      return node.type === type || (type === 'integer' && node.type === 'number' && (node as NumberASTNode).isInteger);
-    };
+    const matchesType = (type: string): boolean => this.matchesSchemaType(node, type);
 
     const mergeEvaluated = (target: ValidationResult, source: ValidationResult): void => {
       if (source.evaluatedProperties) {
@@ -1596,7 +1606,7 @@ export abstract class BaseValidator {
           maxOneMatch &&
           bestMatch.schema.type === 'object' &&
           node.type !== 'null' &&
-          node.type !== bestMatch.schema.type)
+          (node.customTagReturnType ?? node.type) !== bestMatch.schema.type)
       ) {
         bestMatch = { schema: subSchema, validationResult: subValidationResult, matchingSchemas: subMatchingSchemas };
       } else if (compareResult === 0 || ((node.value === null || node.type === 'null') && node.length === 0)) {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -18,10 +18,11 @@ import {
   TextEdit,
 } from 'vscode-languageserver-types';
 import { Node, isPair, isScalar, isMap, YAMLMap, isSeq, YAMLSeq, isNode, Pair } from 'yaml';
+import { parseCustomTag } from '../utils/customTags';
 import { Telemetry } from '../telemetry';
 import { SingleYAMLDocument, YamlDocuments } from '../parser/yaml-documents';
 import { YamlVersion } from '../parser/yamlParser07';
-import { filterInvalidCustomTags, matchOffsetToDocument } from '../utils/arrUtils';
+import { matchOffsetToDocument } from '../utils/arrUtils';
 import { guessIndentation } from '../utils/indentationGuesser';
 import { TextBuffer } from '../utils/textBuffer';
 import { LanguageSettings } from '../yamlLanguageService';
@@ -1625,12 +1626,12 @@ export class YamlCompletion {
   }
 
   private getCustomTagValueCompletions(collector: CompletionsCollector): void {
-    const validCustomTags = filterInvalidCustomTags(this.customTags);
-    validCustomTags.forEach((validTag) => {
-      // Valid custom tags are guarenteed to be strings
-      const label = validTag.split(' ')[0];
-      this.addCustomTagValueCompletion(collector, ' ', label);
-    });
+    for (const customTag of this.customTags ?? []) {
+      const parsedTag = parseCustomTag(customTag);
+      if (parsedTag) {
+        this.addCustomTagValueCompletion(collector, ' ', parsedTag.tag);
+      }
+    }
   }
 
   private addCustomTagValueCompletion(collector: CompletionsCollector, separatorAfter: string, label: string): void {

--- a/src/languageservice/utils/arrUtils.ts
+++ b/src/languageservice/utils/arrUtils.ts
@@ -55,27 +55,6 @@ export function matchOffsetToDocument(offset: number, jsonDocuments: YAMLDocumen
   return null;
 }
 
-export function filterInvalidCustomTags(customTags: string[]): string[] {
-  const validCustomTags = ['mapping', 'scalar', 'sequence'];
-
-  if (!customTags) {
-    return [];
-  }
-  return customTags.filter((tag) => {
-    if (typeof tag === 'string') {
-      const typeInfo = tag.split(' ');
-      const type = (typeInfo[1] && typeInfo[1].toLowerCase()) || 'scalar';
-
-      // We need to check if map is a type because map will throw an error within the yaml-ast-parser
-      if (type === 'map') {
-        return false;
-      }
-
-      return validCustomTags.indexOf(type) !== -1;
-    }
-    return false;
-  });
-}
 export function isArrayEqual(fst: Array<unknown>, snd: Array<unknown>): boolean {
   if (!snd || !fst) {
     return false;

--- a/src/languageservice/utils/customTags.ts
+++ b/src/languageservice/utils/customTags.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) IBM Corp. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export type CustomTagInputType = 'mapping' | 'scalar' | 'sequence';
+export type CustomTagReturnType = 'object' | 'array' | 'string' | 'number' | 'integer' | 'boolean' | 'null';
+
+export interface CustomTag {
+  tag: string;
+  inputType: CustomTagInputType;
+  returnType?: CustomTagReturnType;
+}
+
+const validCustomTagInputTypes: CustomTagInputType[] = ['mapping', 'scalar', 'sequence'];
+
+const customTagReturnTypeAliases: Record<string, CustomTagReturnType> = {
+  mapping: 'object',
+  object: 'object',
+  sequence: 'array',
+  array: 'array',
+  scalar: 'string',
+  string: 'string',
+  number: 'number',
+  integer: 'integer',
+  boolean: 'boolean',
+  null: 'null',
+};
+
+export function parseCustomTag(customTagStr: unknown): CustomTag | undefined {
+  if (typeof customTagStr !== 'string') return undefined;
+
+  const typeInfo = customTagStr.trim().split(/\s+/);
+  const tag = typeInfo[0];
+  if (!tag) return undefined;
+
+  const rawType = (typeInfo[1] && typeInfo[1].toLowerCase()) || 'scalar';
+  const [inputType, returnType, extra] = rawType.split(':');
+  const normalizedInputType = validCustomTagInputTypes.find((validType) => validType === inputType);
+  if (extra || !normalizedInputType) return undefined;
+  if (!rawType.includes(':')) {
+    return { tag, inputType: normalizedInputType };
+  }
+
+  const normalizedReturnType = customTagReturnTypeAliases[returnType];
+  if (!normalizedReturnType) return undefined;
+
+  return { tag, inputType: normalizedInputType, returnType: normalizedReturnType };
+}
+
+export function getCustomTagReturnType(node: unknown): CustomTagReturnType | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+
+  const returnType = (node as { customTagReturnType?: unknown }).customTagReturnType;
+  if (typeof returnType !== 'string') {
+    return undefined;
+  }
+
+  return Object.values(customTagReturnTypeAliases).includes(returnType as CustomTagReturnType)
+    ? (returnType as CustomTagReturnType)
+    : undefined;
+}
+
+export function setCustomTagReturnType(node: unknown, returnType: CustomTagReturnType | undefined): void {
+  if (returnType && node && typeof node === 'object') {
+    (node as { customTagReturnType?: CustomTagReturnType }).customTagReturnType = returnType;
+  }
+}

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -63,6 +63,16 @@ describe('Custom Tag tests Tests', () => {
         .then(done, done);
     });
 
+    it('Custom Tags with input and return types', (done) => {
+      const content = 'resolvers: !Ref\n  - test';
+      const validator = parseSetup(content, ['!Ref sequence:string']);
+      validator
+        .then(function (result) {
+          assert.equal(result.length, 0);
+        })
+        .then(done, done);
+    });
+
     it('Allow multiple different custom tag types with different use', (done) => {
       const content = '!test\nhello: !test\n  world';
       const validator = parseSetup(content, ['!test scalar', '!test mapping']);

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -40,7 +40,6 @@ describe('Validation Tests', () => {
     languageSettingsSetup = new ServiceSetup()
       .withValidate()
       .withCompletion()
-      .withCustomTags(['!Test', '!Ref sequence'])
       .withSchemaFileMatch({ uri: KUBERNETES_SCHEMA_URL, fileMatch: ['.drone.yml'] })
       .withSchemaFileMatch({ uri: 'https://json.schemastore.org/drone', fileMatch: ['.drone.yml'] })
       .withSchemaFileMatch({ uri: KUBERNETES_SCHEMA_URL, fileMatch: ['test.yml'] })
@@ -69,7 +68,13 @@ describe('Validation Tests', () => {
     return validationHandler.validateTextDocument(testTextDocument);
   }
 
+  function configureCustomTags(customTags: string[]): void {
+    languageSettingsSetup.languageSettings.customTags = customTags;
+    languageService.configure(languageSettingsSetup.languageSettings);
+  }
+
   afterEach(() => {
+    configureCustomTags([]);
     schemaProvider.deleteSchema(SCHEMA_ID);
   });
 
@@ -1112,6 +1117,7 @@ obj:
 
   describe('Custom tag tests', () => {
     it('Custom Tags without type', async () => {
+      configureCustomTags(['!Test']);
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1139,6 +1145,7 @@ obj:
     });
 
     it('Custom Tags with type', (done) => {
+      configureCustomTags(['!Ref sequence']);
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1186,6 +1193,37 @@ obj:
           assert.deepEqual(result[0], createExpectedError(IncludeWithoutValueError, 0, 11, 0, 19));
         })
         .then(done, done);
+    });
+
+    it('Custom Tags with return type validate against evaluated schema type', async () => {
+      configureCustomTags(['!Ref scalar:string', '!FindInMap sequence:string']);
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          ImageId: {
+            type: 'string',
+          },
+        },
+      });
+      const content = 'ImageId: !FindInMap [AWSRegionArch2AMI, !Ref "AWS::Region", HVM64]';
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
+    });
+
+    it('Custom Tags without return type still validate against input node type', async () => {
+      configureCustomTags(['!Ref scalar:string', '!FindInMap sequence']);
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          ImageId: {
+            type: 'string',
+          },
+        },
+      });
+      const content = 'ImageId: !FindInMap [AWSRegionArch2AMI, !Ref "AWS::Region", HVM64]';
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.ok(result[0].message.includes('Incorrect type. Expected "string".'));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds optional return types to the `yaml.customTags` setting.

Previously, a custom tag could only describe the YAML node type the tag is written on. For example, `"!Seq-example sequence"` tells the parser that `!Seq-example` would map to a sequence custom tag, but schema validation still treats the tagged value as a sequence.

This PR adds a new form `"!Tag nodeType:returnType"`, where `nodeType` specifies the YAML node type that the tag is written on, and `returnType` specifies the schema type that the tagged value evaluates to.

`yaml.customTags` now supports three forms:
```
!Tag
!Tag nodeType
!Tag nodeType:returnType
```

Existing configurations remain supported, so this is backward compatible. Behavior only changes when a user explicitly adds `:returnType`.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/867

Note that `yaml.customTags` only applies to YAML short-form tags. It does not apply to CloudFormation long form such as `Fn::...`. Long form values are normal YAML mappings, not YAML tags.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing:

1. Add the following `yaml.customTags` configuration in workspace setting (a list of all intrinsic functions in short form with return types added, based on the [AWS CloudFormation intrinsic function docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)):
```json
{
  "yaml.customTags": [
    "!Base64 scalar:string",
    "!Cidr sequence:array",
    "!And sequence:boolean",
    "!Equals sequence:boolean",
    "!If sequence",
    "!Not sequence:boolean",
    "!Or sequence:boolean",
    "!Condition scalar:boolean",
    "!FindInMap sequence:string",
    "!GetAtt scalar:string",
    "!GetAtt sequence:string",
    "!GetAZs scalar:array",
    "!ImportValue scalar:string",
    "!Join sequence:string",
    "!Select sequence:string",
    "!Split sequence:array",
    "!Sub scalar:string",
    "!Sub sequence:string",
    "!Transform mapping",
    "!Ref scalar:string"
  ]
}
```

2. Create a file named `template.yaml` with the following content:
```yaml
Resources:
  EC2Instance:
    Type: AWS::EC2::Instance
    Properties:
      # example of short-form tag with block sequence input
      AvailabilityZone: !GetAtt
        - Ec2SecurityGroup
        - GroupId

      # example of short-form tag with flow sequence input
      ImageId: !FindInMap [AWSRegionArch2AMI, !Ref "AWS::Region", HVM64]

      # example of short-form tag with scalar input
      InstanceType: !Ref InstanceType

      SecurityGroupIds:
        # example of short-form tag inside an array item
        - !GetAtt
          - Ec2SecurityGroup
          - GroupId
```
3. Expect no errors.