### PR TITLE
Fix "jump to schema location" for POSIX absolute paths

### DIFF
--- a/src/languageservice/services/yamlCommands.ts
+++ b/src/languageservice/services/yamlCommands.ts
@@ -24,7 +24,7 @@ export function registerCommands(commandExecutor: CommandExecutor, connection: C
       const wsUri = URI.parse(wsFolders[0].uri);
       const pathFromUri = URI.parse(uri).path;
       uri = wsUri.with({ path: pathFromUri }).toString();
-    } else if (!uri.startsWith('file') && !/^[a-z]:[\\/]/i.test(uri)) {
+    } else if (!uri.startsWith('file') && !uri.startsWith('/') && !/^[a-z]:[\\/]/i.test(uri)) {
       // if uri points to local file of its a windows path
       const origUri = URI.parse(uri);
       const customUri = URI.from({
@@ -36,10 +36,10 @@ export function registerCommands(commandExecutor: CommandExecutor, connection: C
       uri = customUri.toString();
     }
 
-    // test if uri is windows path, ie starts with 'c:\' and convert to URI
-    if (/^[a-z]:[\\/]/i.test(uri)) {
-      const winUri = URI.file(uri);
-      uri = winUri.toString();
+    // test if uri is a plain local file path and convert it to URI
+    if (uri.startsWith('/') || /^[a-z]:[\\/]/i.test(uri)) {
+      const fileUri = URI.file(uri);
+      uri = fileUri.toString();
     }
 
     const result = await connection.window.showDocument({ uri: uri, external: false, takeFocus: true });

--- a/test/yamlCommands.test.ts
+++ b/test/yamlCommands.test.ts
@@ -73,6 +73,28 @@ describe('Yaml Commands', () => {
     });
   });
 
+  it('JumpToSchema handler should call "showDocument" with plain POSIX path', async () => {
+    const showDocumentStub = sandbox.stub();
+    const getWorkspaceFoldersStub = sandbox.stub().returns(Promise.resolve([]));
+    const connection = {
+      window: {
+        showDocument: showDocumentStub,
+      },
+      workspace: {
+        getWorkspaceFolders: getWorkspaceFoldersStub,
+      },
+    } as unknown as Connection;
+    showDocumentStub.resolves(true);
+    registerCommands(commandExecutor, connection);
+    const arg = commandExecutorStub.args[0];
+    await arg[1]('/some/path/to/schema.json');
+    expect(showDocumentStub).to.have.been.calledWith({
+      uri: URI.file('/some/path/to/schema.json').toString(),
+      external: false,
+      takeFocus: true,
+    });
+  });
+
   it('JumpToSchema handler should call "showDocument" with custom web schema', async () => {
     const showDocumentStub = sandbox.stub();
     const getWorkspaceFoldersStub = sandbox.stub().returns(Promise.resolve([{ uri: 'vscode-test:///root/' }]));


### PR DESCRIPTION
### What does this PR do?
`yaml.schemas` supports local absolute schema paths, but the `JUMP_TO_SCHEMA` command handler only recognized relative paths and Windows paths, but missed POSIX (linux/macOS) absolute paths starting with `/`.

This PR fixes the JUMP_TO_SCHEMA` command to handle POSIX paths properly.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/948

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated test
- [x] Manually tested with the example from the linked issue