### PR TITLE
Update to TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "sinon-chai": "^3.5.0",
         "source-map-support": "^0.5.19",
         "ts-node": "^10.0.0",
-        "typescript": "^4.8.3",
+        "typescript": "^6.0.0",
         "typescript-eslint": "^8.59.4"
       }
     },
@@ -6818,9 +6818,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6828,7 +6828,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "sinon-chai": "^3.5.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.0.0",
-    "typescript": "^4.8.3",
+    "typescript": "^6.0.0",
     "typescript-eslint": "^8.59.4"
   },
   "scripts": {

--- a/test/arrUtils.test.ts
+++ b/test/arrUtils.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { getLineOffsets, removeDuplicatesObj } from '../src/languageservice/utils/arrUtils';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('Array Utils Tests', () => {
   describe('Server - Array Utils', function () {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -11,7 +11,7 @@ import {
   TestCustomSchemaProvider,
   toFsPath,
 } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as path from 'path';
 import { createExpectedCompletion } from './utils/verifyError';
 import { ServiceSetup } from './utils/serviceSetup';

--- a/test/bundlel10n.test.ts
+++ b/test/bundlel10n.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as l10n from '@vscode/l10n';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as path from 'path';
 import { Connection, createConnection } from 'vscode-languageserver/node';
 import { schemaRequestHandler, workspaceContext } from '../src/languageservice/services/schemaRequestHandler';

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -5,7 +5,7 @@
 import { setupLanguageService, setupTextDocument } from './utils/testHelper';
 import { ServiceSetup } from './utils/serviceSetup';
 import { createExpectedError } from './utils/verifyError';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Diagnostic } from 'vscode-languageserver-types';
 import { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { toFsPath, setupSchemaIDTextDocument, setupLanguageService, caretPosition } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as path from 'path';
 import { ServiceSetup } from './utils/serviceSetup';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';

--- a/test/documentPositionCalculator.test.ts
+++ b/test/documentPositionCalculator.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { binarySearch, getLineStartPositions, getPosition } from '../src/languageservice/utils/documentPositionCalculator';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('DocumentPositionCalculator Tests', () => {
   describe('binarySearch', function () {

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -9,7 +9,7 @@ import {
   createExpectedDocumentSymbolNoDetail,
 } from './utils/verifyError';
 import { DocumentSymbol, SymbolKind, SymbolInformation } from 'vscode-languageserver-types';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ServiceSetup } from './utils/serviceSetup';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ServiceSetup } from './utils/serviceSetup';
 import { DocumentLink } from 'vscode-languageserver-types';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as assert from 'assert';
+import assert from 'assert';
 import * as sinon from 'sinon';
 import { FormattingOptions, TextEdit } from 'vscode-languageserver-types';
 import { CustomFormatterOptions } from '../src';

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -10,7 +10,7 @@ import {
   setupSchemaIDTextDocument,
   TestCustomSchemaProvider,
 } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Hover, MarkupContent, Position } from 'vscode-languageserver-types';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Diagnostic, CompletionList, Hover, MarkupContent } from 'vscode-languageserver-types';
 import { ServiceSetup } from './utils/serviceSetup';
 import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';

--- a/test/jsonParser.test.ts
+++ b/test/jsonParser.test.ts
@@ -4,7 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
+import assert from 'assert';
 import { JSONDocument } from '../src/languageservice/parser/jsonDocument';
 import { getNodeValue } from '../src/languageservice/parser/astNodeUtils';
 import * as JsonSchema from './../src/languageservice/jsonSchema';

--- a/test/multipleDocuments.test.ts
+++ b/test/multipleDocuments.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as path from 'path';
 import { setupLanguageService, setupTextDocument, toFsPath } from './utils/testHelper';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ServiceSetup } from './utils/serviceSetup';
 import { Diagnostic, Hover, MarkupContent } from 'vscode-languageserver-types';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { equals, convertErrorToTelemetryMsg } from '../src/languageservice/utils/objects';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('Object Equals Tests', () => {
   describe('Equals', function () {

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import { WorkspaceFolder } from 'vscode-languageserver-protocol';
 import { join } from 'path';
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import * as parser from '../src/languageservice/parser/yamlParser07';
 import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import * as JsonSchema from '../src/languageservice/jsonSchema';

--- a/test/schemaRequestHandler.test.ts
+++ b/test/schemaRequestHandler.test.ts
@@ -10,7 +10,7 @@ import { XHRResponse } from 'request-light';
 import { Connection } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/schemaSelectionHandlers.test.ts
+++ b/test/schemaSelectionHandlers.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as sinon from 'sinon';
 import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import { JSONSchemaSelection } from '../src/languageserver/handlers/schemaSelectionHandlers';
 import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaService';
 import { Connection, RemoteClient } from 'vscode-languageserver/node';

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -15,7 +15,7 @@ import {
   propertyIsNotAllowed,
   MissingRequiredPropWarning,
 } from './utils/errorMessages';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as path from 'path';
 import { Diagnostic, DiagnosticSeverity, Position } from 'vscode-languageserver-types';
 import { expect } from 'chai';

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -6,7 +6,7 @@
 import * as chai from 'chai';
 import * as request from 'request-light';
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver';
 import { CodeLensRefreshRequest } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { startsWith, endsWith, convertSimple2RegExp, safeCreateUnicodeRegExp } from '../src/languageservice/utils/strings';
-import * as assert from 'assert';
+import assert from 'assert';
 import { expect } from 'chai';
 
 describe('String Tests', () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { checkSchemaURI } from '../src/languageservice/utils/schemaUrls';
 import { TelemetryImpl } from '../src/languageserver/telemetry';

--- a/test/textBuffer.test.ts
+++ b/test/textBuffer.test.ts
@@ -5,7 +5,7 @@
 
 import { TextBuffer } from '../src/languageservice/utils/textBuffer';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import * as assert from 'assert';
+import assert from 'assert';
 
 describe('TextBuffer', () => {
   it('getLineLength should return actual line length', () => {

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
 import { setupTextDocument } from './utils/testHelper';

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
 import {

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { YamlCodeLens } from '../src/languageservice/services/yamlCodeLens';
 import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaService';

--- a/test/yamlCommands.test.ts
+++ b/test/yamlCommands.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import { registerCommands } from '../src/languageservice/services/yamlCommands';
 import { commandExecutor } from '../src/languageserver/commandExecutor';

--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as assert from 'assert';
+import assert from 'assert';
 import { expect } from 'chai';
 import { ArrayASTNode, ObjectASTNode, PropertyASTNode } from '../src/languageservice/jsonASTTypes';
 import { parse, YAMLDocument } from './../src/languageservice/parser/yamlParser07';

--- a/test/yamlSchema.test.ts
+++ b/test/yamlSchema.test.ts
@@ -6,7 +6,7 @@ import * as SchemaService from '../src/languageservice/services/yamlSchemaServic
 import * as url from 'url';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as sinon from 'sinon';
 import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
+import sinonChai from 'sinon-chai';
 import * as path from 'path';
 import * as url from 'url';
 import * as SchemaService from '../src/languageservice/services/yamlSchemaService';

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,15 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "downlevelIteration": true,
     "lib": ["WebWorker"],
     "module": "esnext",
+    "moduleResolution": "bundler",
     "outDir": "./lib/esm",
+    "rootDir": "./src"
   },
-  "exclude": [
-    "node_modules",
-    "out",
-    "lib",
-    "test"
-  ]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,19 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
-    "forceConsistentCasingInFileNames": true,
     "lib": ["es2020", "WebWorker"],
-    "module": "commonjs",
-    "moduleResolution": "nodenext",
+    "module": "nodenext",
+    "noImplicitAny": false,
+    "noImplicitThis": false,
     "outDir": "./out/server",
+    "skipLibCheck": true,
     "sourceMap": true,
+    "strictFunctionTypes": false,
+    "strictNullChecks": false,
     "target": "es2020",
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true
+    "types": ["mocha", "node"],
+    "useUnknownInCatchVariables": false
   },
-  "include": [ "src", "test" ],
+  "include": ["src", "test"],
   "exclude": ["node_modules", "out"]
 }

--- a/tsconfig.umd.json
+++ b/tsconfig.umd.json
@@ -1,14 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "lib": ["webworker"],
     "module": "umd",
+    "moduleResolution": "node10",
     "outDir": "./lib/umd",
+    "rootDir": "./src"
   },
-  "exclude": [
-    "node_modules",
-    "out",
-    "lib",
-    "test"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
### What does this PR do?

TypeScrit 5 and 6 both removed support for some deprecated features. So the config and code have been minimally adjusted.

The `module` option for the CJS build was changed to `nodenext`. This implies a matching `moduleResolution` and
`allowSyntheticDefaultImports`, to these are now redundant and were removed. `strict` is now true. All non-strict options the code is not compliant with have been disabled explicitly.
`forceConsistentCasingInFileNames` is now true by default, to it was removed.

The correct `module` option for ESM is also `nodenext`, but with `"type": "module"` in `package.json. Unfortunately we can’t use this yet for dual publishing, so as a middle ground, `module` was left at `esnext` and we have to use the `bundler` module resolution. `rootDir` detection was removed, so this is now configured explicitly, with a matching `include` option. `downlevelIteration` is deprecated and was removed.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```sh
tsc
tsc -P tsconfig.esm.json
```