### PR TITLE
Use modern TypeScript module resolution

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -5,7 +5,7 @@
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { JSONDocument } from './jsonDocument';
-import { Document, isNode, isPair, isScalar, LineCounter, Node, visit, YAMLError } from 'yaml';
+import { CST, Document, isNode, isPair, isScalar, LineCounter, Node, visit, YAMLError } from 'yaml';
 import { ASTNode, YamlNode } from '../jsonASTTypes';
 import { defaultOptions, parse as parseYAML, ParserOptions } from './yamlParser07';
 import { ErrorCode } from 'vscode-json-languageservice';
@@ -15,7 +15,6 @@ import { isArrayEqual } from '../utils/arrUtils';
 import { getParent } from '../utils/yamlAstUtils';
 import { TextBuffer } from '../utils/textBuffer';
 import { getIndentation } from '../utils/strings';
-import { Token } from 'yaml/dist/parse/cst';
 
 /**
  * These documents are collected into a final YAMLDocument
@@ -241,12 +240,12 @@ export class SingleYAMLDocument extends JSONDocument {
  */
 export class YAMLDocument {
   documents: SingleYAMLDocument[];
-  tokens: Token[];
+  tokens: CST.Token[];
 
   private errors: YAMLDocDiagnostic[];
   private warnings: YAMLDocDiagnostic[];
 
-  constructor(documents: SingleYAMLDocument[], tokens: Token[]) {
+  constructor(documents: SingleYAMLDocument[], tokens: CST.Token[]) {
     this.documents = documents;
     this.tokens = tokens;
     this.errors = [];

--- a/src/languageservice/services/validation/map-key-order.ts
+++ b/src/languageservice/services/validation/map-key-order.ts
@@ -5,10 +5,9 @@
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
-import { isMap, Node, Pair, visit } from 'yaml';
+import { CST, isMap, Node, Pair, visit } from 'yaml';
 import { SingleYAMLDocument } from '../../parser/yaml-documents';
 import { AdditionalValidator } from './types';
-import { SourceToken } from 'yaml/dist/parse/cst';
 
 export class MapKeyOrderValidator implements AdditionalValidator {
   validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[] {
@@ -38,7 +37,7 @@ export class MapKeyOrderValidator implements AdditionalValidator {
 }
 
 function createRange(document: TextDocument, node: Pair): Range {
-  const keySourceToken = (node.key as Node).srcToken as SourceToken;
+  const keySourceToken = (node.key as Node).srcToken as CST.SourceToken;
   const start = keySourceToken.offset;
   const end = start + keySourceToken.source.length;
   return Range.create(document.positionAt(start), document.positionAt(end));

--- a/src/languageservice/services/validation/yaml-style.ts
+++ b/src/languageservice/services/validation/yaml-style.ts
@@ -1,7 +1,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
-import { isMap, isSeq, visit } from 'yaml';
-import { FlowCollection } from 'yaml/dist/parse/cst';
+import { CST, isMap, isSeq, visit } from 'yaml';
 import { SingleYAMLDocument } from '../../parser/yaml-documents';
 import { LanguageSettings } from '../../yamlLanguageService';
 import { AdditionalValidator } from './types';
@@ -42,7 +41,7 @@ export class YAMLStyleValidator implements AdditionalValidator {
     return result;
   }
 
-  private getRangeOf(document: TextDocument, node: FlowCollection): Range {
+  private getRangeOf(document: TextDocument, node: CST.FlowCollection): Range {
     const endOffset = node.end[0].offset;
     let endPosition = document.positionAt(endOffset);
     endPosition = { character: endPosition.character + 1, line: endPosition.line };

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -20,7 +20,6 @@ import { ClientCapabilities, CodeActionParams } from 'vscode-languageserver-prot
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { CST, isMap, isSeq, isScalar, Scalar, visit, YAMLMap } from 'yaml';
-import { SourceToken } from 'yaml/dist/parse/cst';
 
 import { YamlCommands } from '../../commands';
 import { TextBuffer } from '../utils/textBuffer';
@@ -313,12 +312,12 @@ export class YamlCodeActions {
         if (node && isMap(node.internalNode)) {
           const sorted: YAMLMap = structuredClone(node.internalNode);
 
-          const _getTrailingTokens = (value: CST.Token): SourceToken[] => {
+          const _getTrailingTokens = (value: CST.Token): CST.SourceToken[] => {
             if (!value) return;
             if (CST.isScalar(value)) {
               if (value.type === 'block-scalar') {
                 value.props ??= [];
-                return value.props as SourceToken[];
+                return value.props as CST.SourceToken[];
               }
               value.end ??= [];
               return value.end;
@@ -364,7 +363,7 @@ export class YamlCodeActions {
                 _getTrailingTokens(uItem.value)?.find((p) => p.type === 'newline' && p.offset < node.offset + node.length) ??
                 null;
               if (uNewLineToken && itemNewLineIndex < 0 && itemTokens) {
-                itemTokens.push({ type: 'newline', indent: 0, offset: item.value.offset, source: '\n' } as SourceToken);
+                itemTokens.push({ type: 'newline', indent: 0, offset: item.value.offset, source: '\n' });
               }
               if (!uNewLineToken && itemNewLineIndex > -1 && itemTokens) {
                 itemTokens.splice(itemNewLineIndex, 1);

--- a/src/languageservice/services/yamlRename.ts
+++ b/src/languageservice/services/yamlRename.ts
@@ -10,14 +10,13 @@ import { matchOffsetToDocument } from '../utils/arrUtils';
 import { TextBuffer } from '../utils/textBuffer';
 import { Telemetry } from '../telemetry';
 import { CST, isAlias, isCollection, isScalar, visit, Node } from 'yaml';
-import { SourceToken, CollectionItem } from 'yaml/dist/parse/cst';
 import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { isCollectionItem } from '../utils/yamlAstUtils';
 import { PrepareRenameParams, RenameParams, ResponseError, ErrorCodes } from 'vscode-languageserver-protocol';
 
 interface RenameTarget {
   anchorNode: Node;
-  token: SourceToken;
+  token: CST.SourceToken;
   yamlDoc: SingleYAMLDocument;
 }
 
@@ -64,7 +63,7 @@ export class YamlRename {
 
       visit(target.yamlDoc.internalDocument, (key, node) => {
         if (isAlias(node) && node.srcToken && node.resolve(target.yamlDoc.internalDocument) === target.anchorNode) {
-          edits.push(TextEdit.replace(this.getNameRange(document, node.srcToken as SourceToken), newName));
+          edits.push(TextEdit.replace(this.getNameRange(document, node.srcToken as CST.SourceToken), newName));
         }
       });
 
@@ -95,12 +94,12 @@ export class YamlRename {
       return this.findByToken(yamlDoc, offset);
     }
 
-    if (isAlias(node) && node.srcToken && this.isOffsetInsideToken(node.srcToken as SourceToken, offset)) {
+    if (isAlias(node) && node.srcToken && this.isOffsetInsideToken(node.srcToken as CST.SourceToken, offset)) {
       const anchorNode = node.resolve(yamlDoc.internalDocument);
       if (!anchorNode) {
         return null;
       }
-      return { anchorNode, token: node.srcToken as SourceToken, yamlDoc };
+      return { anchorNode, token: node.srcToken as CST.SourceToken, yamlDoc };
     }
 
     if ((isCollection(node) || isScalar(node)) && node.anchor) {
@@ -116,10 +115,10 @@ export class YamlRename {
   private findByToken(yamlDoc: SingleYAMLDocument, offset: number): RenameTarget | null {
     let target: RenameTarget;
     visit(yamlDoc.internalDocument, (key, node) => {
-      if (isAlias(node) && node.srcToken && this.isOffsetInsideToken(node.srcToken as SourceToken, offset)) {
+      if (isAlias(node) && node.srcToken && this.isOffsetInsideToken(node.srcToken as CST.SourceToken, offset)) {
         const anchorNode = node.resolve(yamlDoc.internalDocument);
         if (anchorNode) {
-          target = { anchorNode, token: node.srcToken as SourceToken, yamlDoc };
+          target = { anchorNode, token: node.srcToken as CST.SourceToken, yamlDoc };
           return visit.BREAK;
         }
       }
@@ -135,14 +134,14 @@ export class YamlRename {
     return target ?? null;
   }
 
-  private findAnchorToken(yamlDoc: SingleYAMLDocument, node: Node): SourceToken | undefined {
+  private findAnchorToken(yamlDoc: SingleYAMLDocument, node: Node): CST.SourceToken | undefined {
     const parent = yamlDoc.getParent(node);
-    const candidates = [];
-    if (parent && (parent as unknown as { srcToken?: SourceToken }).srcToken) {
-      candidates.push((parent as unknown as { srcToken: SourceToken }).srcToken);
+    const candidates: CST.SourceToken[] = [];
+    if (parent && parent.srcToken) {
+      candidates.push(parent.srcToken as CST.SourceToken);
     }
-    if ((node as unknown as { srcToken?: SourceToken }).srcToken) {
-      candidates.push((node as unknown as { srcToken: SourceToken }).srcToken);
+    if (node.srcToken) {
+      candidates.push(node.srcToken as CST.SourceToken);
     }
 
     for (const token of candidates) {
@@ -155,13 +154,13 @@ export class YamlRename {
     return undefined;
   }
 
-  private getAnchorFromToken(token: SourceToken, node: Node): SourceToken | undefined {
+  private getAnchorFromToken(token: CST.SourceToken, node: Node): CST.SourceToken | undefined {
     if (isCollectionItem(token)) {
       return this.getAnchorFromCollectionItem(token);
     } else if (CST.isCollection(token)) {
-      const collection = token as unknown as { items?: CollectionItem[] };
+      const collection = token as unknown as { items?: CST.CollectionItem[] };
       for (const item of collection.items ?? []) {
-        if (item.value !== (node as unknown as { srcToken?: SourceToken }).srcToken) {
+        if (item.value !== node.srcToken) {
           continue;
         }
         const anchor = this.getAnchorFromCollectionItem(item);
@@ -173,7 +172,7 @@ export class YamlRename {
     return undefined;
   }
 
-  private getAnchorFromCollectionItem(token: CollectionItem): SourceToken | undefined {
+  private getAnchorFromCollectionItem(token: CST.CollectionItem): CST.SourceToken | undefined {
     for (const t of token.start) {
       if (t.type === 'anchor') {
         return t;
@@ -189,13 +188,13 @@ export class YamlRename {
     return undefined;
   }
 
-  private getNameRange(document: TextDocument, token: SourceToken): Range {
+  private getNameRange(document: TextDocument, token: CST.SourceToken): Range {
     const startOffset = token.offset + 1;
     const endOffset = token.offset + token.source.length;
     return Range.create(document.positionAt(startOffset), document.positionAt(endOffset));
   }
 
-  private isOffsetInsideToken(token: SourceToken, offset: number): boolean {
+  private isOffsetInsideToken(token: CST.SourceToken, offset: number): boolean {
     return offset >= token.offset && offset <= token.offset + token.source.length;
   }
 

--- a/src/languageservice/utils/block-string-rewriter.ts
+++ b/src/languageservice/utils/block-string-rewriter.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { CST, Scalar } from 'yaml';
-import { FlowScalar } from 'yaml/dist/parse/cst';
 
 export class BlockStringRewriter {
   constructor(
@@ -17,7 +16,7 @@ export class BlockStringRewriter {
     }
 
     const stringContent = node.value;
-    const currentIndentNum = (node.srcToken as FlowScalar).indent;
+    const currentIndentNum = (node.srcToken as CST.FlowScalar).indent;
     let indentText = this.indentation;
     for (let i = 0; i < currentIndentNum / this.indentation.length; i++) {
       indentText += this.indentation;
@@ -160,7 +159,7 @@ export class BlockStringRewriter {
     if (stringContent.indexOf('\n') < 0) {
       return null;
     }
-    const currentIndentNum = (node.srcToken as FlowScalar).indent;
+    const currentIndentNum = (node.srcToken as CST.FlowScalar).indent;
     let indentText = this.indentation;
     for (let i = 0; i < currentIndentNum / this.indentation.length; i++) {
       indentText += this.indentation;

--- a/src/languageservice/utils/flow-style-rewriter.ts
+++ b/src/languageservice/utils/flow-style-rewriter.ts
@@ -1,5 +1,4 @@
 import { CST, visit } from 'yaml';
-import { SourceToken } from 'yaml/dist/parse/cst';
 import { ASTNode } from '../jsonASTTypes';
 
 export class FlowStyleRewriter {
@@ -23,10 +22,10 @@ export class FlowStyleRewriter {
     for (const item of collection.items) {
       CST.visit(item, ({ key, sep, value }) => {
         if (blockType === 'block-map') {
-          const start = [{ type: 'space', indent: 0, offset: key.offset, source: this.indentation } as SourceToken];
+          const start: CST.SourceToken[] = [{ type: 'space', indent: 0, offset: key.offset, source: this.indentation }];
           if (parentType === 'property') {
             // add a new line if part of a map
-            start.unshift({ type: 'newline', indent: 0, offset: key.offset, source: '\n' } as SourceToken);
+            start.unshift({ type: 'newline', indent: 0, offset: key.offset, source: '\n' });
           }
           blockStyle.items.push({
             start: start,
@@ -37,11 +36,11 @@ export class FlowStyleRewriter {
         } else if (blockType === 'block-seq') {
           blockStyle.items.push({
             start: [
-              { type: 'newline', indent: 0, offset: value.offset, source: '\n' } as SourceToken,
-              { type: 'space', indent: 0, offset: value.offset, source: this.indentation } as SourceToken,
-              { type: 'seq-item-ind', indent: 0, offset: value.offset, source: '-' } as SourceToken,
-              { type: 'space', indent: 0, offset: value.offset, source: ' ' } as SourceToken,
-            ],
+              { type: 'newline', indent: 0, offset: value.offset, source: '\n' },
+              { type: 'space', indent: 0, offset: value.offset, source: this.indentation },
+              { type: 'seq-item-ind', indent: 0, offset: value.offset, source: '-' },
+              { type: 'space', indent: 0, offset: value.offset, source: ' ' },
+            ] satisfies CST.SourceToken[],
             value: value,
           });
         }

--- a/src/languageservice/utils/yamlAstUtils.ts
+++ b/src/languageservice/utils/yamlAstUtils.ts
@@ -3,12 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Document, isDocument, isScalar, Node, visit, YAMLMap, YAMLSeq } from 'yaml';
-import { CollectionItem, SourceToken, Token } from 'yaml/dist/parse/cst';
-import { VisitPath } from 'yaml/dist/parse/cst-visit';
+import { CST, Document, isDocument, isScalar, Node, visit, YAMLMap, YAMLSeq } from 'yaml';
 import { YamlNode } from '../jsonASTTypes';
 
-type Visitor = (item: SourceToken, path: VisitPath) => number | symbol | Visitor | void;
+type Visitor = (item: CST.SourceToken, path: CST.VisitPath) => number | symbol | Visitor | void;
 
 export function getParent(doc: Document, nodeToFind: YamlNode): YamlNode | undefined {
   let parentNode: Node;
@@ -48,11 +46,11 @@ export function indexOf(seq: YAMLSeq, item: YamlNode): number | undefined {
  * @param doc the yaml document
  * @param offset the offset to check
  */
-export function isInComment(tokens: Token[], offset: number): boolean {
+export function isInComment(tokens: CST.Token[], offset: number): boolean {
   let inComment = false;
   for (const token of tokens) {
     if (token.type === 'document') {
-      _visit([], token as unknown as SourceToken, (item) => {
+      _visit([], token as unknown as CST.SourceToken, (item) => {
         if (isCollectionItem(item) && item.value?.type === 'comment') {
           if (token.offset <= offset && item.value.source.length + item.value.offset >= offset) {
             inComment = true;
@@ -76,11 +74,11 @@ export function isInComment(tokens: Token[], offset: number): boolean {
   return inComment;
 }
 
-export function isCollectionItem(token: unknown): token is CollectionItem {
+export function isCollectionItem(token: unknown): token is CST.CollectionItem {
   return token['start'] !== undefined;
 }
 
-function _visit(path: VisitPath, item: SourceToken, visitor: Visitor): number | symbol | Visitor | void {
+function _visit(path: CST.VisitPath, item: CST.SourceToken, visitor: Visitor): number | symbol | Visitor | void {
   let ctrl = visitor(item, path);
   if (typeof ctrl === 'symbol') return ctrl;
   for (const field of ['key', 'value'] as const) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2020", "WebWorker"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "outDir": "./out/server",
     "sourceMap": true,
     "target": "es2020",


### PR DESCRIPTION
### What does this PR do?

This project was still using the deprecated TypeScript module resolution `node10` (aka `node`). This change updates the module resolution to `nodenext`. Imports were fixed accordingly.

Notably, `yaml/dist/parse/cst` isn’t exported, but this is exported as the `CST` namespace in the `yaml` module.

This is a preparation for updating to LSP 3.18, because some related packages no longer support the old module resolution anymore. It’s also a preparation to go ESM-only at some point.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```
tsc
```
