### PR TITLE
Fix auto-completion for array with default

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -708,7 +708,7 @@ export class YamlCompletion {
     const lineContent = textBuffer.getLineContent(overwriteRange.start.line);
     const hasOnlyWhitespace = lineContent.trim().length === 0;
     const hasColon = lineContent.indexOf(':') !== -1;
-    const isInArray = lineContent.trimLeft().indexOf('-') === 0;
+    const isInArray = lineContent.trimStart().indexOf('-') === 0;
     const nodeParent = doc.getParent(node);
     const matchOriginal = matchingSchemas.find((it) => it.node.internalNode === originalNode && it.schema.properties);
     const oneOfSchema = matchingSchemas.filter((schema) => schema.schema.oneOf).map((oneOfSchema) => oneOfSchema.schema.oneOf)[0];
@@ -1001,7 +1001,7 @@ export class YamlCompletion {
     index?: number
   ): void {
     const schemaType = getSchemaTypeName(schema);
-    const insertText = `- ${this.getInsertTextForObject(schema, separatorAfter).insertText.trimLeft()}`;
+    const insertText = `- ${this.getInsertTextForObject(schema, separatorAfter).insertText.trimStart()}`;
     //append insertText to documentation
     const schemaTypeTitle = schemaType ? ' type `' + schemaType + '`' : '';
     const schemaDescription = schema.description ? ' (' + schema.description + ')' : '';
@@ -1100,6 +1100,14 @@ export class YamlCompletion {
       if (propertySchema.properties) {
         return `${resultText}\n${this.getInsertTextForObject(propertySchema, separatorAfter, indent).insertText}`;
       } else if (propertySchema.items) {
+        if (type === 'array' && Array.isArray(propertySchema.default)) {
+          if (propertySchema.default.length === 0) {
+            return `${resultText} []${separatorAfter}`;
+          }
+          return (
+            resultText + this.getInsertTemplateForValue(propertySchema.default, indent, { index: 1 }, separatorAfter).trimEnd()
+          );
+        }
         return `${resultText}\n${indent}- ${
           this.getInsertTextForArray(propertySchema.items, separatorAfter, 1, indent).insertText
         }`;
@@ -1231,7 +1239,7 @@ export class YamlCompletion {
     if (insertText.trim().length === 0) {
       insertText = `${indent}$${insertIndex++}\n`;
     }
-    insertText = insertText.trimRight() + separatorAfter;
+    insertText = insertText.trimEnd() + separatorAfter;
     return { insertText, insertIndex };
   }
 
@@ -1251,24 +1259,28 @@ export class YamlCompletion {
         type = 'array';
       }
     }
-    switch (schema.type) {
-      case 'boolean':
-        insertText = `\${${insertIndex++}:false}`;
-        break;
-      case 'number':
-      case 'integer':
-        insertText = `\${${insertIndex++}:0}`;
-        break;
-      case 'string':
-        insertText = `\${${insertIndex++}}`;
-        break;
-      case 'object':
-        {
-          const objectInsertResult = this.getInsertTextForObject(schema, separatorAfter, `${indent}  `, insertIndex++);
-          insertText = objectInsertResult.insertText.trimLeft();
-          insertIndex = objectInsertResult.insertIndex;
-        }
-        break;
+    if (isDefined(schema.default)) {
+      insertText = this.getInsertTextForGuessedValue(schema.default, separatorAfter, type);
+    } else {
+      switch (schema.type) {
+        case 'boolean':
+          insertText = `\${${insertIndex++}:false}`;
+          break;
+        case 'number':
+        case 'integer':
+          insertText = `\${${insertIndex++}:0}`;
+          break;
+        case 'string':
+          insertText = `\${${insertIndex++}}`;
+          break;
+        case 'object':
+          {
+            const objectInsertResult = this.getInsertTextForObject(schema, separatorAfter, `${indent}  `, insertIndex++);
+            insertText = objectInsertResult.insertText.trimStart();
+            insertIndex = objectInsertResult.insertIndex;
+          }
+          break;
+      }
     }
     return { insertText, insertIndex };
   }

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -2410,6 +2410,146 @@ describe('Auto Completion Tests', () => {
       expect(envItem.textEdit.newText).equal('env: ${1:1}');
     });
 
+    it('should use array property default when completing array property', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          'foo-default-outside': {
+            type: 'array',
+            default: ['foo-default-outside'],
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        required: ['foo-default-outside'],
+      });
+
+      const completion = await parseSetup('foo', 3);
+
+      const defaultOutside = completion.items.find((i) => i.label === 'foo-default-outside');
+      expect(defaultOutside).to.not.undefined;
+      expect(defaultOutside.textEdit.newText).equal('foo-default-outside:\n  - ${1:foo-default-outside}');
+
+      const nextItemContent = 'foo-default-outside:\n  - foo-default-outside\n  - ';
+      const nextItemCompletion = await parseSetup(nextItemContent, nextItemContent.length);
+      expect(nextItemCompletion.items).is.empty;
+    });
+
+    it('should use array item default when completing array property', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          'foo-default-in-items': {
+            type: 'array',
+            items: {
+              type: 'string',
+              default: 'foo-default-in-items',
+            },
+          },
+        },
+        required: ['foo-default-in-items'],
+      });
+
+      const completion = await parseSetup('foo', 3);
+
+      const defaultInItems = completion.items.find((i) => i.label === 'foo-default-in-items');
+      expect(defaultInItems).to.not.undefined;
+      expect(defaultInItems.textEdit.newText).equal('foo-default-in-items:\n  - ${1:foo-default-in-items}');
+
+      const nextItemContent = 'foo-default-in-items:\n  - foo-default-in-items\n  - ';
+      const nextItemCompletion = await parseSetup(nextItemContent, nextItemContent.length);
+      const nextItemDefault = nextItemCompletion.items.find((i) => i.label === 'foo-default-in-items');
+      expect(nextItemDefault).to.not.undefined;
+      expect(nextItemDefault.textEdit.newText).equal('foo-default-in-items');
+    });
+
+    it('should prefer array property default over item default', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          'foo-two-default': {
+            type: 'array',
+            default: ['foo-two-default'],
+            items: {
+              type: 'string',
+              default: 'item-default',
+            },
+          },
+        },
+        required: ['foo-two-default'],
+      });
+
+      const completion = await parseSetup('foo', 3);
+
+      const twoDefaults = completion.items.find((i) => i.label === 'foo-two-default');
+      expect(twoDefaults).to.not.undefined;
+      expect(twoDefaults.textEdit.newText).equal('foo-two-default:\n  - ${1:foo-two-default}');
+
+      const nextItemContent = 'foo-two-default:\n  - foo-two-default\n  - ';
+      const nextItemCompletion = await parseSetup(nextItemContent, nextItemContent.length);
+      const nextItemDefault = nextItemCompletion.items.find((i) => i.label === 'item-default');
+      expect(nextItemDefault).to.not.undefined;
+      expect(nextItemDefault.textEdit.newText).equal('item-default');
+    });
+
+    it('should keep parent skeleton array defaults on separate snippet tab stops', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        title: 'dummy',
+        properties: {
+          bar: {
+            type: 'string',
+            default: 'hello',
+          },
+          num: {
+            type: 'number',
+            default: '42',
+          },
+          'foo-two-default': {
+            type: 'array',
+            default: ['foo-two-default'],
+            items: {
+              type: 'string',
+              default: 'item-default',
+            },
+          },
+          'foo-default-in-items': {
+            type: 'array',
+            items: {
+              type: 'string',
+              default: 'foo-default-in-items',
+            },
+          },
+          'foo-default-outside': {
+            type: 'array',
+            default: ['foo-default-outside'],
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        required: ['foo-two-default', 'foo-default-in-items', 'foo-default-outside', 'bar', 'num'],
+      });
+
+      const completion = await parseSetup('dum|m|y');
+      const dummy = completion.items.find((i) => i.label === 'dummy');
+
+      expect(dummy).to.not.undefined;
+      expect(dummy.textEdit.newText).equal(
+        [
+          'bar: hello',
+          'num: 42',
+          'foo-two-default:',
+          '  - ${1:foo-two-default}',
+          'foo-default-in-items:',
+          '  - ${2:foo-default-in-items}',
+          'foo-default-outside:',
+          '  - ${3:foo-default-outside}',
+        ].join('\n')
+      );
+    });
+
     it('should complete string which contains number in examples values', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',


### PR DESCRIPTION
### What does this PR do?

Fixes auto-completion for array properties that define defaults either on the array property itself or on the array item schema.

Before this fix, auto-completing an array property inserted an empty item placeholder even when the schema provided a default.

Completion behavior is now:
- If the array property has `default`, use that value when completing the array property
- If the array property has no `default` but its `items` schema has `default`, complete the array property as an array with one item using the items default
- For subsequent array items, suggest items default when it exists; otherwise provide no suggestion
- Inserted default values are snippet placeholders, so users can tab through them and edit/replace the values easily

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1187

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Manual testing with the example from the linked issue