### PR TITLE
Fix to show SchemaStore entries without `fileMatch` field in schema selection

### DIFF
--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -257,10 +257,21 @@ export class SettingsHandler {
 
     for (const schemaIndex in schemas.schemas) {
       const schema = schemas.schemas[schemaIndex];
-
-      if (schema && schema.fileMatch) {
-        for (const fileMatch in schema.fileMatch) {
-          const currFileMatch: string = schema.fileMatch[fileMatch];
+      if (!schema.url) {
+        continue;
+      }
+      const fileMatches = schema.fileMatch ?? [];
+      if (fileMatches.length === 0) {
+        languageSettings.schemas.push({
+          uri: schema.url,
+          fileMatch: [],
+          priority: SchemaPriority.SchemaStore,
+          name: schema.name,
+          description: schema.description,
+          versions: schema.versions,
+        });
+      } else {
+        for (const currFileMatch of fileMatches) {
           // If the schema is for files with a YAML extension, save the schema association
           if (
             this.yamlSettings.fileExtensions.findIndex((value) => {

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -277,6 +277,37 @@ describe('Settings Handlers Tests', () => {
         versions: undefined,
       });
     });
+    it('SettingsHandler should include schemas without file matches as selectable schemas', async () => {
+      const languageServerSetup = setupLanguageService({});
+      const languageService = languageServerSetup.languageService;
+      xhrStub.resolves({
+        responseText: `{"schemas": [
+        {
+          "name": "Traefik v3",
+          "description": "Traefik v3 YAML configuration file",
+          "url": "https://www.schemastore.org/traefik-v3.json"
+        }]}`,
+      });
+      const settingsHandler = new SettingsHandler(
+        connection,
+        languageService as unknown as LanguageService,
+        settingsState,
+        validationHandler as unknown as ValidationHandler,
+        {} as Telemetry
+      );
+      workspaceStub.getConfiguration.resolves([{}, {}, {}, {}]);
+      const configureSpy = sinon.stub(languageService, 'configure');
+      await settingsHandler.pullConfiguration();
+      configureSpy.restore();
+      expect(settingsState.schemaStoreSettings).deep.include({
+        uri: 'https://www.schemastore.org/traefik-v3.json',
+        fileMatch: [],
+        priority: SchemaPriority.SchemaStore,
+        name: 'Traefik v3',
+        description: 'Traefik v3 YAML configuration file',
+        versions: undefined,
+      });
+    });
   });
 
   it('SettingsHandler should not modify file match patterns', async () => {


### PR DESCRIPTION
### What does this PR do?
SchemaStore entries were only added to schema settings when they define a `fileMatch` field. Schemas like Traefik v3, which exist in SchemaStore but do not define `fileMatch`, were dropped before they could appear in the schema picker UI.

This fix keeps all SchemaStore entries even without a `fileMatch` field, so all schemas from SchemaStore remain selectable by users.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1130

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Tested manually: Expect schemas without a `fileMatch` field to be displayed in the schema picker UI, e.g. search for "Traefik v3" and it should appear.