### PR TITLE
Fix minor version of vscode-languageserver-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "vscode-json-languageservice": "4.1.8",
         "vscode-languageserver": "^9.0.0",
         "vscode-languageserver-textdocument": "^1.0.1",
-        "vscode-languageserver-types": "^3.16.0",
+        "vscode-languageserver-types": "~3.17.5",
         "vscode-uri": "^3.0.2",
         "yaml": "2.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "vscode-json-languageservice": "4.1.8",
     "vscode-languageserver": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "vscode-languageserver-types": "^3.16.0",
+    "vscode-languageserver-types": "~3.17.5",
     "vscode-uri": "^3.0.2",
     "yaml": "2.8.3"
   },


### PR DESCRIPTION
### What does this PR do?
The most recent release isn't compatible with the version of vscode-languageserver that we're using.

### What issues does this PR fix or reference?
Fixes #1270

### Is it tested? How?
CI
