### PR TITLE
Fix handling of absolute local schema paths from `yaml.schemas` and `yaml/get/jsonSchema` StackOverflow

### DIFF
--- a/src/languageserver/handlers/schemaSelectionHandlers.ts
+++ b/src/languageserver/handlers/schemaSelectionHandlers.ts
@@ -7,7 +7,6 @@ import { Connection } from 'vscode-languageserver/node';
 import { JSONSchema } from '../../languageservice/jsonSchema';
 import { yamlDocumentsCache } from '../../languageservice/parser/yaml-documents';
 import { YAMLSchemaService } from '../../languageservice/services/yamlSchemaService';
-import { getSchemaUrls } from '../../languageservice/utils/schemaUrls';
 import { SettingsState } from '../../yamlSettings';
 import { JSONSchemaDescription, JSONSchemaDescriptionExt, SchemaSelectionRequests } from '../../requestTypes';
 
@@ -47,15 +46,14 @@ export class JSONSchemaSelection {
     const yamlDoc = yamlDocumentsCache.getYamlDocument(document);
 
     for (const currentYAMLDoc of yamlDoc.documents) {
-      const schema = await this.schemaService.getSchemaForResource(document.uri, currentYAMLDoc);
-      if (schema?.schema) {
-        const schemaUrls = getSchemaUrls(schema?.schema);
-        if (schemaUrls.size === 0) {
-          continue;
-        }
-        for (const urlToSchema of schemaUrls) {
-          schemas.set(urlToSchema[0], urlToSchema[1]);
-        }
+      const schemaDescriptions = await this.schemaService.getSchemaDescriptionsForResource(document.uri, currentYAMLDoc);
+      for (const schemaDescription of schemaDescriptions) {
+        schemas.set(schemaDescription.uri, {
+          url: schemaDescription.uri,
+          title: schemaDescription.name,
+          description: schemaDescription.description,
+          versions: schemaDescription.versions,
+        });
       }
     }
     return schemas;

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -19,7 +19,7 @@ import { SchemaPriority, SchemaRequestService, WorkspaceContextService } from '.
 import * as l10n from '@vscode/l10n';
 import * as path from 'path';
 import { URI } from 'vscode-uri';
-import { JSONSchemaDescriptionExt } from '../../requestTypes';
+import { JSONSchemaDescription, JSONSchemaDescriptionExt } from '../../requestTypes';
 import { JSONDocument } from '../parser/jsonDocument';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { SchemaVersions } from '../yamlTypes';
@@ -206,6 +206,103 @@ export class YAMLSchemaService extends JSONSchemaService {
   private schemaMapValues(map?: JSONSchemaMap): JSONSchemaRef[] | undefined {
     if (!map || typeof map !== 'object') return undefined;
     return Object.values(map);
+  }
+
+  private resolveModelineSchema(resource: string, doc: JSONDocument): string | undefined {
+    let schemaFromModeline = getSchemaFromModeline(doc);
+    if (schemaFromModeline !== undefined) {
+      if (!schemaFromModeline.startsWith('file:') && !schemaFromModeline.startsWith('http')) {
+        // If path contains a fragment and it is left intact, "#" will be
+        // considered part of the filename and converted to "%23" by
+        // path.resolve() -> take it out and add back after path.resolve
+        let appendix = '';
+        if (schemaFromModeline.indexOf('#') > 0) {
+          const segments = schemaFromModeline.split('#', 2);
+          schemaFromModeline = segments[0];
+          appendix = segments[1];
+        }
+        if (!path.isAbsolute(schemaFromModeline)) {
+          const resUri = URI.parse(resource);
+          schemaFromModeline = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaFromModeline)).toString();
+        } else {
+          schemaFromModeline = URI.file(schemaFromModeline).toString();
+        }
+        if (appendix.length > 0) {
+          schemaFromModeline += '#' + appendix;
+        }
+      }
+      return schemaFromModeline;
+    }
+  }
+
+  private async getSchemaIdsForResource(resource: string, doc: JSONDocument): Promise<string[]> {
+    const modelineSchema = this.resolveModelineSchema(resource, doc);
+    if (modelineSchema) {
+      return [modelineSchema];
+    }
+
+    if (this.customSchemaProvider) {
+      try {
+        const schemaUri = await this.customSchemaProvider(resource);
+        if (Array.isArray(schemaUri)) {
+          if (schemaUri.length > 0) {
+            return schemaUri;
+          }
+        } else if (schemaUri) {
+          return [schemaUri];
+        }
+      } catch {
+        // Fall back to configured schemas
+      }
+    }
+
+    const seen: { [schemaId: string]: boolean } = Object.create(null);
+    const schemas: string[] = [];
+    for (const entry of this.filePatternAssociations) {
+      if (entry.matchesPattern(resource)) {
+        for (const schemaId of entry.getURIs()) {
+          if (!seen[schemaId]) {
+            schemas.push(schemaId);
+            seen[schemaId] = true;
+          }
+        }
+      }
+    }
+
+    return schemas.length > 0 ? this.highestPrioritySchemas(schemas) : [];
+  }
+
+  public async getSchemaDescriptionsForResource(resource: string, doc: JSONDocument): Promise<JSONSchemaDescription[]> {
+    const schemaIds = await this.getSchemaIdsForResource(resource, doc);
+    const result: JSONSchemaDescription[] = [];
+
+    for (const schemaId of schemaIds) {
+      if (schemaId === EMPTY_SCHEMA_URL) {
+        continue;
+      }
+
+      const metadata = this.schemaUriToNameAndDescription.get(schemaId);
+      let schema: JSONSchema | undefined;
+      if (!metadata) {
+        try {
+          const unresolvedSchema = await this.loadSchema(schemaId);
+          if (unresolvedSchema.schema && typeof unresolvedSchema.schema === 'object') {
+            schema = unresolvedSchema.schema;
+          }
+        } catch {
+          // Keep the schema URI visible even when its content cannot be loaded.
+        }
+      }
+
+      result.push({
+        uri: schemaId,
+        name: metadata?.name ?? schema?.title,
+        description: metadata?.description ?? schema?.description,
+        versions: metadata?.versions ?? schema?.versions,
+      });
+    }
+
+    return result;
   }
 
   async resolveSchemaContent(
@@ -983,33 +1080,6 @@ export class YAMLSchemaService extends JSONSchemaService {
   }
 
   public getSchemaForResource(resource: string, doc: JSONDocument): Promise<ResolvedSchema> {
-    const resolveModelineSchema = (): string | undefined => {
-      let schemaFromModeline = getSchemaFromModeline(doc);
-      if (schemaFromModeline !== undefined) {
-        if (!schemaFromModeline.startsWith('file:') && !schemaFromModeline.startsWith('http')) {
-          // If path contains a fragment and it is left intact, "#" will be
-          // considered part of the filename and converted to "%23" by
-          // path.resolve() -> take it out and add back after path.resolve
-          let appendix = '';
-          if (schemaFromModeline.indexOf('#') > 0) {
-            const segments = schemaFromModeline.split('#', 2);
-            schemaFromModeline = segments[0];
-            appendix = segments[1];
-          }
-          if (!path.isAbsolute(schemaFromModeline)) {
-            const resUri = URI.parse(resource);
-            schemaFromModeline = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaFromModeline)).toString();
-          } else {
-            schemaFromModeline = URI.file(schemaFromModeline).toString();
-          }
-          if (appendix.length > 0) {
-            schemaFromModeline += '#' + appendix;
-          }
-        }
-        return schemaFromModeline;
-      }
-    };
-
     const resolveSchemaForResource = (schemas: string[]): Promise<ResolvedSchema> => {
       const schemaHandle = super.createCombinedSchema(resource, schemas);
       return schemaHandle.getResolvedSchema().then((schema) => {
@@ -1060,7 +1130,7 @@ export class YAMLSchemaService extends JSONSchemaService {
 
       return Promise.resolve(null);
     };
-    const modelineSchema = resolveModelineSchema();
+    const modelineSchema = this.resolveModelineSchema(resource, doc);
     if (modelineSchema) {
       return resolveSchemaForResource([modelineSchema]);
     }

--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -1,5 +1,6 @@
 import { WorkspaceFolder } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
+import * as path from 'path';
 import { Telemetry } from '../telemetry';
 import { JSONSchema, JSONSchemaRef } from '../jsonSchema';
 import { isBoolean } from './objects';
@@ -21,6 +22,9 @@ export function checkSchemaURI(
   if (uri.trim().toLowerCase() === 'kubernetes') {
     telemetry.send({ name: 'yaml.schema.configured', properties: { kubernetes: true } });
     return KUBERNETES_SCHEMA_URL;
+  } else if (path.isAbsolute(uri) || /^[a-z]:[\\/]/i.test(uri)) {
+    const localPath = uri.split('#', 2)[0];
+    return URI.file(localPath).toString() + uri.substring(localPath.length);
   } else if (isRelativePath(uri)) {
     return relativeToAbsolutePath(workspaceFolders, workspaceRoot, uri);
   } else {

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -19,6 +19,7 @@ export interface JSONSchemaDescription {
    * Schema description, from schema store
    */
   description?: string;
+  versions?: SchemaVersions;
 }
 
 export interface JSONSchemaDescriptionExt extends JSONSchemaDescription {
@@ -30,8 +31,6 @@ export interface JSONSchemaDescriptionExt extends JSONSchemaDescription {
    * Is schema from schema store
    */
   fromStore: boolean;
-
-  versions?: SchemaVersions;
 }
 
 export namespace SchemaAssociationNotification {

--- a/test/schemaSelectionHandlers.test.ts
+++ b/test/schemaSelectionHandlers.test.ts
@@ -100,6 +100,75 @@ describe('Schema Selection Handlers', () => {
     });
   });
 
+  it('getSchemas should not resolve schema references', async () => {
+    requestServiceMock = sandbox.fake((uri: string) => {
+      if (uri === 'https://some.com/some.json') {
+        return Promise.resolve(
+          JSON.stringify({
+            title: 'Schema name',
+            description: 'Schema description',
+            properties: {
+              child: {
+                $ref: 'https://some.com/ref.json',
+              },
+            },
+          })
+        );
+      }
+      return Promise.reject(`Resource ${uri} not found.`);
+    });
+    service = new YAMLSchemaService(requestServiceMock);
+    service.registerExternalSchema('https://some.com/some.json', [SCHEMA_ID]);
+    const settings = new SettingsState();
+    const testTextDocument = setupSchemaIDTextDocument('');
+    settings.documents = new TextDocumentTestManager();
+    (settings.documents as TextDocumentTestManager).set(testTextDocument);
+    const selection = new JSONSchemaSelection(service, settings, connection);
+
+    const result = await selection.getSchemas(testTextDocument.uri);
+
+    expect(result).length(1);
+    expect(result[0]).to.be.eqls({
+      uri: 'https://some.com/some.json',
+      name: 'Schema name',
+      description: 'Schema description',
+      versions: undefined,
+    });
+    expect(requestServiceMock).calledOnceWith('https://some.com/some.json');
+    expect(requestServiceMock).not.calledWith('https://some.com/ref.json');
+  });
+
+  it('getSchemas should use registered schema metadata without loading schema content', async () => {
+    const versions = {
+      '1.0.0': 'https://some.com/some-1.0.0.json',
+      '2.0.0': 'https://some.com/some-2.0.0.json',
+    };
+    service.registerExternalSchema(
+      'https://some.com/some.json',
+      [SCHEMA_ID],
+      undefined,
+      'Schema name',
+      'Schema description',
+      versions
+    );
+    const settings = new SettingsState();
+    const testTextDocument = setupSchemaIDTextDocument('');
+    settings.documents = new TextDocumentTestManager();
+    (settings.documents as TextDocumentTestManager).set(testTextDocument);
+    const selection = new JSONSchemaSelection(service, settings, connection);
+
+    const result = await selection.getSchemas(testTextDocument.uri);
+
+    expect(result).length(1);
+    expect(result[0]).to.be.eqls({
+      uri: 'https://some.com/some.json',
+      name: 'Schema name',
+      description: 'Schema description',
+      versions,
+    });
+    expect(requestServiceMock).not.called;
+  });
+
   it('getSchemas should handle empty schemas', async () => {
     const settings = new SettingsState();
     const testTextDocument = setupSchemaIDTextDocument('');

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -338,6 +338,32 @@ describe('Settings Handlers Tests', () => {
         priority: SchemaPriority.Settings,
       });
     });
+    it('Schema Settings should normalize multiple absolute local paths for the same file', async () => {
+      xhrStub.resolves({
+        responseText: '{"schemas":[]}',
+      });
+      const schemaPath1 = '/Users/test/schemas/schema1.json';
+      const schemaPath2 = '/Users/test/schemas/schema2.json';
+      const fileMatch = ['asdf.yaml'];
+      const schemas = {};
+      schemas[schemaPath1] = fileMatch;
+      schemas[schemaPath2] = fileMatch;
+      workspaceStub.getConfiguration.resolves([{ schemas }, {}, {}, {}]);
+      const configureSpy = await configureSchemaSettingsTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: URI.file(schemaPath1).toString(),
+        fileMatch,
+        schema: undefined,
+        priority: SchemaPriority.Settings,
+      });
+      expect(configureSpy.schemas).deep.include({
+        uri: URI.file(schemaPath2).toString(),
+        fileMatch,
+        schema: undefined,
+        priority: SchemaPriority.Settings,
+      });
+    });
   });
 
   describe('Test that schema priorities are available', async () => {

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -8,6 +8,7 @@ import * as request from 'request-light';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
 import { LanguageService, LanguageSettings, SchemaConfiguration, SchemaPriority } from '../src';
 import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
@@ -263,6 +264,79 @@ describe('Settings Handlers Tests', () => {
       name: '.adonisrc.json',
       description: 'AdonisJS configuration file',
       versions: undefined,
+    });
+  });
+
+  describe('Schema URI normalization', () => {
+    const testSchemaFileMatch = ['foo/*.yml'];
+
+    async function configureSchemaSettingsTest(): Promise<LanguageSettings> {
+      const settingsHandler = new SettingsHandler(
+        connection,
+        languageService,
+        settingsState,
+        validationHandler as unknown as ValidationHandler,
+        {} as Telemetry
+      );
+      const configureSpy = sinon.spy(languageService, 'configure');
+      await settingsHandler.pullConfiguration();
+      configureSpy.restore();
+      return configureSpy.args[0][0];
+    }
+
+    it('Schema Settings should normalize absolute local paths', async () => {
+      xhrStub.resolves({
+        responseText: '{"schemas":[]}',
+      });
+      const absoluteSchemaPath = '/Users/test/schemas/schema.json';
+      const schemas = {};
+      schemas[absoluteSchemaPath] = testSchemaFileMatch;
+      workspaceStub.getConfiguration.resolves([{ schemas: schemas }, {}, {}, {}]);
+      const configureSpy = await configureSchemaSettingsTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: URI.file(absoluteSchemaPath).toString(),
+        fileMatch: testSchemaFileMatch,
+        schema: undefined,
+        priority: SchemaPriority.Settings,
+      });
+    });
+
+    it('Schema Settings should preserve fragments when normalizing absolute local paths', async () => {
+      xhrStub.resolves({
+        responseText: '{"schemas":[]}',
+      });
+      const absoluteSchemaPath = '/Users/test/schemas/schema.json';
+      const schemaUri = `${absoluteSchemaPath}#/definitions/foo`;
+      const schemas = {};
+      schemas[schemaUri] = testSchemaFileMatch;
+      workspaceStub.getConfiguration.resolves([{ schemas: schemas }, {}, {}, {}]);
+      const configureSpy = await configureSchemaSettingsTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: `${URI.file(absoluteSchemaPath).toString()}#/definitions/foo`,
+        fileMatch: testSchemaFileMatch,
+        schema: undefined,
+        priority: SchemaPriority.Settings,
+      });
+    });
+
+    it('Schema Settings should preserve remote schema URLs', async () => {
+      xhrStub.resolves({
+        responseText: '{"schemas":[]}',
+      });
+      const schemaUri = 'https://example.com/schemas/schema.json#/definitions/foo';
+      const schemas = {};
+      schemas[schemaUri] = testSchemaFileMatch;
+      workspaceStub.getConfiguration.resolves([{ schemas: schemas }, {}, {}, {}]);
+      const configureSpy = await configureSchemaSettingsTest();
+
+      expect(configureSpy.schemas).deep.include({
+        uri: schemaUri,
+        fileMatch: testSchemaFileMatch,
+        schema: undefined,
+        priority: SchemaPriority.Settings,
+      });
     });
   });
 

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -10,7 +10,7 @@ import * as url from 'url';
 import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import { parse } from '../src/languageservice/parser/yamlParser07';
 import { SettingsState } from '../src/yamlSettings';
-import { BASE_KUBERNETES_SCHEMA_URL, KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
+import { BASE_KUBERNETES_SCHEMA_URL, getSchemaUrls, KUBERNETES_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -449,6 +449,42 @@ describe('YAML Schema Service', () => {
       // _preferLocalBaseForRemoteId should NOT probe for the $id basename as a local sibling
       // when the parent schema was loaded from https:// (not file://)
       expect(requestedUris).to.not.include('https://example.com/schemas/schema.json');
+    });
+
+    it('should resolve and expose multiple local file schemas with absolute local paths', async () => {
+      const content = `foo: bar`;
+      const yamlDock = parse(content);
+      const schemaOneUri = 'file:///Users/test/schemas/schema1.json';
+      const schemaTwoUri = 'file:///Users/test/schemas/schema2.json';
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === schemaOneUri) {
+          return Promise.resolve(JSON.stringify({ title: 'Schema 1', type: 'object' }));
+        }
+        if (uri === schemaTwoUri) {
+          return Promise.resolve(JSON.stringify({ title: 'Schema 2', type: 'object' }));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      service.registerExternalSchema(schemaOneUri, ['test.yaml']);
+      service.registerExternalSchema(schemaTwoUri, ['test.yaml']);
+
+      const schema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.include(schemaOneUri);
+      expect(requestedUris).to.include(schemaTwoUri);
+      expect(requestedUris.some((uri) => uri.startsWith('schemaservice:///'))).to.be.false;
+
+      expect(schema.errors).to.eql([]);
+      expect(schema.schema.url).to.equal('schemaservice://combinedSchema/test.yaml');
+      expect(schema.schema.allOf.map((item) => item.url)).to.have.members([schemaOneUri, schemaTwoUri]);
+
+      const schemaUris = Array.from(getSchemaUrls(schema.schema).keys());
+      expect(schemaUris).to.have.members([schemaOneUri, schemaTwoUri]);
+      expect(schemaUris.some((uri) => uri.startsWith('schemaservice:///'))).to.be.false;
     });
 
     it('should handle modeline schema comment in the middle of file', () => {


### PR DESCRIPTION
### What does this PR do?

1. Fixed handling of absolute local schema paths from `yaml.schemas`

    When multiple schemas with absolute local paths matched the same YAML file, the paths were kept as plain filesystem paths instead of being normalized to `file://` URIs before schema registration.
    
    This causes problem when a YAML file matches multiple schemas:
    - yaml-language-server combines those schemas internally as `schemaservice://combinedSchema/...`
    - because the schema paths were not normalized first, the combined-schema resolution resolved each absolute local schema path `/Users/.../schema.json` against the internal `schemaservice://combinedSchema/...` URI, producing invalid references like `schemaservice:///.../schema.json`
    - schema loading failed with `Unable to load schema from 'schemaservice:///...': No content.`
    
    This PR fixes normalizes absolute local paths from `yaml.schemas` to `file://` URIs before schema registration. This ensures schema registration uses the correct local file URI, so schema validation and schema selection (schema picker) works properly.

2. Fixed `yaml/get/jsonSchema` StackOverflow

    The problem was that the schema picker (status bar) in `vscode-yaml` calls `yaml/get/jsonSchema` only wanting to get schema metadata such as schema URI, name, description, and versions. However, the `yaml/get/jsonSchema` handler in YLS was using the full schema resolution path through the `getSchemaForResource()`. Since this path is intended for validation, it can resolve combined schemas and walk complex `$ref` graphs. When a YAML file matched multiple "large" or "complex" schemas, the metadata request could end up doing deep schema resolution just to render the UI, which could cause a StackOverflow: 
    ```
    [Trace - 3:22:55 PM] Received response 'yaml/get/jsonSchema - (153)' in 22ms.
    Request failed: Request yaml/get/jsonSchema failed with message: Maximum call stack size exceeded (-32603).
    ```
    
    Since `yaml/get/jsonSchema` is used for schema status UI and only needs display metadata for the schemas associated with the current YAML doc, this PR adds a lightweight lookup path for that request to return metadata only without fully resolving the schemas.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1249
Related to https://github.com/redhat-developer/vscode-yaml/pull/1253

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing

To verify absolute local paths from `yaml.schemas` is registered correctly:
1. Map two or more JSON schemas with absolute local paths to the same YAML file:

```json
"yaml.schemas": {
  "/Users/.../schema1.json": "/Users/.../asdf.yaml",
  "/Users/.../schema2.json": "/Users/.../asdf.yaml"
}
```
2. Go to `/Users/.../asdf.yaml`. Verify validation works and no error appears like `Problems loading reference 'schemaservice:///...': Unable to load schema from 'schemaservice:///...': No content.`.
5. Open the schema picker from `Multiple JSON Schemas`, verify the schemas are shown as `file:///...` URIs, not `schemaservice:///...` URIs.

To verify `yaml/get/jsonSchema` does not cause StackOverflow:
1. Map multiple "large" JSON schemas to the same YAML file, e.g.:
```json
"yaml.schemas": {
      "https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json": "/Users/.../asdf.yaml",
      "https://www.schemastore.org/sourcehut-build-0.65.0.json": "/Users/.../asdf.yaml"
}
```
2. Open the schema picker, verify that there's no error appears like `[Trace - 3:22:55 PM] Received response 'yaml/get/jsonSchema - (153)' in 22ms.
Request failed: Request yaml/get/jsonSchema failed with message: Maximum call stack size exceeded (-32603).`