### PR TITLE
Support disabling schema validation via modeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following settings are supported:
 
 ## Suppressing diagnostics
 
-You can suppress specific validation warnings on a per-line basis by adding a `# yaml-language-server-disable` comment on the line immediately before the one producing the diagnostic.
+You can suppress specific validation warnings on a per-line basis by adding a `# yaml-language-server-disable` comment on the line immediately before the one producing the diagnostic. To disable schema validation for an entire file, use a [modeline schema association](#using-modeline).
 
 ### Suppress all diagnostics on a line
 
@@ -275,9 +275,9 @@ yaml.schemas: {
 > **Note**
 > This will require reading your existing schema and understanding the schemastore structure a bit. (TODO: link to a documentation or blog post here?)
 
-### Using inlined schema
+### Using modeline
 
-It is possible to specify a yaml schema using a modeline.
+You can specify a JSON Schema for a YAML file using a modeline.
 
 ```yaml
 # yaml-language-server: $schema=<urlToTheSchema>
@@ -299,6 +299,12 @@ or IntelliJ compatible format:
 
 ```yaml
 # $schema: <urlOrPathToTheSchema>
+```
+
+You can also disable schema validation entirely for a specific file using the modeline:
+
+```yaml
+# yaml-language-server: $schema=none
 ```
 
 ### Disabling automatic schema detection for specific files

--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -11,7 +11,7 @@ import { JSONDocument } from '../parser/jsonDocument';
  * Public for testing purpose, not part of the API.
  * @param doc
  */
-export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): string {
+export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): string | undefined {
   if (doc instanceof SingleYAMLDocument) {
     const yamlLanguageServerModeline = doc.lineComments.find((lineComment) => {
       return isModeline(lineComment);

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -211,6 +211,9 @@ export class YAMLSchemaService extends JSONSchemaService {
   private resolveModelineSchema(resource: string, doc: JSONDocument): string | undefined {
     let schemaFromModeline = getSchemaFromModeline(doc);
     if (schemaFromModeline !== undefined) {
+      if (schemaFromModeline.trim().toLowerCase() === 'none') {
+        return 'none';
+      }
       if (!schemaFromModeline.startsWith('file:') && !schemaFromModeline.startsWith('http')) {
         // If path contains a fragment and it is left intact, "#" will be
         // considered part of the filename and converted to "%23" by
@@ -238,6 +241,9 @@ export class YAMLSchemaService extends JSONSchemaService {
   private async getSchemaIdsForResource(resource: string, doc: JSONDocument): Promise<string[]> {
     const modelineSchema = this.resolveModelineSchema(resource, doc);
     if (modelineSchema) {
+      if (modelineSchema === 'none') {
+        return [];
+      }
       return [modelineSchema];
     }
 
@@ -1143,6 +1149,9 @@ export class YAMLSchemaService extends JSONSchemaService {
     };
     const modelineSchema = this.resolveModelineSchema(resource, doc);
     if (modelineSchema) {
+      if (modelineSchema === 'none') {
+        return Promise.resolve(null);
+      }
       return resolveSchemaForResource([modelineSchema]);
     }
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1243,6 +1243,34 @@ address:
     }
   });
 
+  describe('Test schema validation disabling via modeline', function () {
+    it('should not validate when schema is disabled via modeline with $schema=none', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          age: {
+            type: 'number',
+            minimum: 0,
+          },
+        },
+        required: ['name'],
+      };
+      const languageSettingsSetup = new ServiceSetup().withValidate().withSchemaFileMatch({
+        uri: 'http://test-schema.org/person',
+        fileMatch: ['*.yml'],
+        schema,
+      });
+      const { languageService: langService } = setupLanguageService(languageSettingsSetup.languageSettings);
+      const content = '# yaml-language-server: $schema=none\nage: not-a-number';
+      const testTextDocument = setupTextDocument(content);
+      const result = await langService.doValidation(testTextDocument, false);
+      expect(result).to.be.empty;
+    });
+  });
+
   describe('Test getSchemaFromModeline', function () {
     it('simple case', async () => {
       checkReturnSchemaUrl('# yaml-language-server: $schema=expectedUrl', 'expectedUrl');


### PR DESCRIPTION
### What does this PR do?
Adds support for disabling schema validation for a single YAML file with a modeline:

```yaml
# yaml-language-server: $schema=none
```

Since we support disabling schema detection for specific files using the `yaml.disableSchemaDetection` setting, I think it makes sense to offer the same control through a modeline.

### What issues does this PR fix or reference?

Fixes https://github.com/redhat-developer/yaml-language-server/issues/446

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
New automated test + tested manually