### PR TITLE
Fix `textDocument/codeLens` race condition

### DIFF
--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -242,11 +242,11 @@ export class LanguageHandlers {
   }
 
   async codeLensHandler(params: CodeLensParams): Promise<CodeLens[] | undefined> {
+    await this.yamlSettings.configurationPullPromise;
     const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
     if (!textDocument) {
       return;
     }
-    await this.yamlSettings.configurationPullPromise;
     return this.languageService.getCodeLens(textDocument);
   }
 

--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -241,11 +241,12 @@ export class LanguageHandlers {
     return this.languageService.getCodeAction(textDocument, params);
   }
 
-  codeLensHandler(params: CodeLensParams): PromiseLike<CodeLens[] | undefined> | CodeLens[] | undefined {
+  async codeLensHandler(params: CodeLensParams): Promise<CodeLens[] | undefined> {
     const textDocument = this.yamlSettings.documents.get(params.textDocument.uri);
     if (!textDocument) {
       return;
     }
+    await this.yamlSettings.configurationPullPromise;
     return this.languageService.getCodeLens(textDocument);
   }
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -12,14 +12,15 @@ import {
   JSON_SCHEMASTORE_URL,
   KUBERNETES_SCHEMA_URL,
 } from '../../languageservice/utils/schemaUrls';
-import { LanguageService, LanguageSettings, SchemaPriority } from '../../languageservice/yamlLanguageService';
+import { equals } from '../../languageservice/utils/objects';
+import { LanguageService, LanguageSettings, SchemaPriority, SchemasSettings } from '../../languageservice/yamlLanguageService';
 import { SchemaSelectionRequests } from '../../requestTypes';
 import { Settings, SettingsState } from '../../yamlSettings';
 import { Telemetry } from '../../languageservice/telemetry';
 import { ValidationHandler } from './validationHandlers';
 
 export class SettingsHandler {
-  private schemaSettings: string | undefined;
+  private schemaSettings: SchemasSettings[] | undefined;
 
   constructor(
     private readonly connection: Connection,
@@ -365,12 +366,10 @@ export class SettingsHandler {
       languageSettings.schemas = languageSettings.schemas.concat(this.yamlSettings.schemaStoreSettings);
     }
 
-    const schemaSettings = JSON.stringify(languageSettings.schemas ?? []);
-    const shouldRefreshCodeLens = this.schemaSettings !== undefined && this.schemaSettings !== schemaSettings;
-
     this.languageService.configure(languageSettings);
-    this.schemaSettings = schemaSettings;
 
+    const shouldRefreshCodeLens = this.schemaSettings !== undefined && !equals(this.schemaSettings, languageSettings.schemas);
+    this.schemaSettings = languageSettings.schemas;
     if (shouldRefreshCodeLens) {
       this.refreshCodeLens();
     }

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { configure as configureHttpRequests, xhr } from 'request-light';
 import { Connection, DidChangeConfigurationNotification, DocumentFormattingRequest } from 'vscode-languageserver';
+import { CodeLensRefreshRequest } from 'vscode-languageserver-protocol';
 import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
 import {
   checkSchemaURI,
@@ -18,6 +19,8 @@ import { Telemetry } from '../../languageservice/telemetry';
 import { ValidationHandler } from './validationHandlers';
 
 export class SettingsHandler {
+  private schemaSettings: string | undefined;
+
   constructor(
     private readonly connection: Connection,
     private readonly languageService: LanguageService,
@@ -41,7 +44,13 @@ export class SettingsHandler {
   /**
    *  The server pull the 'yaml', 'http.proxy', 'http.proxyStrictSSL', '[yaml]' settings sections
    */
-  async pullConfiguration(): Promise<void> {
+  pullConfiguration(): Promise<void> {
+    const configurationPullPromise = this.doPullConfiguration();
+    this.yamlSettings.configurationPullPromise = configurationPullPromise.catch(() => undefined);
+    return configurationPullPromise;
+  }
+
+  private async doPullConfiguration(): Promise<void> {
     const config = await this.connection.workspace.getConfiguration([
       { section: 'yaml' },
       { section: 'http' },
@@ -356,10 +365,26 @@ export class SettingsHandler {
       languageSettings.schemas = languageSettings.schemas.concat(this.yamlSettings.schemaStoreSettings);
     }
 
-    this.languageService.configure(languageSettings);
+    const schemaSettings = JSON.stringify(languageSettings.schemas ?? []);
+    const shouldRefreshCodeLens = this.schemaSettings !== undefined && this.schemaSettings !== schemaSettings;
 
+    this.languageService.configure(languageSettings);
+    this.schemaSettings = schemaSettings;
+
+    if (shouldRefreshCodeLens) {
+      this.refreshCodeLens();
+    }
     // Revalidate any open text documents
     this.yamlSettings.documents.all().forEach((document) => this.validationHandler.validate(document));
+  }
+
+  private refreshCodeLens(): void {
+    if (!this.yamlSettings.hasCodeLensRefreshSupport) {
+      return;
+    }
+    this.connection
+      .sendRequest(CodeLensRefreshRequest.type)
+      .catch((err) => this.telemetry.sendError('yaml.codeLens.refresh.error', err));
   }
 
   /**

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -90,6 +90,7 @@ export class YAMLServerInit {
     this.yamlSettings.hasConfigurationCapability = !!(
       this.yamlSettings.capabilities.workspace && !!this.yamlSettings.capabilities.workspace.configuration
     );
+    this.yamlSettings.hasCodeLensRefreshSupport = !!this.yamlSettings.capabilities.workspace?.codeLens?.refreshSupport;
 
     this.yamlSettings.hasWsChangeWatchedFileDynamicRegistration = !!(
       this.yamlSettings.capabilities.workspace &&

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -119,6 +119,8 @@ export class SettingsState {
   hierarchicalDocumentSymbolSupport = false;
   hasWorkspaceFolderCapability = false;
   hasConfigurationCapability = false;
+  hasCodeLensRefreshSupport = false;
+  configurationPullPromise: Promise<void> = Promise.resolve();
   useVSCodeContentRequest = false;
   yamlVersion: YamlVersion = '1.2';
   useSchemaSelectionRequests = false;

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -8,6 +8,7 @@ import * as request from 'request-light';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver';
+import { CodeLensRefreshRequest } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 import { LanguageService, LanguageSettings, SchemaConfiguration, SchemaPriority } from '../src';
 import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
@@ -77,6 +78,54 @@ describe('Settings Handlers Tests', () => {
 
     settingsHandler.registerHandlers();
     expect(connection.client.register).calledOnce;
+  });
+
+  it('should request CodeLens refresh after schema settings update if client supports it', async () => {
+    settingsState.hasCodeLensRefreshSupport = true;
+    const sendRequest = sandbox.stub().resolves();
+    connection.sendRequest = sendRequest;
+    workspaceStub.getConfiguration.onFirstCall().resolves([{ schemaStore: { enable: false } }, {}, {}, {}, {}]);
+    workspaceStub.getConfiguration
+      .onSecondCall()
+      .resolves([
+        { schemas: { 'https://example.com/schema.json': 'test.yaml' }, schemaStore: { enable: false } },
+        {},
+        {},
+        {},
+        {},
+      ]);
+    const settingsHandler = new SettingsHandler(
+      connection,
+      languageService as unknown as LanguageService,
+      settingsState,
+      validationHandler as unknown as ValidationHandler,
+      {} as Telemetry
+    );
+    await settingsHandler.pullConfiguration();
+    await settingsHandler.pullConfiguration();
+    expect(sendRequest).calledOnceWithExactly(CodeLensRefreshRequest.type);
+  });
+
+  it('should not request CodeLens refresh when only non-schema settings update', async () => {
+    settingsState.hasCodeLensRefreshSupport = true;
+    const sendRequest = sandbox.stub().resolves();
+    connection.sendRequest = sendRequest;
+    const yamlSettings = {
+      schemas: { 'https://example.com/schema.json': 'test.yaml' },
+      schemaStore: { enable: false },
+    };
+    workspaceStub.getConfiguration.onFirstCall().resolves([yamlSettings, {}, {}, {}, {}]);
+    workspaceStub.getConfiguration.onSecondCall().resolves([{ ...yamlSettings, keyOrdering: true }, {}, {}, {}, {}]);
+    const settingsHandler = new SettingsHandler(
+      connection,
+      languageService as unknown as LanguageService,
+      settingsState,
+      validationHandler as unknown as ValidationHandler,
+      {} as Telemetry
+    );
+    await settingsHandler.pullConfiguration();
+    await settingsHandler.pullConfiguration();
+    expect(sendRequest).not.called;
   });
 
   describe('Settings for YAML style should ', () => {

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -10,9 +10,14 @@ import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaSer
 import { setupTextDocument } from './utils/testHelper';
 import { JSONSchema } from '../src/languageservice/jsonSchema';
 import { CodeLens, Command, Range } from 'vscode-languageserver-protocol';
+import { Connection } from 'vscode-languageserver';
 import { YamlCommands } from '../src/commands';
 import { TelemetryImpl } from '../src/languageserver/telemetry';
 import { Telemetry } from '../src/languageservice/telemetry';
+import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import { LanguageService } from '../src/languageservice/yamlLanguageService';
+import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -74,6 +79,44 @@ describe('YAML CodeLens', () => {
     expect(result[0].command).is.deep.equal(
       createCommand('schema.json', YamlCommands.JUMP_TO_SCHEMA, 'some://url/to/schema.json')
     );
+  });
+
+  it('should wait for configuration update before providing CodeLens', async () => {
+    const doc = setupTextDocument('foo: bar');
+    const expected = createCodeLens('schema.json', YamlCommands.JUMP_TO_SCHEMA, 'some://url/to/schema.json');
+    const yamlSettings = new SettingsState();
+    yamlSettings.documents = new TextDocumentTestManager();
+    (yamlSettings.documents as TextDocumentTestManager).set(doc);
+
+    let resolveConfiguration: () => void = () => undefined;
+    yamlSettings.configurationPullPromise = new Promise<void>((resolve) => {
+      resolveConfiguration = resolve;
+    });
+
+    const getCodeLensStub = sandbox.stub().returns([expected]);
+    const languageService = {
+      getCodeLens: getCodeLensStub,
+    } as unknown as LanguageService;
+    const codeLensHandler = new LanguageHandlers({} as Connection, languageService, yamlSettings, {} as ValidationHandler);
+
+    const response = Promise.resolve(
+      codeLensHandler.codeLensHandler({
+        textDocument: { uri: doc.uri },
+      })
+    );
+    let settled = false;
+    response.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).to.be.false;
+    expect(getCodeLensStub).not.called;
+
+    resolveConfiguration();
+    const result = await response;
+    expect(getCodeLensStub).calledOnceWithExactly(doc);
+    expect(result).deep.equal([expected]);
   });
 
   it('should place one CodeLens at beginning of the file for multiple documents', async () => {


### PR DESCRIPTION
### What does this PR do?

Previously, clients could send `textDocument/codeLens` before the server had finished its initial configuration work.
The startup order can look like this:

1. The client sends `initialized`.
2. The server asks the client for settings with `workspace/configuration`.
3. Before the server receives and applies that configuration, the client opens a YAML file and sends `textDocument/codeLens`.
4. CodeLens asks `YAMLSchemaService` which schema applies to the file.
5. `YAMLSchemaService` does not yet have information for schema associations, so it returns no matching schema.
6. The server responds to `textDocument/codeLens` with `[]`.

This PR fixes CodeLens handling so `textDocument/codeLens` waits for the yaml configuration pull before resolving CodeLens entries.

Additionally, this PR refreshes CodeLens when schema-related configuration changes, if the client supports `workspace/codeLens/refresh`.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/501

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing
  - [x] Reproduced the issue mentioned above and verified the first `textDocument/codeLens` response is no longer empty
  - [x] Verified CodeLens refreshes when schema-related configuration changes:
      1. Open a YAML file with existing mapped schema, e.g. `/Users/.../.github/workflows/daily.yml`
      2. Confirm CodeLens shows the GitHub Workflow schema
      3. Update the YAML schema mapping in settings, e.g.

         ```json
         "yaml.schemas": {
           "/Users/.../schema.json": "/Users/.../.github/workflows/daily.yml"
         }

      5. Confirm CodeLens updates in real time. Verify the server sends a `workspace/codeLens/refresh` request.
