### PR TITLE
Fix another bug in indent on enter

### DIFF
--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -21,7 +21,7 @@ export function doDocumentOnTypeFormatting(
       if (previousLine.trimStart().startsWith('-')) {
         expectedIndentationLength += params.options.tabSize;
       }
-      const currentLine = tb.getLineContent(position.line);
+      const currentLine = tb.getLineContent(position.line).replace('\r', '').replace('\n', '');
       if (currentLine.trim().length !== 0) {
         // non-space content, do nothing
         return;

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -66,6 +66,15 @@ describe('YAML On Type Formatter', () => {
     expect(result[0]).to.deep.equal(TextEdit.insert(pos, '  '));
   });
 
+  it('should handle nested maps with content afterwards', () => {
+    const doc = setupTextDocument('some:\n  BODY:\n  \n  foo: asdf');
+    const pos = Position.create(2, 2);
+    const params = createParams(pos);
+    const result = doDocumentOnTypeFormatting(doc, params);
+    expect(result).to.have.length(1);
+    expect(result[0]).to.deep.equal(TextEdit.insert(pos, '  '));
+  });
+
   it('should handle nested arrays', () => {
     const doc = setupTextDocument('some:\n  - BODY:\n  ');
     const pos = Position.create(2, 2);


### PR DESCRIPTION
### What does this PR do?
Fixes indent on enter in a nested map that has content after it. I didn't test this case when I was writing the first fix.

eg. turn on formatting on enter, then try hitting enter after `hjkl:`:

```yaml
asdf:
  hjkl:
  description: some content
```

### What issues does this PR fix or reference?
Fixes #1258

### Is it tested? How?
Manually, and with a new unit test.
