### PR TITLE
Sort imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,10 +33,22 @@ export default defineConfig(
       },
     },
     rules: {
+      'sort-imports': ['error', { ignoreDeclarationSort: true }],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false }],
       '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
       'import-x/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+      'import-x/first': 'error',
+      'import-x/newline-after-import': 'error',
+      'import-x/order': [
+        'error',
+        {
+          alphabetize: { order: 'asc' },
+          groups: ['type', 'builtin', 'external', ['parent', 'sibling', 'index']],
+          'newlines-between': 'always',
+          sortTypesGroup: true,
+        },
+      ],
     },
   },
   {

--- a/src/languageserver/handlers/languageHandlers.ts
+++ b/src/languageserver/handlers/languageHandlers.ts
@@ -6,19 +6,20 @@
 import type { Connection } from 'vscode-languageserver';
 import type {
   CodeActionParams,
+  CodeLensParams,
+  DefinitionParams,
   DidChangeWatchedFilesParams,
   DocumentFormattingParams,
   DocumentLinkParams,
   DocumentOnTypeFormattingParams,
   DocumentSymbolParams,
   FoldingRangeParams,
-  SelectionRangeParams,
-  TextDocumentPositionParams,
-  CodeLensParams,
-  DefinitionParams,
   PrepareRenameParams,
   RenameParams,
+  SelectionRangeParams,
+  TextDocumentPositionParams,
 } from 'vscode-languageserver-protocol';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type {
   CodeAction,
   CodeLens,
@@ -26,21 +27,23 @@ import type {
   DefinitionLink,
   DocumentLink,
   DocumentSymbol,
-  Hover,
   FoldingRange,
+  Hover,
   Range,
   SelectionRange,
   SymbolInformation,
   TextEdit,
   WorkspaceEdit,
 } from 'vscode-languageserver-types';
-import { isKubernetesAssociatedDocument } from '../../languageservice/parser/isKubernetes';
+
+import type { ValidationHandler } from './validationHandlers';
 import type { LanguageService } from '../../languageservice/yamlLanguageService';
 import type { SettingsState } from '../../yamlSettings';
-import type { ValidationHandler } from './validationHandlers';
-import { ResultLimitReachedNotification } from '../../requestTypes';
+
 import * as path from 'path';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { isKubernetesAssociatedDocument } from '../../languageservice/parser/isKubernetes';
+import { ResultLimitReachedNotification } from '../../requestTypes';
 
 export class LanguageHandlers {
   private languageService: LanguageService;

--- a/src/languageserver/handlers/notificationHandlers.ts
+++ b/src/languageserver/handlers/notificationHandlers.ts
@@ -3,8 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { Connection } from 'vscode-languageserver';
+
+import type { SettingsHandler } from './settingsHandlers';
 import type { CustomSchemaProvider } from '../../languageservice/services/yamlSchemaService';
 import type { LanguageService, SchemaConfiguration } from '../../languageservice/yamlLanguageService';
+import type { SettingsState } from '../../yamlSettings';
+
 import {
   CustomSchemaRequest,
   DynamicCustomSchemaRequestRegistration,
@@ -12,8 +16,6 @@ import {
   SchemaSelectionRequests,
   VSCodeContentRequestRegistration,
 } from '../../requestTypes';
-import type { SettingsState } from '../../yamlSettings';
-import type { SettingsHandler } from './settingsHandlers';
 
 export class NotificationHandlers {
   private languageService: LanguageService;

--- a/src/languageserver/handlers/requestHandlers.ts
+++ b/src/languageserver/handlers/requestHandlers.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { Connection } from 'vscode-languageserver';
+
 import type { SchemaAdditions, SchemaDeletions, SchemaDeletionsAll } from '../../languageservice/services/yamlSchemaService';
-import { MODIFICATION_ACTIONS } from '../../languageservice/services/yamlSchemaService';
 import type { LanguageService } from '../../languageservice/yamlLanguageService';
+
+import { MODIFICATION_ACTIONS } from '../../languageservice/services/yamlSchemaService';
 import { SchemaModificationNotification } from '../../requestTypes';
 
 export class RequestHandlers {

--- a/src/languageserver/handlers/schemaSelectionHandlers.ts
+++ b/src/languageserver/handlers/schemaSelectionHandlers.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Connection } from 'vscode-languageserver/node';
+
 import type { JSONSchema } from '../../languageservice/jsonSchema';
-import { yamlDocumentsCache } from '../../languageservice/parser/yaml-documents';
 import type { YAMLSchemaService } from '../../languageservice/services/yamlSchemaService';
-import type { SettingsState } from '../../yamlSettings';
 import type { JSONSchemaDescription, JSONSchemaDescriptionExt } from '../../requestTypes';
+import type { SettingsState } from '../../yamlSettings';
+
+import { yamlDocumentsCache } from '../../languageservice/parser/yaml-documents';
 import { SchemaSelectionRequests } from '../../requestTypes';
 
 export class JSONSchemaSelection {

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -2,19 +2,22 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { configure as configureHttpRequests, xhr } from 'request-light';
 import type { Connection } from 'vscode-languageserver';
+
+import type { ValidationHandler } from './validationHandlers';
+import type { Telemetry } from '../../languageservice/telemetry';
+import type { LanguageService, LanguageSettings, SchemasSettings } from '../../languageservice/yamlLanguageService';
+import type { Settings, SettingsState } from '../../yamlSettings';
+
+import { configure as configureHttpRequests, xhr } from 'request-light';
 import { DidChangeConfigurationNotification, DocumentFormattingRequest } from 'vscode-languageserver';
 import { CodeLensRefreshRequest } from 'vscode-languageserver-protocol';
-import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
-import { checkSchemaURI, EMPTY_SCHEMA_URL, isKubernetes, JSON_SCHEMASTORE_URL } from '../../languageservice/utils/schemaUrls';
+
 import { equals } from '../../languageservice/utils/objects';
-import type { LanguageService, LanguageSettings, SchemasSettings } from '../../languageservice/yamlLanguageService';
+import { isRelativePath, relativeToAbsolutePath } from '../../languageservice/utils/paths';
+import { EMPTY_SCHEMA_URL, JSON_SCHEMASTORE_URL, checkSchemaURI, isKubernetes } from '../../languageservice/utils/schemaUrls';
 import { SchemaPriority } from '../../languageservice/yamlLanguageService';
 import { SchemaSelectionRequests } from '../../requestTypes';
-import type { Settings, SettingsState } from '../../yamlSettings';
-import type { Telemetry } from '../../languageservice/telemetry';
-import type { ValidationHandler } from './validationHandlers';
 
 export class SettingsHandler {
   private schemaSettings: SchemasSettings[] | undefined;

--- a/src/languageserver/handlers/validationHandlers.ts
+++ b/src/languageserver/handlers/validationHandlers.ts
@@ -5,10 +5,12 @@
 import type { Connection } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Diagnostic } from 'vscode-languageserver-types';
-import { isKubernetesAssociatedDocument } from '../../languageservice/parser/isKubernetes';
-import { removeDuplicatesObj } from '../../languageservice/utils/arrUtils';
+
 import type { LanguageService } from '../../languageservice/yamlLanguageService';
 import type { SettingsState } from '../../yamlSettings';
+
+import { isKubernetesAssociatedDocument } from '../../languageservice/parser/isKubernetes';
+import { removeDuplicatesObj } from '../../languageservice/utils/arrUtils';
 
 export class ValidationHandler {
   private languageService: LanguageService;

--- a/src/languageserver/handlers/workspaceHandlers.ts
+++ b/src/languageserver/handlers/workspaceHandlers.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { ExecuteCommandParams, Connection } from 'vscode-languageserver';
+import type { Connection, ExecuteCommandParams } from 'vscode-languageserver';
+
 import type { CommandExecutor } from '../commandExecutor';
 
 export class WorkspaceHandlers {

--- a/src/languageserver/telemetry.ts
+++ b/src/languageserver/telemetry.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Connection } from 'vscode-languageserver';
-import type { TelemetryEvent, Telemetry } from '../languageservice/telemetry';
+
+import type { Telemetry, TelemetryEvent } from '../languageservice/telemetry';
+
 import { convertErrorToTelemetryMsg } from '../languageservice/utils/objects';
 
 export class TelemetryImpl implements Telemetry {

--- a/src/languageservice/jsonLanguageTypes.ts
+++ b/src/languageservice/jsonLanguageTypes.ts
@@ -6,49 +6,53 @@
 // Forked from vscode-json-languageservice@6.0.0-next.1
 // Source: https://github.com/microsoft/vscode-json-languageservice/blob/810471bbb462bb6b87351c2232e209a3bb4062ca/src/jsonLanguageTypes.ts
 
-import { JSONSchema } from './jsonSchema';
 import type { FormattingOptions as LSPFormattingOptions } from 'vscode-languageserver-types';
+import type { Node, Pair } from 'yaml';
+
+import type { CustomTagReturnType } from './utils/customTags';
+
+import { TextDocument, TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
 import {
-  Range,
-  Position,
-  DocumentUri,
-  MarkupContent,
-  MarkupKind,
+  CodeAction,
+  CodeActionContext,
+  CodeActionKind,
   Color,
   ColorInformation,
   ColorPresentation,
-  FoldingRange,
-  FoldingRangeKind,
-  SelectionRange,
-  Diagnostic,
-  DiagnosticSeverity,
+  Command,
   CompletionItem,
   CompletionItemKind,
-  CompletionList,
   CompletionItemTag,
+  CompletionList,
+  DefinitionLink,
+  Diagnostic,
+  DiagnosticSeverity,
+  DocumentHighlight,
+  DocumentHighlightKind,
+  DocumentLink,
+  DocumentSymbol,
+  DocumentUri,
+  FoldingRange,
+  FoldingRangeKind,
+  Hover,
   InsertTextFormat,
+  Location,
+  MarkedString,
+  MarkupContent,
+  MarkupKind,
+  Position,
+  Range,
+  SelectionRange,
   SymbolInformation,
   SymbolKind,
-  DocumentSymbol,
-  Location,
-  Hover,
-  MarkedString,
-  DefinitionLink,
-  CodeActionContext,
-  Command,
-  CodeAction,
-  DocumentHighlight,
-  DocumentLink,
-  WorkspaceEdit,
-  TextEdit,
-  CodeActionKind,
   TextDocumentEdit,
+  TextEdit,
   VersionedTextDocumentIdentifier,
-  DocumentHighlightKind,
+  WorkspaceEdit,
 } from 'vscode-languageserver-types';
-import { TextDocument, TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument';
-import type { Node, Pair } from 'yaml';
-import type { CustomTagReturnType } from './utils/customTags';
+
+import { JSONSchema } from './jsonSchema';
+
 export {
   TextDocument,
   TextDocumentContentChangeEvent,

--- a/src/languageservice/parser/ast-converter.ts
+++ b/src/languageservice/parser/ast-converter.ts
@@ -3,19 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Node, Scalar, YAMLMap, Pair, YAMLSeq, Alias, Document, LineCounter } from 'yaml';
-import { isScalar, isMap, isPair, isSeq, isNode, isAlias } from 'yaml';
+import type { Alias, Document, LineCounter, Node, Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml';
+
 import type { ASTNode, YamlNode } from '../jsonLanguageTypes';
-import { getCustomTagReturnType } from '../utils/customTags';
+
+import { isAlias, isMap, isNode, isPair, isScalar, isSeq } from 'yaml';
+
 import {
-  NullASTNodeImpl,
-  PropertyASTNodeImpl,
-  StringASTNodeImpl,
-  ObjectASTNodeImpl,
-  NumberASTNodeImpl,
   ArrayASTNodeImpl,
   BooleanASTNodeImpl,
+  NullASTNodeImpl,
+  NumberASTNodeImpl,
+  ObjectASTNodeImpl,
+  PropertyASTNodeImpl,
+  StringASTNodeImpl,
 } from './jsonDocument';
+import { getCustomTagReturnType } from '../utils/customTags';
 
 type NodeRange = [number, number, number];
 

--- a/src/languageservice/parser/custom-tag-provider.ts
+++ b/src/languageservice/parser/custom-tag-provider.ts
@@ -1,6 +1,9 @@
 import type { Tags, YAMLMap, YAMLSeq } from 'yaml';
-import { isSeq, isMap, Scalar } from 'yaml';
+
 import type { CustomTagInputType, CustomTagReturnType } from '../utils/customTags';
+
+import { Scalar, isMap, isSeq } from 'yaml';
+
 import { parseCustomTag, setCustomTagReturnType } from '../utils/customTags';
 
 class CommonTagImpl {

--- a/src/languageservice/parser/isKubernetes.ts
+++ b/src/languageservice/parser/isKubernetes.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { FilePatternAssociation } from '../utils/filePatternAssociation';
+
 import type * as Parser from './jsonDocument';
+
+import { FilePatternAssociation } from '../utils/filePatternAssociation';
 
 export function setKubernetesParserOption(jsonDocuments: Parser.JSONDocument[], option: boolean): void {
   for (const jsonDoc of jsonDocuments) {

--- a/src/languageservice/parser/jsonDocument.ts
+++ b/src/languageservice/parser/jsonDocument.ts
@@ -3,23 +3,25 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { JSONSchema } from '../jsonSchema';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { Diagnostic, Range } from 'vscode-languageserver-types';
+import type { Node, Pair } from 'yaml';
+
 import type {
   ASTNode,
-  ObjectASTNode,
   ArrayASTNode,
   BooleanASTNode,
-  NumberASTNode,
-  StringASTNode,
   NullASTNode,
+  NumberASTNode,
+  ObjectASTNode,
   PropertyASTNode,
+  StringASTNode,
   YamlNode,
 } from '../jsonLanguageTypes';
+import type { JSONSchema } from '../jsonSchema';
 import type { CustomTagReturnType } from '../utils/customTags';
-import type { Diagnostic, Range } from 'vscode-languageserver-types';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
-import type { Node, Pair } from 'yaml';
 import type { IApplicableSchema } from './schemaValidation/baseValidator';
+
 import { findNodeAtOffset } from '../utils/astNodeUtils';
 import { getValidator } from './schemaValidation/validatorFactory';
 

--- a/src/languageservice/parser/schemaValidation/baseValidator.ts
+++ b/src/languageservice/parser/schemaValidation/baseValidator.ts
@@ -4,29 +4,32 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
+
 import type {
   ASTNode,
   ArrayASTNode,
   NumberASTNode,
   ObjectASTNode,
   PropertyASTNode,
-  StringASTNode,
   SchemaDraft,
+  StringASTNode,
 } from '../../jsonLanguageTypes';
-import { equals, isBoolean, isDefined, isIterable, isNumber, isString } from '../../utils/objects';
-import { getSchemaTypeName } from '../../utils/schemaUtils';
+import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
+
+import * as l10n from '@vscode/l10n';
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import { URI } from 'vscode-uri';
+
+import { getValidator } from './validatorFactory';
+import { ErrorCode } from '../../jsonLanguageTypes';
 import { isArrayEqual } from '../../utils/arrUtils';
-import { safeCreateUnicodeRegExp } from '../../utils/strings';
+import { contains, getNodeValue } from '../../utils/astNodeUtils';
 import { FilePatternAssociation } from '../../utils/filePatternAssociation';
 import { floatSafeRemainder } from '../../utils/math';
-import { ErrorCode } from '../../jsonLanguageTypes';
-import * as l10n from '@vscode/l10n';
-import { URI } from 'vscode-uri';
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { contains, getNodeValue } from '../../utils/astNodeUtils';
-import { getValidator } from './validatorFactory';
+import { equals, isBoolean, isDefined, isIterable, isNumber, isString } from '../../utils/objects';
+import { getSchemaTypeName } from '../../utils/schemaUtils';
+import { safeCreateUnicodeRegExp } from '../../utils/strings';
 
 export const YAML_SOURCE = 'YAML';
 const YAML_SCHEMA_PREFIX = 'yaml-schema: ';

--- a/src/languageservice/parser/schemaValidation/draft04Validator.ts
+++ b/src/languageservice/parser/schemaValidation/draft04Validator.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { JSONSchema } from '../../jsonSchema';
+
+import { BaseValidator } from './baseValidator';
 import { SchemaDraft } from '../../jsonLanguageTypes';
 import { isBoolean, isNumber } from '../../utils/objects';
-import { BaseValidator } from './baseValidator';
 
 export class Draft04Validator extends BaseValidator {
   protected override getCurrentSchemaDraft(): SchemaDraft {

--- a/src/languageservice/parser/schemaValidation/draft07Validator.ts
+++ b/src/languageservice/parser/schemaValidation/draft07Validator.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { JSONSchema } from '../../jsonSchema';
+
+import { BaseValidator } from './baseValidator';
 import { SchemaDraft } from '../../jsonLanguageTypes';
 import { isNumber } from '../../utils/objects';
-import { BaseValidator } from './baseValidator';
 
 export class Draft07Validator extends BaseValidator {
   protected override getCurrentSchemaDraft(): SchemaDraft {

--- a/src/languageservice/parser/schemaValidation/draft2019Validator.ts
+++ b/src/languageservice/parser/schemaValidation/draft2019Validator.ts
@@ -3,15 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
-import { ErrorCode, SchemaDraft } from '../../jsonLanguageTypes';
+import type { ISchemaCollector, Options } from './baseValidator';
 import type { ASTNode, ArrayASTNode, ObjectASTNode } from '../../jsonLanguageTypes';
-import { isNumber } from '../../utils/objects';
+import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
+
 import * as l10n from '@vscode/l10n';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
-import { Draft07Validator } from './draft07Validator';
+
 import { ValidationResult, asSchema } from './baseValidator';
-import type { ISchemaCollector, Options } from './baseValidator';
+import { Draft07Validator } from './draft07Validator';
+import { ErrorCode, SchemaDraft } from '../../jsonLanguageTypes';
+import { isNumber } from '../../utils/objects';
 
 export class Draft2019Validator extends Draft07Validator {
   protected override getCurrentSchemaDraft(): SchemaDraft {

--- a/src/languageservice/parser/schemaValidation/draft2020Validator.ts
+++ b/src/languageservice/parser/schemaValidation/draft2020Validator.ts
@@ -3,15 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
-import { SchemaDraft } from '../../jsonLanguageTypes';
+import type { ISchemaCollector, Options } from './baseValidator';
 import type { ASTNode, ArrayASTNode } from '../../jsonLanguageTypes';
-import { isNumber } from '../../utils/objects';
+import type { JSONSchema, JSONSchemaRef } from '../../jsonSchema';
+
 import * as l10n from '@vscode/l10n';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
-import { Draft2019Validator } from './draft2019Validator';
-import type { ISchemaCollector, Options } from './baseValidator';
+
 import { ValidationResult, asSchema } from './baseValidator';
+import { Draft2019Validator } from './draft2019Validator';
+import { SchemaDraft } from '../../jsonLanguageTypes';
+import { isNumber } from '../../utils/objects';
 
 export class Draft2020Validator extends Draft2019Validator {
   protected override getCurrentSchemaDraft(): SchemaDraft {

--- a/src/languageservice/parser/schemaValidation/validatorFactory.ts
+++ b/src/languageservice/parser/schemaValidation/validatorFactory.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SchemaDraft } from '../../jsonLanguageTypes';
 import type { BaseValidator } from './baseValidator';
+
 import { Draft04Validator } from './draft04Validator';
 import { Draft07Validator } from './draft07Validator';
 import { Draft2019Validator } from './draft2019Validator';
 import { Draft2020Validator } from './draft2020Validator';
+import { SchemaDraft } from '../../jsonLanguageTypes';
 
 export function getValidator(schemaDraft: SchemaDraft): BaseValidator {
   switch (schemaDraft) {

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -4,19 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { JSONDocument } from './jsonDocument';
 import type { CST, Document, LineCounter, Node, YAMLError } from 'yaml';
-import { isNode, isPair, isScalar, visit } from 'yaml';
+
 import type { ASTNode, YamlNode } from '../jsonLanguageTypes';
 import type { ParserOptions } from './yamlParser07';
+import type { YAMLDocDiagnostic } from '../utils/parseUtils';
+import type { TextBuffer } from '../utils/textBuffer';
+
+import { isNode, isPair, isScalar, visit } from 'yaml';
+
+import { JSONDocument } from './jsonDocument';
 import { defaultOptions, parse as parseYAML } from './yamlParser07';
 import { ErrorCode } from '../jsonLanguageTypes';
 import { convertAST } from './ast-converter';
-import type { YAMLDocDiagnostic } from '../utils/parseUtils';
 import { isArrayEqual } from '../utils/arrUtils';
-import { getParent } from '../utils/yamlAstUtils';
-import type { TextBuffer } from '../utils/textBuffer';
 import { getIndentation } from '../utils/strings';
+import { getParent } from '../utils/yamlAstUtils';
 
 /**
  * These documents are collected into a final YAMLDocument

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -4,11 +4,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Document, ParseOptions, DocumentOptions, SchemaOptions } from 'yaml';
-import { Parser, Composer, LineCounter } from 'yaml';
-import { YAMLDocument, SingleYAMLDocument } from './yaml-documents';
-import { getCustomTags } from './custom-tag-provider';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { Document, DocumentOptions, ParseOptions, SchemaOptions } from 'yaml';
+
+import { Composer, LineCounter, Parser } from 'yaml';
+
+import { getCustomTags } from './custom-tag-provider';
+import { SingleYAMLDocument, YAMLDocument } from './yaml-documents';
 import { TextBuffer } from '../utils/textBuffer';
 
 export { YAMLDocument, SingleYAMLDocument };

--- a/src/languageservice/services/documentSymbols.ts
+++ b/src/languageservice/services/documentSymbols.ts
@@ -4,13 +4,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Location, Range, SymbolKind } from 'vscode-languageserver-types';
-import type { DocumentSymbol, SymbolInformation } from 'vscode-languageserver-types';
-import type { DocumentSymbolsContext, ASTNode, PropertyASTNode } from '../jsonLanguageTypes';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
+import type { DocumentSymbol, SymbolInformation } from 'vscode-languageserver-types';
+
+import type { ASTNode, DocumentSymbolsContext, PropertyASTNode } from '../jsonLanguageTypes';
 import type { Telemetry } from '../telemetry';
+
+import { Location, Range, SymbolKind } from 'vscode-languageserver-types';
 import { isMap, isSeq } from 'yaml';
+
+import { yamlDocumentsCache } from '../parser/yaml-documents';
 
 export class YAMLDocumentSymbols {
   constructor(private readonly telemetry?: Telemetry) {}

--- a/src/languageservice/services/dollarUtils.ts
+++ b/src/languageservice/services/dollarUtils.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SingleYAMLDocument } from '../parser/yamlParser07';
 import { JSONDocument } from '../parser/jsonDocument';
+import { SingleYAMLDocument } from '../parser/yamlParser07';
 
 /**
  * Retrieve schema if declared by `$schema`.

--- a/src/languageservice/services/k8sSchemaUtil.ts
+++ b/src/languageservice/services/k8sSchemaUtil.ts
@@ -1,8 +1,8 @@
-import type { JSONDocument } from '../parser/jsonDocument';
-import { SingleYAMLDocument } from '../parser/yamlParser07';
-
 import type { ResolvedSchema } from './yamlSchemaService';
 import type { JSONSchema } from '../jsonSchema';
+import type { JSONDocument } from '../parser/jsonDocument';
+
+import { SingleYAMLDocument } from '../parser/yamlParser07';
 
 /**
  * Attempt to retrieve the schema for a given YAML document based on the Kubernetes GroupVersionKind (GVK).

--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SingleYAMLDocument } from '../parser/yamlParser07';
 import type { JSONDocument } from '../parser/jsonDocument';
+
+import { SingleYAMLDocument } from '../parser/yamlParser07';
 
 /**
  * Retrieve schema if declared as modeline.

--- a/src/languageservice/services/schemaRequestHandler.ts
+++ b/src/languageservice/services/schemaRequestHandler.ts
@@ -1,12 +1,16 @@
-import { join } from 'path';
-import { getErrorStatusDescription, xhr } from 'request-light';
-import * as URL from 'url';
 import type { Connection, WorkspaceFolder } from 'vscode-languageserver';
+
+import type { WorkspaceContextService } from '../yamlLanguageService';
+
+import { join } from 'path';
+import * as URL from 'url';
+
+import { getErrorStatusDescription, xhr } from 'request-light';
 import { RequestType } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+
 import { CustomSchemaContentRequest, VSCodeContentRequest } from '../../requestTypes';
 import { isRelativePath, relativeToAbsolutePath } from '../utils/paths';
-import type { WorkspaceContextService } from '../yamlLanguageService';
 
 export interface FileSystem {
   readFile(fsPath: string, encoding?: string): Promise<string>;

--- a/src/languageservice/services/validation/map-key-order.ts
+++ b/src/languageservice/services/validation/map-key-order.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import type { CST, Node, Pair } from 'yaml';
-import { isMap, visit } from 'yaml';
-import type { SingleYAMLDocument } from '../../parser/yaml-documents';
+
 import type { AdditionalValidator } from './types';
+import type { SingleYAMLDocument } from '../../parser/yaml-documents';
+
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import { isMap, visit } from 'yaml';
 
 export class MapKeyOrderValidator implements AdditionalValidator {
   validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[] {

--- a/src/languageservice/services/validation/types.ts
+++ b/src/languageservice/services/validation/types.ts
@@ -5,6 +5,7 @@
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Diagnostic } from 'vscode-languageserver-types';
+
 import type { SingleYAMLDocument } from '../../parser/yaml-documents';
 
 export interface AdditionalValidator {

--- a/src/languageservice/services/validation/unused-anchors.ts
+++ b/src/languageservice/services/validation/unused-anchors.ts
@@ -4,14 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { Diagnostic, DiagnosticSeverity, DiagnosticTag, Range } from 'vscode-languageserver-types';
-import type { Node, Scalar, YAMLMap, YAMLSeq, Pair } from 'yaml';
-import { isAlias, isCollection, isNode, isScalar, visit, CST } from 'yaml';
+import type { Node, Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml';
+
+import type { AdditionalValidator } from './types';
 import type { YamlNode } from '../../jsonLanguageTypes';
 import type { SingleYAMLDocument } from '../../parser/yaml-documents';
-import type { AdditionalValidator } from './types';
-import { isCollectionItem } from '../../utils/yamlAstUtils';
+
 import * as l10n from '@vscode/l10n';
+import { Diagnostic, DiagnosticSeverity, DiagnosticTag, Range } from 'vscode-languageserver-types';
+import { CST, isAlias, isCollection, isNode, isScalar, visit } from 'yaml';
+
+import { isCollectionItem } from '../../utils/yamlAstUtils';
 
 export class UnusedAnchorsValidator implements AdditionalValidator {
   validate(document: TextDocument, yamlDoc: SingleYAMLDocument): Diagnostic[] {

--- a/src/languageservice/services/validation/yaml-style.ts
+++ b/src/languageservice/services/validation/yaml-style.ts
@@ -1,11 +1,13 @@
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
 import type { CST } from 'yaml';
-import { isMap, isSeq, visit } from 'yaml';
+
+import type { AdditionalValidator } from './types';
 import type { SingleYAMLDocument } from '../../parser/yaml-documents';
 import type { LanguageSettings } from '../../yamlLanguageService';
-import type { AdditionalValidator } from './types';
+
 import * as l10n from '@vscode/l10n';
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import { isMap, isSeq, visit } from 'yaml';
 
 export class YAMLStyleValidator implements AdditionalValidator {
   private forbidSequence: boolean;

--- a/src/languageservice/services/yamlCodeActions.ts
+++ b/src/languageservice/services/yamlCodeActions.ts
@@ -3,30 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as l10n from '@vscode/l10n';
-import * as path from 'path';
-import { ErrorCode } from '../jsonLanguageTypes';
-import type { Diagnostic, WorkspaceEdit } from 'vscode-languageserver-types';
-import { CodeAction, CodeActionKind, Command, Position, Range, TextEdit } from 'vscode-languageserver-types';
 import type { ClientCapabilities, CodeActionParams } from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-
+import type { Diagnostic, WorkspaceEdit } from 'vscode-languageserver-types';
 import type { Scalar, YAMLMap } from 'yaml';
-import { CST, isMap, isSeq, isScalar, visit } from 'yaml';
-
-import { YamlCommands } from '../../commands';
-import { TextBuffer } from '../utils/textBuffer';
-import { toYamlStringScalar } from '../utils/yamlScalar';
-import type { LanguageSettings } from '../yamlLanguageService';
-import { YAML_SOURCE } from '../parser/schemaValidation/baseValidator';
-import { getFirstNonWhitespaceCharacterAfterOffset } from '../utils/strings';
-import { matchOffsetToDocument } from '../utils/arrUtils';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
-
-import { BlockStringRewriter } from '../utils/block-string-rewriter';
-import { FlowStyleRewriter } from '../utils/flow-style-rewriter';
 
 import type { ASTNode } from '../jsonLanguageTypes';
+import type { LanguageSettings } from '../yamlLanguageService';
+
+import * as path from 'path';
+
+import * as l10n from '@vscode/l10n';
+import { CodeAction, CodeActionKind, Command, Position, Range, TextEdit } from 'vscode-languageserver-types';
+import { CST, isMap, isScalar, isSeq, visit } from 'yaml';
+
+import { YamlCommands } from '../../commands';
+import { ErrorCode } from '../jsonLanguageTypes';
+import { YAML_SOURCE } from '../parser/schemaValidation/baseValidator';
+import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { matchOffsetToDocument } from '../utils/arrUtils';
+import { BlockStringRewriter } from '../utils/block-string-rewriter';
+import { FlowStyleRewriter } from '../utils/flow-style-rewriter';
+import { getFirstNonWhitespaceCharacterAfterOffset } from '../utils/strings';
+import { TextBuffer } from '../utils/textBuffer';
+import { toYamlStringScalar } from '../utils/yamlScalar';
 
 interface YamlDiagnosticData {
   schemaUri: string[];

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { CodeLens, Range } from 'vscode-languageserver-types';
-import { YamlCommands } from '../../commands';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
+
 import type { YAMLSchemaService } from './yamlSchemaService';
 import type { JSONSchema } from '../jsonSchema';
 import type { Telemetry } from '../telemetry';
+
+import { CodeLens, Range } from 'vscode-languageserver-types';
+
+import { YamlCommands } from '../../commands';
+import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { getSchemaUrls } from '../utils/schemaUrls';
 import { getSchemaTitle } from '../utils/schemaUtils';
 

--- a/src/languageservice/services/yamlCommands.ts
+++ b/src/languageservice/services/yamlCommands.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Connection } from 'vscode-languageserver';
-import { YamlCommands } from '../../commands';
+
 import type { CommandExecutor } from '../../languageserver/commandExecutor';
+
 import { URI } from 'vscode-uri';
+
+import { YamlCommands } from '../../commands';
 
 export function registerCommands(commandExecutor: CommandExecutor, connection: Connection): void {
   commandExecutor.registerCommand(YamlCommands.JUMP_TO_SCHEMA, async (uri: string) => {

--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -3,9 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { ClientCapabilities } from 'vscode-languageserver';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { MarkupContent } from 'vscode-languageserver-types';
+import type { Node, Pair, YAMLMap, YAMLSeq } from 'yaml';
+
+import type { JSONSchema, JSONSchemaRef } from '../jsonSchema';
+import type { ResolvedSchema, YAMLSchemaService } from './yamlSchemaService';
+import type { SettingsState } from '../../yamlSettings';
+import type { YamlNode } from '../jsonLanguageTypes';
+import type { SingleYAMLDocument, YamlDocuments } from '../parser/yaml-documents';
+import type { YamlVersion } from '../parser/yamlParser07';
+import type { Telemetry } from '../telemetry';
+import type { StringifySettings } from '../utils/json';
+import type { LanguageSettings } from '../yamlLanguageService';
+
+import * as l10n from '@vscode/l10n';
 import {
   CompletionItem as CompletionItemBase,
   CompletionItemKind,
@@ -17,30 +30,20 @@ import {
   Range,
   TextEdit,
 } from 'vscode-languageserver-types';
-import type { Node, YAMLMap, YAMLSeq, Pair } from 'yaml';
-import { isPair, isScalar, isMap, isSeq, isNode } from 'yaml';
-import { parseCustomTag } from '../utils/customTags';
-import type { Telemetry } from '../telemetry';
-import type { SingleYAMLDocument, YamlDocuments } from '../parser/yaml-documents';
-import type { YamlVersion } from '../parser/yamlParser07';
-import { matchOffsetToDocument } from '../utils/arrUtils';
-import { guessIndentation } from '../utils/indentationGuesser';
-import { TextBuffer } from '../utils/textBuffer';
-import type { LanguageSettings } from '../yamlLanguageService';
-import type { ResolvedSchema, YAMLSchemaService } from './yamlSchemaService';
-import type { JSONSchema, JSONSchemaRef } from '../jsonSchema';
-import type { StringifySettings } from '../utils/json';
-import { stringifyObject } from '../utils/json';
-import { isDefined, isString } from '../utils/objects';
+import { isMap, isNode, isPair, isScalar, isSeq } from 'yaml';
+
+import { isModeline } from './modelineUtil';
 import { setKubernetesParserOption } from '../parser/isKubernetes';
 import { asSchema } from '../parser/schemaValidation/baseValidator';
-import { indexOf, isInComment, isMapContainsEmptyPair } from '../utils/yamlAstUtils';
-import { isModeline } from './modelineUtil';
+import { matchOffsetToDocument } from '../utils/arrUtils';
+import { parseCustomTag } from '../utils/customTags';
+import { guessIndentation } from '../utils/indentationGuesser';
+import { stringifyObject } from '../utils/json';
+import { isDefined, isString } from '../utils/objects';
 import { getSchemaTypeName, isAnyOfAllOfOneOfType, isPrimitiveType } from '../utils/schemaUtils';
-import type { YamlNode } from '../jsonLanguageTypes';
-import type { SettingsState } from '../../yamlSettings';
+import { TextBuffer } from '../utils/textBuffer';
+import { indexOf, isInComment, isMapContainsEmptyPair } from '../utils/yamlAstUtils';
 import { toYamlStringScalar } from '../utils/yamlScalar';
-import * as l10n from '@vscode/l10n';
 
 const parentCompletionKind = CompletionItemKind.Class;
 

--- a/src/languageservice/services/yamlDefinition.ts
+++ b/src/languageservice/services/yamlDefinition.ts
@@ -6,9 +6,12 @@
 import type { DefinitionParams } from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { DefinitionLink } from 'vscode-languageserver-types';
+
+import type { Telemetry } from '../telemetry';
+
 import { LocationLink, Range } from 'vscode-languageserver-types';
 import { isAlias } from 'yaml';
-import type { Telemetry } from '../telemetry';
+
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { matchOffsetToDocument } from '../utils/arrUtils';
 import { TextBuffer } from '../utils/textBuffer';

--- a/src/languageservice/services/yamlFolding.ts
+++ b/src/languageservice/services/yamlFolding.ts
@@ -2,11 +2,14 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { FoldingRange, Range } from 'vscode-languageserver-types';
-import type { FoldingRangesContext } from '../yamlTypes';
-import type { ASTNode } from '../jsonLanguageTypes';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+
+import type { ASTNode } from '../jsonLanguageTypes';
+import type { FoldingRangesContext } from '../yamlTypes';
+
+import { FoldingRange, Range } from 'vscode-languageserver-types';
+
+import { yamlDocumentsCache } from '../parser/yaml-documents';
 
 export function getFoldingRanges(document: TextDocument, context: FoldingRangesContext): FoldingRange[] | undefined {
   if (!document) {

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -4,14 +4,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { FormattingOptions } from 'vscode-languageserver-types';
-import { Range, Position, TextEdit } from 'vscode-languageserver-types';
-import type { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
 import type { Options } from 'prettier';
-import * as yamlPlugin from 'prettier/plugins/yaml';
-import * as estreePlugin from 'prettier/plugins/estree';
-import { format } from 'prettier/standalone';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { FormattingOptions } from 'vscode-languageserver-types';
+
+import type { CustomFormatterOptions, LanguageSettings } from '../yamlLanguageService';
+
+import * as estreePlugin from 'prettier/plugins/estree';
+import * as yamlPlugin from 'prettier/plugins/yaml';
+import { format } from 'prettier/standalone';
+import { Position, Range, TextEdit } from 'vscode-languageserver-types';
 
 export class YAMLFormatter {
   private formatterEnabled = true;

--- a/src/languageservice/services/yamlHover.ts
+++ b/src/languageservice/services/yamlHover.ts
@@ -4,26 +4,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as l10n from '@vscode/l10n';
-import * as path from 'path';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Hover, MarkupContent, Position } from 'vscode-languageserver-types';
-import { MarkupKind, Range } from 'vscode-languageserver-types';
-import { URI } from 'vscode-uri';
 import type { Node } from 'yaml';
-import { isAlias, isMap, isSeq, stringify as stringifyYAML } from 'yaml';
+
 import type { ASTNode, ObjectASTNode, PropertyASTNode } from '../jsonLanguageTypes';
 import type { JSONSchema } from '../jsonSchema';
-import { setKubernetesParserOption } from '../parser/isKubernetes';
-import { getNodeValue } from '../utils/astNodeUtils';
 import type { IApplicableSchema } from '../parser/schemaValidation/baseValidator';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
 import type { SingleYAMLDocument } from '../parser/yamlParser07';
 import type { Telemetry } from '../telemetry';
-import { matchOffsetToDocument } from '../utils/arrUtils';
-import { toYamlStringScalar } from '../utils/yamlScalar';
 import type { LanguageSettings } from '../yamlLanguageService';
 import type { YAMLSchemaService } from './yamlSchemaService';
+
+import * as path from 'path';
+
+import * as l10n from '@vscode/l10n';
+import { MarkupKind, Range } from 'vscode-languageserver-types';
+import { URI } from 'vscode-uri';
+import { isAlias, isMap, isSeq, stringify as stringifyYAML } from 'yaml';
+
+import { setKubernetesParserOption } from '../parser/isKubernetes';
+import { yamlDocumentsCache } from '../parser/yaml-documents';
+import { matchOffsetToDocument } from '../utils/arrUtils';
+import { getNodeValue } from '../utils/astNodeUtils';
+import { toYamlStringScalar } from '../utils/yamlScalar';
 
 export class YAMLHover {
   private shouldHover: boolean;

--- a/src/languageservice/services/yamlLinks.ts
+++ b/src/languageservice/services/yamlLinks.ts
@@ -3,13 +3,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { DocumentLink } from 'vscode-languageserver-types';
-import { Range } from 'vscode-languageserver-types';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import type { Telemetry } from '../telemetry';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
+import type { DocumentLink } from 'vscode-languageserver-types';
+
 import type { ASTNode, PropertyASTNode } from '../jsonLanguageTypes';
 import type { JSONDocument } from '../parser/jsonDocument';
+import type { Telemetry } from '../telemetry';
+
+import { Range } from 'vscode-languageserver-types';
+
+import { yamlDocumentsCache } from '../parser/yaml-documents';
 
 export class YamlLinks {
   constructor(private readonly telemetry?: Telemetry) {}

--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -5,7 +5,9 @@
 
 import type { DocumentOnTypeFormattingParams } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+
 import { Position, Range, TextEdit } from 'vscode-languageserver-types';
+
 import { TextBuffer } from '../utils/textBuffer';
 
 export function doDocumentOnTypeFormatting(

--- a/src/languageservice/services/yamlRename.ts
+++ b/src/languageservice/services/yamlRename.ts
@@ -3,19 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { PrepareRenameParams, RenameParams } from 'vscode-languageserver-protocol';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Position, WorkspaceEdit } from 'vscode-languageserver-types';
+import type { Node } from 'yaml';
+
+import type { SingleYAMLDocument } from '../parser/yamlParser07';
+import type { Telemetry } from '../telemetry';
+
+import { ErrorCodes, ResponseError } from 'vscode-languageserver-protocol';
 import { Range, TextEdit } from 'vscode-languageserver-types';
+import { CST, isAlias, isCollection, isScalar, visit } from 'yaml';
+
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import { matchOffsetToDocument } from '../utils/arrUtils';
 import { TextBuffer } from '../utils/textBuffer';
-import type { Telemetry } from '../telemetry';
-import type { Node } from 'yaml';
-import { CST, isAlias, isCollection, isScalar, visit } from 'yaml';
-import type { SingleYAMLDocument } from '../parser/yamlParser07';
 import { isCollectionItem } from '../utils/yamlAstUtils';
-import type { PrepareRenameParams, RenameParams } from 'vscode-languageserver-protocol';
-import { ResponseError, ErrorCodes } from 'vscode-languageserver-protocol';
 
 interface RenameTarget {
   anchorNode: Node;

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -18,6 +18,7 @@ import type { SchemaRequestService, WorkspaceContextService } from '../yamlLangu
 import type { SchemaVersions } from '../yamlTypes';
 
 import * as path from 'path';
+
 import * as l10n from '@vscode/l10n';
 import Ajv from 'ajv';
 import Ajv2019 from 'ajv/dist/2019';

--- a/src/languageservice/services/yamlSelectionRanges.ts
+++ b/src/languageservice/services/yamlSelectionRanges.ts
@@ -1,8 +1,11 @@
-import type { Position, Range } from 'vscode-languageserver-types';
-import { SelectionRange } from 'vscode-languageserver-types';
-import { yamlDocumentsCache } from '../parser/yaml-documents';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { Position, Range } from 'vscode-languageserver-types';
+
 import type { ASTNode } from '../jsonLanguageTypes';
+
+import { SelectionRange } from 'vscode-languageserver-types';
+
+import { yamlDocumentsCache } from '../parser/yaml-documents';
 
 export function getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] {
   const doc = yamlDocumentsCache.getYamlDocument(document);

--- a/src/languageservice/services/yamlValidation.ts
+++ b/src/languageservice/services/yamlValidation.ts
@@ -4,25 +4,28 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Diagnostic, DiagnosticSeverity, Position, Range } from 'vscode-languageserver-types';
+import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { DiagnosticRelatedInformation } from 'vscode-languageserver-types';
+
+import type { ErrorCode } from '../jsonLanguageTypes';
+import type { SingleYAMLDocument, YamlVersion } from '../parser/yamlParser07';
+import type { Telemetry } from '../telemetry';
 import type { LanguageSettings } from '../yamlLanguageService';
-import type { YamlVersion, SingleYAMLDocument } from '../parser/yamlParser07';
+import type { AdditionalValidator } from './validation/types';
 import type { YAMLSchemaService } from './yamlSchemaService';
 import type { YAMLDocDiagnostic } from '../utils/parseUtils';
-import type { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { Diagnostic, DiagnosticSeverity, Position, Range } from 'vscode-languageserver-types';
+
+import { getSchemaFromModeline } from './modelineUtil';
 import { YAML_SOURCE } from '../parser/schemaValidation/baseValidator';
-import { TextBuffer } from '../utils/textBuffer';
-import { filterSuppressedDiagnostics } from '../utils/diagnostic-filter';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
-import type { Telemetry } from '../telemetry';
-import type { AdditionalValidator } from './validation/types';
+import { filterSuppressedDiagnostics } from '../utils/diagnostic-filter';
+import { TextBuffer } from '../utils/textBuffer';
+import { MapKeyOrderValidator } from './validation/map-key-order';
 import { UnusedAnchorsValidator } from './validation/unused-anchors';
 import { YAMLStyleValidator } from './validation/yaml-style';
-import { MapKeyOrderValidator } from './validation/map-key-order';
-import { getSchemaFromModeline } from './modelineUtil';
 import { isKubernetes as isKubernetesSchemaURI } from '../utils/schemaUrls';
-import type { ErrorCode } from '../jsonLanguageTypes';
 
 /**
  * Convert a YAMLDocDiagnostic to a language server Diagnostic

--- a/src/languageservice/utils/arrUtils.ts
+++ b/src/languageservice/utils/arrUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { YAMLDocument, SingleYAMLDocument } from '../parser/yamlParser07';
+import type { SingleYAMLDocument, YAMLDocument } from '../parser/yamlParser07';
 
 export function getLineOffsets(textDocString: string): number[] {
   const lineOffsets: number[] = [];

--- a/src/languageservice/utils/block-string-rewriter.ts
+++ b/src/languageservice/utils/block-string-rewriter.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { Scalar } from 'yaml';
+
 import { CST } from 'yaml';
 
 export class BlockStringRewriter {

--- a/src/languageservice/utils/flow-style-rewriter.ts
+++ b/src/languageservice/utils/flow-style-rewriter.ts
@@ -1,5 +1,6 @@
-import { CST, visit } from 'yaml';
 import type { ASTNode } from '../jsonLanguageTypes';
+
+import { CST, visit } from 'yaml';
 
 export class FlowStyleRewriter {
   constructor(private readonly indentation: string) {}

--- a/src/languageservice/utils/indentationGuesser.ts
+++ b/src/languageservice/utils/indentationGuesser.ts
@@ -5,8 +5,9 @@
 
 //copied from https://github.com/Microsoft/vscode/blob/015c3afe96966df50c15a7d66be2ab0ef1dc5f49/src/vs/editor/common/model/indentationGuesser.ts
 
-import { CharCode } from './charCode';
 import type { TextBuffer } from './textBuffer';
+
+import { CharCode } from './charCode';
 
 class SpacesDiffResult {
   public spacesDiff = 0;

--- a/src/languageservice/utils/parseUtils.ts
+++ b/src/languageservice/utils/parseUtils.ts
@@ -1,4 +1,5 @@
 import type { ErrorCode } from '../jsonLanguageTypes';
+
 export const DUPLICATE_KEY_REASON = 'duplicate key';
 
 /**

--- a/src/languageservice/utils/paths.ts
+++ b/src/languageservice/utils/paths.ts
@@ -1,5 +1,7 @@
 import type { WorkspaceFolder, WorkspaceFoldersChangeEvent } from 'vscode-languageserver-protocol';
+
 import { join, normalize, sep } from 'path';
+
 import { URI } from 'vscode-uri';
 
 export const isRelativePath = (path: string): boolean => {

--- a/src/languageservice/utils/schemaUrls.ts
+++ b/src/languageservice/utils/schemaUrls.ts
@@ -1,8 +1,12 @@
 import type { WorkspaceFolder } from 'vscode-languageserver-protocol';
-import { URI } from 'vscode-uri';
-import * as path from 'path';
-import type { Telemetry } from '../telemetry';
+
 import type { JSONSchema, JSONSchemaRef } from '../jsonSchema';
+import type { Telemetry } from '../telemetry';
+
+import * as path from 'path';
+
+import { URI } from 'vscode-uri';
+
 import { isBoolean } from './objects';
 import { isRelativePath, relativeToAbsolutePath } from './paths';
 

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -1,6 +1,8 @@
-import { URI } from 'vscode-uri';
 import type { JSONSchema } from '../jsonSchema';
+
 import * as path from 'path';
+
+import { URI } from 'vscode-uri';
 
 export function getSchemaTypeName(schema: JSONSchema): string {
   const closestTitleWithType = schema.type && schema.closestTitle;

--- a/src/languageservice/utils/textBuffer.ts
+++ b/src/languageservice/utils/textBuffer.ts
@@ -5,6 +5,7 @@
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Position } from 'vscode-languageserver-types';
+
 import { Range } from 'vscode-languageserver-types';
 
 interface FullTextDocument {

--- a/src/languageservice/utils/yamlAstUtils.ts
+++ b/src/languageservice/utils/yamlAstUtils.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { CST, Document, Node, YAMLMap, YAMLSeq } from 'yaml';
-import { isDocument, isScalar, visit } from 'yaml';
+
 import type { YamlNode } from '../jsonLanguageTypes';
+
+import { isDocument, isScalar, visit } from 'yaml';
 
 type Visitor = (item: CST.SourceToken, path: CST.VisitPath) => number | symbol | Visitor | void;
 

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -4,56 +4,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { CustomSchemaProvider, SchemaAdditions, SchemaDeletions, SchemaDeletionsAll } from './services/yamlSchemaService';
-import { YAMLSchemaService } from './services/yamlSchemaService';
-import type {
-  Position,
-  CodeAction,
-  CompletionList,
-  Diagnostic,
-  Hover,
-  SymbolInformation,
-  DocumentSymbol,
-  FoldingRange,
-  TextEdit,
-  DocumentLink,
-  CodeLens,
-  DefinitionLink,
-  SelectionRange,
-  Range,
-  WorkspaceEdit,
-} from 'vscode-languageserver-types';
-import type { JSONSchema } from './jsonSchema';
-import { YAMLDocumentSymbols } from './services/documentSymbols';
-import { YAMLHover } from './services/yamlHover';
-import { YAMLValidation } from './services/yamlValidation';
-import { YAMLFormatter } from './services/yamlFormatter';
-import type { DocumentSymbolsContext } from './jsonLanguageTypes';
-import { YamlLinks } from './services/yamlLinks';
 import type {
   ClientCapabilities,
   CodeActionParams,
   Connection,
-  DocumentOnTypeFormattingParams,
   DefinitionParams,
+  DocumentOnTypeFormattingParams,
   PrepareRenameParams,
   RenameParams,
 } from 'vscode-languageserver';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { getFoldingRanges } from './services/yamlFolding';
-import type { FoldingRangesContext, SchemaVersions } from './yamlTypes';
-import { YamlCodeActions } from './services/yamlCodeActions';
-import { doDocumentOnTypeFormatting } from './services/yamlOnTypeFormatting';
-import { YamlCodeLens } from './services/yamlCodeLens';
+import type {
+  CodeAction,
+  CodeLens,
+  CompletionList,
+  DefinitionLink,
+  Diagnostic,
+  DocumentLink,
+  DocumentSymbol,
+  FoldingRange,
+  Hover,
+  Position,
+  Range,
+  SelectionRange,
+  SymbolInformation,
+  TextEdit,
+  WorkspaceEdit,
+} from 'vscode-languageserver-types';
+
+import type { DocumentSymbolsContext } from './jsonLanguageTypes';
+import type { JSONSchema } from './jsonSchema';
 import type { Telemetry } from './telemetry';
-import type { YamlVersion } from './parser/yamlParser07';
-import { YamlCompletion } from './services/yamlCompletion';
-import { yamlDocumentsCache } from './parser/yaml-documents';
 import type { SettingsState } from '../yamlSettings';
-import { JSONSchemaSelection } from '../languageserver/handlers/schemaSelectionHandlers';
+import type { YamlVersion } from './parser/yamlParser07';
+import type { CustomSchemaProvider, SchemaAdditions, SchemaDeletions, SchemaDeletionsAll } from './services/yamlSchemaService';
+import type { FoldingRangesContext, SchemaVersions } from './yamlTypes';
+
+import { yamlDocumentsCache } from './parser/yaml-documents';
+import { YAMLDocumentSymbols } from './services/documentSymbols';
+import { YamlCodeActions } from './services/yamlCodeActions';
+import { YamlCodeLens } from './services/yamlCodeLens';
+import { YamlCompletion } from './services/yamlCompletion';
 import { YamlDefinition } from './services/yamlDefinition';
-import { getSelectionRanges } from './services/yamlSelectionRanges';
+import { getFoldingRanges } from './services/yamlFolding';
+import { YAMLFormatter } from './services/yamlFormatter';
+import { YAMLHover } from './services/yamlHover';
+import { YamlLinks } from './services/yamlLinks';
+import { doDocumentOnTypeFormatting } from './services/yamlOnTypeFormatting';
 import { YamlRename } from './services/yamlRename';
+import { YAMLSchemaService } from './services/yamlSchemaService';
+import { getSelectionRanges } from './services/yamlSelectionRanges';
+import { YAMLValidation } from './services/yamlValidation';
+import { JSONSchemaSelection } from '../languageserver/handlers/schemaSelectionHandlers';
 
 export enum SchemaPriority {
   SchemaStore = 1,

--- a/src/nodeTranslationSetup.ts
+++ b/src/nodeTranslationSetup.ts
@@ -2,11 +2,13 @@
  *  Copyright (c) IBM Corp. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as path from 'path';
-import { existsSync } from 'fs';
-import { URI } from 'vscode-uri';
-import * as l10n from '@vscode/l10n';
 import type { InitializeParams } from 'vscode-languageserver';
+
+import { existsSync } from 'fs';
+import * as path from 'path';
+
+import * as l10n from '@vscode/l10n';
+import { URI } from 'vscode-uri';
 
 /**
  * Loads translations from the filesystem based on the configured locale and the folder of translations provided in the initialization parameters.

--- a/src/requestTypes.ts
+++ b/src/requestTypes.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { NotificationType, RequestType } from 'vscode-languageserver';
 import type { SchemaAdditions, SchemaDeletions } from './languageservice/services/yamlSchemaService';
 import type { SchemaConfiguration } from './languageservice/yamlLanguageService';
 import type { SchemaVersions } from './languageservice/yamlTypes';
+
+import { NotificationType, RequestType } from 'vscode-languageserver';
 
 export type ISchemaAssociations = Record<string, string[]>;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { promises as fs } from 'fs';
 import type { Connection } from 'vscode-languageserver/node';
-import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
+
+import { promises as fs } from 'fs';
+
+import { ProposedFeatures, createConnection } from 'vscode-languageserver/node';
+
 import { TelemetryImpl } from './languageserver/telemetry';
 import { schemaRequestHandler, workspaceContext } from './languageservice/services/schemaRequestHandler';
 import { convertErrorToTelemetryMsg } from './languageservice/utils/objects';

--- a/src/webworker/yamlServerMain.ts
+++ b/src/webworker/yamlServerMain.ts
@@ -3,10 +3,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as l10n from '@vscode/l10n';
 import type { Connection } from 'vscode-languageserver';
+
+import * as l10n from '@vscode/l10n';
 import { RequestType } from 'vscode-languageserver';
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser';
+
 import { TelemetryImpl } from '../languageserver/telemetry';
 import { schemaRequestHandler, workspaceContext } from '../languageservice/services/schemaRequestHandler';
 import { YAMLServerInit } from '../yamlServerInit';

--- a/src/yamlServerInit.ts
+++ b/src/yamlServerInit.ts
@@ -1,6 +1,12 @@
 import type { Connection, InitializeParams, InitializeResult } from 'vscode-languageserver';
+
+import type { Telemetry } from './languageservice/telemetry';
+import type { LanguageService, SchemaRequestService, WorkspaceContextService } from './languageservice/yamlLanguageService';
+import type { SettingsState } from './yamlSettings';
+
 import { TextDocumentSyncKind } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+
 import { YamlCommands } from './commands';
 import { commandExecutor } from './languageserver/commandExecutor';
 import { LanguageHandlers } from './languageserver/handlers/languageHandlers';
@@ -10,11 +16,8 @@ import { SettingsHandler } from './languageserver/handlers/settingsHandlers';
 import { ValidationHandler } from './languageserver/handlers/validationHandlers';
 import { WorkspaceHandlers } from './languageserver/handlers/workspaceHandlers';
 import { registerCommands } from './languageservice/services/yamlCommands';
-import type { Telemetry } from './languageservice/telemetry';
 import { workspaceFoldersChanged } from './languageservice/utils/paths';
-import type { LanguageService, SchemaRequestService, WorkspaceContextService } from './languageservice/yamlLanguageService';
 import { getLanguageService as getCustomLanguageService } from './languageservice/yamlLanguageService';
-import type { SettingsState } from './yamlSettings';
 
 export class YAMLServerInit {
   languageService: LanguageService;

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -1,12 +1,15 @@
-import type { Disposable, ClientCapabilities, WorkspaceFolder } from 'vscode-languageserver';
-import { TextDocuments } from 'vscode-languageserver';
+import type { ClientCapabilities, Disposable, WorkspaceFolder } from 'vscode-languageserver';
+import type { URI } from 'vscode-uri';
+
+import type { JSONSchema } from './languageservice/jsonSchema';
+import type { YamlVersion } from './languageservice/parser/yamlParser07';
 import type { CustomFormatterOptions, SchemaConfiguration } from './languageservice/yamlLanguageService';
 import type { ISchemaAssociations } from './requestTypes';
-import type { URI } from 'vscode-uri';
-import type { JSONSchema } from './languageservice/jsonSchema';
+
+import { TextDocuments } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+
 import { CRD_CATALOG_URL, JSON_SCHEMASTORE_URL } from './languageservice/utils/schemaUrls';
-import type { YamlVersion } from './languageservice/parser/yamlParser07';
 
 // Client settings interface to grab settings relevant for the language server
 export interface Settings {

--- a/test/arrUtils.test.ts
+++ b/test/arrUtils.test.ts
@@ -2,8 +2,9 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { getLineOffsets, removeDuplicatesObj } from '../src/languageservice/utils/arrUtils';
 import assert from 'assert';
+
+import { getLineOffsets, removeDuplicatesObj } from '../src/languageservice/utils/arrUtils';
 
 describe('Array Utils Tests', () => {
   describe('Server - Array Utils', function () {

--- a/test/astUtils.test.ts
+++ b/test/astUtils.test.ts
@@ -3,13 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as chai from 'chai';
 import type { Pair, YAMLSeq } from 'yaml';
+
+import * as chai from 'chai';
 import { isPair, isSeq } from 'yaml';
-import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
-import { getParent, isInComment } from '../src/languageservice/utils/yamlAstUtils';
-import { TextBuffer } from '../src/languageservice/utils/textBuffer';
+
 import { setupTextDocument } from './utils/testHelper';
+import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
+import { TextBuffer } from '../src/languageservice/utils/textBuffer';
+import { getParent, isInComment } from '../src/languageservice/utils/yamlAstUtils';
+
 const expect = chai.expect;
 
 describe('AST Utils Tests', () => {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -3,19 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { CompletionList, MarkupContent } from 'vscode-languageserver-types';
+
+import type { LanguageService } from '../src';
 import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument, toFsPath } from './utils/testHelper';
+import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import type { SettingsState } from '../src/yamlSettings';
+
 import assert from 'assert';
 import * as path from 'path';
-import { createExpectedCompletion } from './utils/verifyError';
-import { ServiceSetup } from './utils/serviceSetup';
-import type { CompletionList, MarkupContent } from 'vscode-languageserver-types';
-import { CompletionItemKind, InsertTextFormat, MarkupKind, Position } from 'vscode-languageserver-types';
+
 import { expect } from 'chai';
-import type { SettingsState } from '../src/yamlSettings';
+import { CompletionItemKind, InsertTextFormat, MarkupKind, Position } from 'vscode-languageserver-types';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, caretPosition, setupLanguageService, setupSchemaIDTextDocument, toFsPath } from './utils/testHelper';
+import { createExpectedCompletion } from './utils/verifyError';
 import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { LanguageService } from '../src';
-import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 
 describe('Auto Completion Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/autoCompletionFix.test.ts
+++ b/test/autoCompletionFix.test.ts
@@ -4,18 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { CompletionList } from 'vscode-languageserver-types';
-import { CompletionItemKind, InsertTextFormat, Position, Range } from 'vscode-languageserver-types';
+
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import type { LanguageService } from '../src/languageservice/yamlLanguageService';
 import type { SettingsState } from '../src/yamlSettings';
+import type { JSONSchema } from './../src/languageservice/jsonSchema';
+import type { TestCustomSchemaProvider } from './utils/testHelper';
+
+import * as path from 'path';
+
+import { expect } from 'chai';
+import { CompletionItemKind, InsertTextFormat, Position, Range } from 'vscode-languageserver-types';
+
 import { TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { expect } from 'chai';
+import { SCHEMA_ID, caretPosition, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
 import { createExpectedCompletion } from './utils/verifyError';
-import * as path from 'path';
-import type { JSONSchema } from './../src/languageservice/jsonSchema';
 
 describe('Auto Completion Fix Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/bundlel10n.test.ts
+++ b/test/bundlel10n.test.ts
@@ -2,11 +2,14 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as l10n from '@vscode/l10n';
+import type { Connection } from 'vscode-languageserver/node';
+
 import assert from 'assert';
 import * as path from 'path';
-import type { Connection } from 'vscode-languageserver/node';
+
+import * as l10n from '@vscode/l10n';
 import { createConnection } from 'vscode-languageserver/node';
+
 import { schemaRequestHandler, workspaceContext } from '../src/languageservice/services/schemaRequestHandler';
 import { setupl10nBundle } from '../src/nodeTranslationSetup';
 import { YAMLServerInit } from '../src/yamlServerInit';

--- a/test/code-action-schema.test.ts
+++ b/test/code-action-schema.test.ts
@@ -2,17 +2,20 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument, TEST_URI } from './utils/testHelper';
-import { ServiceSetup } from './utils/serviceSetup';
 import type { CodeActionParams } from 'vscode-languageserver';
-import { TextDocumentIdentifier, CodeActionContext, TextEdit, Range } from 'vscode-languageserver';
-import { expect } from 'chai';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+
+import type { TestCustomSchemaProvider } from './utils/testHelper';
+import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { SettingsState } from '../src/yamlSettings';
+
+import { expect } from 'chai';
+import { CodeActionContext, Range, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, TEST_URI, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 describe('Schema Errors Code Action Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -2,13 +2,16 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import { ServiceSetup } from './utils/serviceSetup';
-import { createExpectedError } from './utils/verifyError';
-import assert from 'assert';
 import type { Diagnostic } from 'vscode-languageserver-types';
-import type { LanguageService } from '../src/languageservice/yamlLanguageService';
+
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { LanguageService } from '../src/languageservice/yamlLanguageService';
+
+import assert from 'assert';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { setupLanguageService, setupTextDocument } from './utils/testHelper';
+import { createExpectedError } from './utils/verifyError';
 
 // Defines a Mocha test describe to group tests of similar kind together
 describe('Custom Tag tests Tests', () => {

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -2,15 +2,19 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { toFsPath, setupSchemaIDTextDocument, setupLanguageService, caretPosition } from './utils/testHelper';
-import assert from 'assert';
-import * as path from 'path';
-import { ServiceSetup } from './utils/serviceSetup';
+import type { CompletionList, TextEdit } from 'vscode-languageserver-types';
+
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { CompletionList, TextEdit } from 'vscode-languageserver-types';
+
+import assert from 'assert';
+import * as path from 'path';
+
 import { expect } from 'chai';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { caretPosition, setupLanguageService, setupSchemaIDTextDocument, toFsPath } from './utils/testHelper';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 describe('Default Snippet Tests', () => {
   let languageHandler: LanguageHandlers;

--- a/test/diagnostic-filter.test.ts
+++ b/test/diagnostic-filter.test.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from 'chai';
 import type { GetLineText } from '../src/languageservice/utils/diagnostic-filter';
+
+import { expect } from 'chai';
+
 import {
-  filterSuppressedDiagnostics,
   YAML_DISABLE_PATTERN,
+  filterSuppressedDiagnostics,
   parseDisableSpecifiers,
   shouldSuppressDiagnostic,
 } from '../src/languageservice/utils/diagnostic-filter';

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -2,19 +2,23 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupLanguageService, setupTextDocument, TEST_URI } from './utils/testHelper';
+import type { DocumentSymbol, SymbolInformation } from 'vscode-languageserver-types';
+
+import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+
+import { SymbolKind } from 'vscode-languageserver-types';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { TEST_URI, setupLanguageService, setupTextDocument } from './utils/testHelper';
 import {
-  createExpectedSymbolInformation,
   createExpectedDocumentSymbol,
   createExpectedDocumentSymbolNoDetail,
+  createExpectedSymbolInformation,
 } from './utils/verifyError';
-import type { DocumentSymbol, SymbolInformation } from 'vscode-languageserver-types';
-import { SymbolKind } from 'vscode-languageserver-types';
-import assert from 'assert';
-import { ServiceSetup } from './utils/serviceSetup';
-import type { SettingsState } from '../src/yamlSettings';
 import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 
 describe('Document Symbols Tests', () => {
   let languageHandler: LanguageHandlers;

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -2,13 +2,16 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import assert from 'assert';
-import { ServiceSetup } from './utils/serviceSetup';
 import type { DocumentLink } from 'vscode-languageserver-types';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
+
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { setupLanguageService, setupTextDocument } from './utils/testHelper';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 describe('Find Links Tests', () => {
   let languageHandler: LanguageHandlers;

--- a/test/flow-style-rewriter.test.ts
+++ b/test/flow-style-rewriter.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
+
+import { setupTextDocument } from './utils/testHelper';
 import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
 import { FlowStyleRewriter } from '../src/languageservice/utils/flow-style-rewriter';
-import { setupTextDocument } from './utils/testHelper';
 
 describe('Flow style rewriter', () => {
   let writer: FlowStyleRewriter;

--- a/test/formatter.test.ts
+++ b/test/formatter.test.ts
@@ -2,12 +2,16 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import assert from 'assert';
-import * as sinon from 'sinon';
 import type { FormattingOptions, TextEdit } from 'vscode-languageserver-types';
+
 import type { CustomFormatterOptions } from '../src';
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+
+import * as sinon from 'sinon';
+
 import { TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
 import { setupLanguageService, setupTextDocument } from './utils/testHelper';

--- a/test/hover.test.ts
+++ b/test/hover.test.ts
@@ -2,17 +2,21 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { ServiceSetup } from './utils/serviceSetup';
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { caretPosition, SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import assert from 'assert';
 import type { Hover } from 'vscode-languageserver-types';
-import { MarkupContent, Position } from 'vscode-languageserver-types';
+
+import type { TestCustomSchemaProvider } from './utils/testHelper';
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
 import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
-import { expect } from 'chai';
 import type { TestTelemetry } from './utils/testsTypes';
+
+import assert from 'assert';
+
+import { expect } from 'chai';
+import { MarkupContent, Position } from 'vscode-languageserver-types';
+
+import { SCHEMA_ID, caretPosition, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { TextDocumentTestManager } from '../src/yamlSettings';
+import { ServiceSetup } from './utils/serviceSetup';
 
 describe('Hover Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,15 +2,19 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { setupLanguageService, setupTextDocument } from './utils/testHelper';
-import assert from 'assert';
-import type { Diagnostic, CompletionList, Hover } from 'vscode-languageserver-types';
-import { MarkupContent } from 'vscode-languageserver-types';
-import { ServiceSetup } from './utils/serviceSetup';
+import type { CompletionList, Diagnostic, Hover } from 'vscode-languageserver-types';
+
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+
+import { MarkupContent } from 'vscode-languageserver-types';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { TextDocumentTestManager } from '../src/yamlSettings';
+import { setupLanguageService, setupTextDocument } from './utils/testHelper';
 
 // Defines a Mocha test describe to group tests of similar kind together
 describe('Kubernetes Integration Tests', () => {

--- a/test/invalid-metaschema.test.ts
+++ b/test/invalid-metaschema.test.ts
@@ -2,9 +2,11 @@
  *  Copyright (c) IBM Corp. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import type { Connection, RemoteClient } from 'vscode-languageserver/node';
+
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import type { Connection, RemoteClient } from 'vscode-languageserver/node';
+
 import { JSONSchemaSelection } from '../src/languageserver/handlers/schemaSelectionHandlers';
 import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';

--- a/test/multipleDocuments.test.ts
+++ b/test/multipleDocuments.test.ts
@@ -2,17 +2,21 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as path from 'path';
-import { setupLanguageService, setupTextDocument, toFsPath } from './utils/testHelper';
-import assert from 'assert';
-import { ServiceSetup } from './utils/serviceSetup';
 import type { Diagnostic, Hover } from 'vscode-languageserver-types';
-import { MarkupContent } from 'vscode-languageserver-types';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { LanguageService } from '../src/languageservice/yamlLanguageService';
-import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+
 import type { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { LanguageService } from '../src/languageservice/yamlLanguageService';
+import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+import * as path from 'path';
+
+import { MarkupContent } from 'vscode-languageserver-types';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { setupLanguageService, setupTextDocument, toFsPath } from './utils/testHelper';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 /**
  * Setup the schema we are going to use with the language settings

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -2,8 +2,9 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { equals, convertErrorToTelemetryMsg } from '../src/languageservice/utils/objects';
 import assert from 'assert';
+
+import { convertErrorToTelemetryMsg, equals } from '../src/languageservice/utils/objects';
 
 describe('Object Equals Tests', () => {
   describe('Equals', function () {

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,9 +1,11 @@
-import assert from 'assert';
 import type { WorkspaceFolder } from 'vscode-languageserver-protocol';
+
+import assert from 'assert';
 import { join } from 'path';
 
-import { relativeToAbsolutePath, isRelativePath, workspaceFoldersChanged } from '../src/languageservice/utils/paths';
 import { URI } from 'vscode-uri';
+
+import { isRelativePath, relativeToAbsolutePath, workspaceFoldersChanged } from '../src/languageservice/utils/paths';
 
 class TestWorkspace {
   folders: WorkspaceFolder[];

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,27 +1,31 @@
-import assert from 'assert';
-import * as parser from '../src/languageservice/parser/yamlParser07';
-import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
-import type * as JsonSchema from '../src/languageservice/jsonSchema';
-import * as url from 'url';
-import * as path from 'path';
-import { xhr } from 'request-light';
-import type { SchemaDeletions } from '../src/languageservice/services/yamlSchemaService';
-import { MODIFICATION_ACTIONS } from '../src/languageservice/services/yamlSchemaService';
-import { EMPTY_SCHEMA_URL, DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
-import { expect } from 'chai';
-import { ServiceSetup } from './utils/serviceSetup';
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument, setupTextDocument, TEST_URI } from './utils/testHelper';
-import type { LanguageService } from '../src';
-import { SchemaPriority } from '../src';
-import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
 import type { Diagnostic, MarkupContent } from 'vscode-languageserver-types';
+
+import type { LanguageService } from '../src';
+import type { TestCustomSchemaProvider } from './utils/testHelper';
+import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type * as JsonSchema from '../src/languageservice/jsonSchema';
+import type { SchemaDeletions } from '../src/languageservice/services/yamlSchemaService';
+import type { SettingsState } from '../src/yamlSettings';
+
+import assert from 'assert';
+import * as path from 'path';
+import * as url from 'url';
+
+import { expect } from 'chai';
+import { xhr } from 'request-light';
 import { Position } from 'vscode-languageserver-types';
 import { LineCounter } from 'yaml';
-import { getSchemaFromModeline } from '../src/languageservice/services/modelineUtil';
+
+import { SchemaPriority } from '../src';
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, TEST_URI, setupLanguageService, setupSchemaIDTextDocument, setupTextDocument } from './utils/testHelper';
+import * as parser from '../src/languageservice/parser/yamlParser07';
 import { getGroupVersionKindFromDocument } from '../src/languageservice/services/k8sSchemaUtil';
+import { getSchemaFromModeline } from '../src/languageservice/services/modelineUtil';
+import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
+import { MODIFICATION_ACTIONS } from '../src/languageservice/services/yamlSchemaService';
+import { DEFAULT_KUBERNETES_SCHEMA_VERSION, EMPTY_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 const KUBERNETES_SCHEMA_URL = `https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${DEFAULT_KUBERNETES_SCHEMA_VERSION}-standalone-strict/all.json`;
 

--- a/test/schema2019Validation.test.ts
+++ b/test/schema2019Validation.test.ts
@@ -2,16 +2,19 @@
  *  Copyright (c) IBM Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { ServiceSetup } from './utils/serviceSetup';
 import type { Diagnostic } from 'vscode-languageserver-types';
-import { expect } from 'chai';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
+
+import type { TestCustomSchemaProvider } from './utils/testHelper';
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import { DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
 import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import type { SettingsState } from '../src/yamlSettings';
+
+import { expect } from 'chai';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 describe('Validation Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/schema2020Validation.test.ts
+++ b/test/schema2020Validation.test.ts
@@ -2,16 +2,19 @@
  *  Copyright (c) IBM Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { ServiceSetup } from './utils/serviceSetup';
 import type { Diagnostic } from 'vscode-languageserver-types';
-import { expect } from 'chai';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
+
+import type { TestCustomSchemaProvider } from './utils/testHelper';
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import { DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
 import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import type { SettingsState } from '../src/yamlSettings';
+
+import { expect } from 'chai';
+
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 describe('Validation Tests', () => {
   let languageSettingsSetup: ServiceSetup;

--- a/test/schemaRequestHandler.test.ts
+++ b/test/schemaRequestHandler.test.ts
@@ -3,18 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { schemaRequestHandler } from '../src/languageservice/services/schemaRequestHandler';
-import * as sinon from 'sinon';
-import * as request from 'request-light';
 import type { XHRResponse } from 'request-light';
 import type { Connection } from 'vscode-languageserver';
-import { URI } from 'vscode-uri';
+
 import * as chai from 'chai';
+import * as request from 'request-light';
+import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import { URI } from 'vscode-uri';
+
+import { testFileSystem } from './utils/testHelper';
+import { schemaRequestHandler } from '../src/languageservice/services/schemaRequestHandler';
 
 const expect = chai.expect;
 chai.use(sinonChai);
-import { testFileSystem } from './utils/testHelper';
 
 describe('Schema Request Handler Tests', () => {
   describe('schemaRequestHandler', () => {

--- a/test/schemaSelectionHandlers.test.ts
+++ b/test/schemaSelectionHandlers.test.ts
@@ -2,14 +2,16 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as sinon from 'sinon';
+import type { Connection, RemoteClient } from 'vscode-languageserver/node';
+
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+
 import { JSONSchemaSelection } from '../src/languageserver/handlers/schemaSelectionHandlers';
 import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaService';
-import type { Connection, RemoteClient } from 'vscode-languageserver/node';
-import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { SchemaSelectionRequests } from '../src/requestTypes';
+import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 import { SCHEMA_ID, setupSchemaIDTextDocument } from './utils/testHelper';
 
 const expect = chai.expect;

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -2,34 +2,38 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import type { Diagnostic } from 'vscode-languageserver-types';
+
 import type { TestCustomSchemaProvider } from './utils/testHelper';
-import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { createDiagnosticWithData, createExpectedError } from './utils/verifyError';
-import { ServiceSetup } from './utils/serviceSetup';
-import {
-  StringTypeError,
-  BooleanTypeError,
-  ArrayTypeError,
-  IncludeWithoutValueError,
-  BlockMappingEntryError,
-  DuplicateKeyError,
-  propertyIsNotAllowed,
-  MissingRequiredPropWarning,
-} from './utils/errorMessages';
+import type { TestTelemetry } from './utils/testsTypes';
+import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import type { IProblem } from '../src/languageservice/parser/schemaValidation/baseValidator';
+import type { LanguageService } from '../src/languageservice/yamlLanguageService';
+import type { SettingsState } from '../src/yamlSettings';
+
 import assert from 'assert';
 import * as path from 'path';
-import type { Diagnostic } from 'vscode-languageserver-types';
-import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
+
 import { expect } from 'chai';
-import type { SettingsState } from '../src/yamlSettings';
-import { TextDocumentTestManager } from '../src/yamlSettings';
-import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import type { LanguageService } from '../src/languageservice/yamlLanguageService';
-import type { IProblem } from '../src/languageservice/parser/schemaValidation/baseValidator';
-import type { JSONSchema } from '../src/languageservice/jsonSchema';
-import type { TestTelemetry } from './utils/testsTypes';
+import { DiagnosticSeverity, Position } from 'vscode-languageserver-types';
+
+import {
+  ArrayTypeError,
+  BlockMappingEntryError,
+  BooleanTypeError,
+  DuplicateKeyError,
+  IncludeWithoutValueError,
+  MissingRequiredPropWarning,
+  StringTypeError,
+  propertyIsNotAllowed,
+} from './utils/errorMessages';
+import { ServiceSetup } from './utils/serviceSetup';
+import { SCHEMA_ID, setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
+import { createDiagnosticWithData, createExpectedError } from './utils/verifyError';
 import { ErrorCode } from '../src/languageservice/jsonLanguageTypes';
 import { DEFAULT_KUBERNETES_SCHEMA_VERSION } from '../src/languageservice/utils/schemaUrls';
+import { TextDocumentTestManager } from '../src/yamlSettings';
 
 const KUBERNETES_SCHEMA_URL = `https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${DEFAULT_KUBERNETES_SCHEMA_VERSION}-standalone-strict/all.json`;
 

--- a/test/settingsHandlers.test.ts
+++ b/test/settingsHandlers.test.ts
@@ -3,19 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver';
+
+import type { LanguageService, LanguageSettings, SchemaConfiguration } from '../src';
+import type { Telemetry } from '../src/languageservice/telemetry';
+
 import * as chai from 'chai';
 import * as request from 'request-light';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import type { Connection, RemoteClient, RemoteWorkspace } from 'vscode-languageserver';
 import { CodeLensRefreshRequest } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
-import type { LanguageService, LanguageSettings, SchemaConfiguration } from '../src';
+
 import { SchemaPriority } from '../src';
 import { SettingsHandler } from '../src/languageserver/handlers/settingsHandlers';
 import { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
 import { EMPTY_SCHEMA_URL } from '../src/languageservice/utils/schemaUrls';
-import type { Telemetry } from '../src/languageservice/telemetry';
 import { SettingsState } from '../src/yamlSettings';
 import { TestCustomSchemaProvider, setupLanguageService, setupSchemaIDTextDocument, setupTextDocument } from './utils/testHelper';
 import { TestWorkspace } from './utils/testsTypes';

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -2,9 +2,11 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { startsWith, endsWith, convertSimple2RegExp, safeCreateUnicodeRegExp } from '../src/languageservice/utils/strings';
 import assert from 'assert';
+
 import { expect } from 'chai';
+
+import { convertSimple2RegExp, endsWith, safeCreateUnicodeRegExp, startsWith } from '../src/languageservice/utils/strings';
 
 describe('String Tests', () => {
   describe('startsWith', function () {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -2,13 +2,15 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import type { Connection } from 'vscode-languageserver';
+
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
-import { checkSchemaURI } from '../src/languageservice/utils/schemaUrls';
-import { TelemetryImpl } from '../src/languageserver/telemetry';
 import { URI } from 'vscode-uri';
-import type { Connection } from 'vscode-languageserver';
+
+import { TelemetryImpl } from '../src/languageserver/telemetry';
+import { checkSchemaURI } from '../src/languageservice/utils/schemaUrls';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/textBuffer.test.ts
+++ b/test/textBuffer.test.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TextBuffer } from '../src/languageservice/utils/textBuffer';
-import { TextDocument } from 'vscode-languageserver-textdocument';
 import assert from 'assert';
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { TextBuffer } from '../src/languageservice/utils/textBuffer';
 
 describe('TextBuffer', () => {
   it('getLineLength should return actual line length', () => {

--- a/test/utils/serviceSetup.ts
+++ b/test/utils/serviceSetup.ts
@@ -2,8 +2,8 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import type { LanguageSettings, SchemasSettings } from '../../src/languageservice/yamlLanguageService';
 import type { YamlVersion } from '../../src/languageservice/parser/yamlParser07';
+import type { LanguageSettings, SchemasSettings } from '../../src/languageservice/yamlLanguageService';
 
 export class ServiceSetup {
   /*

--- a/test/utils/testHelper.ts
+++ b/test/utils/testHelper.ts
@@ -2,22 +2,26 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { promises as fs } from 'fs';
-import { ClientCapabilities } from '../../src/languageservice/jsonLanguageTypes';
-import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Connection, ClientCapabilities as LSPClientCapabilities } from 'vscode-languageserver/node';
-import { createConnection } from 'vscode-languageserver/node';
+
 import type { LanguageService, LanguageSettings } from '../../src';
 import type { LanguageHandlers } from '../../src/languageserver/handlers/languageHandlers';
 import type { ValidationHandler } from '../../src/languageserver/handlers/validationHandlers';
 import type { JSONSchema } from '../../src/languageservice/jsonSchema';
-import { yamlDocumentsCache } from '../../src/languageservice/parser/yaml-documents';
 import type { FileSystem } from '../../src/languageservice/services/schemaRequestHandler';
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+import { createConnection } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+import { TestTelemetry } from './testsTypes';
+import { ClientCapabilities } from '../../src/languageservice/jsonLanguageTypes';
+import { yamlDocumentsCache } from '../../src/languageservice/parser/yaml-documents';
 import { schemaRequestHandler, workspaceContext } from '../../src/languageservice/services/schemaRequestHandler';
 import { YAMLServerInit } from '../../src/yamlServerInit';
 import { SettingsState } from '../../src/yamlSettings';
-import { TestTelemetry } from './testsTypes';
-import * as path from 'path';
 
 export function toFsPath(str: unknown): string {
   if (typeof str !== 'string') {

--- a/test/utils/testsTypes.ts
+++ b/test/utils/testsTypes.ts
@@ -4,22 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Disposable, Event, NotificationHandler, RequestHandler } from 'vscode-jsonrpc';
+import type { Connection, RemoteWorkspace } from 'vscode-languageserver';
 import type {
   ApplyWorkspaceEditParams,
-  WorkspaceEdit,
   ApplyWorkspaceEditResponse,
+  ClientCapabilities,
   ConfigurationItem,
+  CreateFilesParams,
+  DeleteFilesParams,
+  RenameFilesParams,
+  ServerCapabilities,
+  WorkspaceEdit,
   WorkspaceFolder,
   WorkspaceFoldersChangeEvent,
-  CreateFilesParams,
-  RenameFilesParams,
-  DeleteFilesParams,
-  ClientCapabilities,
-  ServerCapabilities,
 } from 'vscode-languageserver-protocol';
-import type { Connection, RemoteWorkspace } from 'vscode-languageserver';
-import { TelemetryImpl } from '../../src/languageserver/telemetry';
+
 import type { TelemetryEvent } from '../../src/languageservice/telemetry';
+
+import { TelemetryImpl } from '../../src/languageserver/telemetry';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/test/utils/verifyError.ts
+++ b/test/utils/verifyError.ts
@@ -7,10 +7,12 @@ import type {
   CompletionItem,
   CompletionItemKind,
   InsertTextFormat,
-  SymbolKind,
   SymbolInformation,
+  SymbolKind,
 } from 'vscode-languageserver-types';
+
 import { Diagnostic, DiagnosticSeverity, DiagnosticTag, DocumentSymbol, Range } from 'vscode-languageserver-types';
+
 import { ErrorCode } from '../../src/languageservice/jsonLanguageTypes';
 
 export function createExpectedError(

--- a/test/yaml-documents.test.ts
+++ b/test/yaml-documents.test.ts
@@ -3,15 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml';
+
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
-import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
-import { setupTextDocument } from './utils/testHelper';
-import * as yamlParser from '../src/languageservice/parser/yamlParser07';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import type { Pair, Scalar, YAMLMap, YAMLSeq } from 'yaml';
 import { isMap, isScalar, isSeq } from 'yaml';
+
+import { setupTextDocument } from './utils/testHelper';
+import { YamlDocuments } from '../src/languageservice/parser/yaml-documents';
+import * as yamlParser from '../src/languageservice/parser/yamlParser07';
 import { TextBuffer } from '../src/languageservice/utils/textBuffer';
 
 const expect = chai.expect;

--- a/test/yamlCodeActions.test.ts
+++ b/test/yamlCodeActions.test.ts
@@ -3,10 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { ClientCapabilities, CodeActionParams } from 'vscode-languageserver';
+
+import type { LanguageSettings } from '../src';
+
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
-import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
 import {
   CodeAction,
   CodeActionContext,
@@ -18,12 +21,12 @@ import {
   TextEdit,
   WorkspaceEdit,
 } from 'vscode-languageserver-types';
-import type { ClientCapabilities, CodeActionParams } from 'vscode-languageserver';
-import { setupTextDocument, TEST_URI } from './utils/testHelper';
+
+import { TEST_URI, setupTextDocument } from './utils/testHelper';
 import { createDiagnosticWithData, createExpectedError, createUnusedAnchorDiagnostic } from './utils/verifyError';
 import { YamlCommands } from '../src/commands';
-import type { LanguageSettings } from '../src';
 import { ErrorCode } from '../src/languageservice/jsonLanguageTypes';
+import { YamlCodeActions } from '../src/languageservice/services/yamlCodeActions';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -2,22 +2,25 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import type { Connection } from 'vscode-languageserver';
+import type { Command } from 'vscode-languageserver-protocol';
+
+import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
+import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import type { Telemetry } from '../src/languageservice/telemetry';
+import type { LanguageService } from '../src/languageservice/yamlLanguageService';
+
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
+import { CodeLens, Range } from 'vscode-languageserver-protocol';
+
+import { setupTextDocument } from './utils/testHelper';
+import { YamlCommands } from '../src/commands';
+import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
+import { TelemetryImpl } from '../src/languageserver/telemetry';
 import { YamlCodeLens } from '../src/languageservice/services/yamlCodeLens';
 import { YAMLSchemaService } from '../src/languageservice/services/yamlSchemaService';
-import { setupTextDocument } from './utils/testHelper';
-import type { JSONSchema } from '../src/languageservice/jsonSchema';
-import type { Command } from 'vscode-languageserver-protocol';
-import { CodeLens, Range } from 'vscode-languageserver-protocol';
-import type { Connection } from 'vscode-languageserver';
-import { YamlCommands } from '../src/commands';
-import { TelemetryImpl } from '../src/languageserver/telemetry';
-import type { Telemetry } from '../src/languageservice/telemetry';
-import { LanguageHandlers } from '../src/languageserver/handlers/languageHandlers';
-import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
-import type { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
 
 const expect = chai.expect;

--- a/test/yamlCommands.test.ts
+++ b/test/yamlCommands.test.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { Connection } from 'vscode-languageserver';
+
+import * as chai from 'chai';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
-import { registerCommands } from '../src/languageservice/services/yamlCommands';
-import { commandExecutor } from '../src/languageserver/commandExecutor';
-import type { Connection } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+
+import { commandExecutor } from '../src/languageserver/commandExecutor';
+import { registerCommands } from '../src/languageservice/services/yamlCommands';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/yamlDefinition.test.ts
+++ b/test/yamlDefinition.test.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { setupTextDocument, TEST_URI } from './utils/testHelper';
-import { expect } from 'chai';
-import { YamlDefinition } from '../src/languageservice/services/yamlDefinition';
-import { LocationLink, Position, Range } from 'vscode-languageserver-types';
 import type { Telemetry } from '../src/languageservice/telemetry';
+
+import { expect } from 'chai';
+import { LocationLink, Position, Range } from 'vscode-languageserver-types';
+
+import { TEST_URI, setupTextDocument } from './utils/testHelper';
+import { YamlDefinition } from '../src/languageservice/services/yamlDefinition';
 
 describe('YAML Definition', () => {
   it('should not provide definition for non anchor node', () => {

--- a/test/yamlFolding.test.ts
+++ b/test/yamlFolding.test.ts
@@ -3,11 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import type { FoldingRangesContext } from '../src/languageservice/yamlTypes';
+
 import { expect } from 'chai';
 import { FoldingRange } from 'vscode-languageserver-types';
+
+import { TEST_URI, setupTextDocument } from './utils/testHelper';
 import { getFoldingRanges } from '../src/languageservice/services/yamlFolding';
-import type { FoldingRangesContext } from '../src/languageservice/yamlTypes';
-import { setupTextDocument, TEST_URI } from './utils/testHelper';
 
 const context: FoldingRangesContext = { rangeLimit: 10_0000 };
 

--- a/test/yamlLanguageService.test.ts
+++ b/test/yamlLanguageService.test.ts
@@ -2,12 +2,15 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { assert } from 'chai';
 import type { Position, TextDocument } from 'vscode-languageserver-textdocument';
+
 import type { LanguageService, SchemaRequestService, WorkspaceContextService } from '../src';
+
+import { assert } from 'chai';
+
 import { getLanguageService } from '../src';
-import { workspaceContext } from '../src/languageservice/services/schemaRequestHandler';
 import { caretPosition, setupSchemaIDTextDocument } from './utils/testHelper';
+import { workspaceContext } from '../src/languageservice/services/schemaRequestHandler';
 
 /**
  * Builds a simple schema request service

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -2,11 +2,13 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { expect } from 'chai';
 import type { DocumentOnTypeFormattingParams } from 'vscode-languageserver-protocol';
+
+import { expect } from 'chai';
 import { FormattingOptions, Position, Range, TextEdit } from 'vscode-languageserver-types';
-import { doDocumentOnTypeFormatting } from '../src/languageservice/services/yamlOnTypeFormatting';
+
 import { setupTextDocument } from './utils/testHelper';
+import { doDocumentOnTypeFormatting } from '../src/languageservice/services/yamlOnTypeFormatting';
 
 function createParams(position: Position): DocumentOnTypeFormattingParams {
   return {

--- a/test/yamlParser.test.ts
+++ b/test/yamlParser.test.ts
@@ -2,12 +2,15 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import assert from 'assert';
-import { expect } from 'chai';
 import type { ArrayASTNode, ObjectASTNode, PropertyASTNode } from '../src/languageservice/jsonLanguageTypes';
 import type { YAMLDocument } from './../src/languageservice/parser/yamlParser07';
-import { parse } from './../src/languageservice/parser/yamlParser07';
+
+import assert from 'assert';
+
+import { expect } from 'chai';
+
 import { aliasDepth } from '../src/languageservice/parser/ast-converter';
+import { parse } from './../src/languageservice/parser/yamlParser07';
 
 describe('YAML parser', () => {
   describe('YAML parser', function () {

--- a/test/yamlRename.test.ts
+++ b/test/yamlRename.test.ts
@@ -1,8 +1,10 @@
-import { expect } from 'chai';
-import type { TextEdit } from 'vscode-languageserver-types';
-import { Position } from 'vscode-languageserver-types';
-import { setupLanguageService, setupTextDocument, TEST_URI } from './utils/testHelper';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { TextEdit } from 'vscode-languageserver-types';
+
+import { expect } from 'chai';
+import { Position } from 'vscode-languageserver-types';
+
+import { TEST_URI, setupLanguageService, setupTextDocument } from './utils/testHelper';
 
 function applyEdits(document: TextDocument, edits: TextEdit[]): string {
   const sorted = [...edits].sort((a, b) => document.offsetAt(b.range.start) - document.offsetAt(a.range.start));

--- a/test/yamlSchema.test.ts
+++ b/test/yamlSchema.test.ts
@@ -2,11 +2,13 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import * as url from 'url';
-import * as sinon from 'sinon';
+
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+
+import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 
 const expect = chai.expect;
 chai.use(sinonChai);

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -2,16 +2,19 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as sinon from 'sinon';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
+import type { JSONSchema } from '../src/languageservice/jsonSchema';
+
 import * as path from 'path';
 import * as url from 'url';
-import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
 import { parse } from '../src/languageservice/parser/yamlParser07';
-import { SettingsState } from '../src/yamlSettings';
+import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import { DEFAULT_KUBERNETES_SCHEMA_VERSION, getSchemaUrls } from '../src/languageservice/utils/schemaUrls';
-import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import { SettingsState } from '../src/yamlSettings';
 
 const BASE_KUBERNETES_SCHEMA_URL = `https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${DEFAULT_KUBERNETES_SCHEMA_VERSION}-standalone-strict/`;
 const KUBERNETES_SCHEMA_URL = BASE_KUBERNETES_SCHEMA_URL + 'all.json';

--- a/test/yamlSelectionRanges.test.ts
+++ b/test/yamlSelectionRanges.test.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
 import type { Position, Range, SelectionRange } from 'vscode-languageserver-types';
+
+import { expect } from 'chai';
+
 import { setupTextDocument } from './utils/testHelper';
 import { getSelectionRanges } from '../src/languageservice/services/yamlSelectionRanges';
 

--- a/test/yamlValidation.test.ts
+++ b/test/yamlValidation.test.ts
@@ -3,14 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import type { Diagnostic } from 'vscode-languageserver-types';
-import { DiagnosticSeverity } from 'vscode-languageserver-types';
+
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
 import type { SettingsState } from '../src/yamlSettings';
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
+
 import { TextDocumentTestManager } from '../src/yamlSettings';
 import { ServiceSetup } from './utils/serviceSetup';
 import { setupLanguageService, setupSchemaIDTextDocument } from './utils/testHelper';
-import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { createExpectedError, createUnusedAnchorDiagnostic } from './utils/verifyError';
 
 type ValidationHandlerWithConnection = {


### PR DESCRIPTION
### What does this PR do?

This change enforces some ESLint rules to ensure consistent import sorting. In my experience this helps identifying how imports, files, and dependencies are used.

The `import-x/first` rule ensures all imports are on top of the file.

The `import-x/order` rule forces a consistent order of import statements. Imports are grouped by Node.js builtins, external dependencies, and relative imports. Type imports are sorted before values. Within each group, the statements are alphabetized.

The `sort-imports` rule sorts the imported members.

The `import/newline-after-import` rule enforces a newline after the last import.

### What issues does this PR fix or reference?

This is built on top of #1282

### Is it tested? How?

```sh
eslint
tsc
```
