### PR TITLE
Explicitly mark `jsonc-parser` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "ajv-i18n": "^4.2.0",
+        "jsonc-parser": "^3.3.1",
         "prettier": "^3.8.1",
         "request-light": "^0.5.7",
         "vscode-json-languageservice": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ajv": "^8.17.1",
     "ajv-draft-04": "^1.0.0",
     "ajv-i18n": "^4.2.0",
+    "jsonc-parser": "^3.3.1",
     "prettier": "^3.8.1",
     "request-light": "^0.5.7",
     "vscode-json-languageservice": "4.1.8",


### PR DESCRIPTION
### What does this PR do?
Explicitly mark jsonc-parser as a dependency. It's currently a transitive dependency (through vscode-json-languageservice), but we use it directly, so it seems like a good idea to mark it as a direct dependency.

### What issues does this PR fix or reference?
Fixes #1264

### Is it tested? How?
Existing tests
