### PR TITLE
Rewrite Mocha tests to use promises

### DIFF
--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -81,7 +81,7 @@ describe('Auto Completion Tests', () => {
 
   describe('YAML Completion Tests', function () {
     describe('JSON Schema Tests', function () {
-      it('Autocomplete on root without word', (done) => {
+      it('Autocomplete on root without word', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -91,21 +91,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = '';
-        const completion = parseSetup(content, 0);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', 'name: ', 0, 0, 0, 0, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 0);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', 'name: ', 0, 0, 0, 0, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on root with partial word', (done) => {
+      it('Autocomplete on root with partial word', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -115,21 +111,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'na'; // len: 2
-        const completion = parseSetup(content, 2);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', 'name: ', 0, 0, 0, 2, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 2);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', 'name: ', 0, 0, 0, 2, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on default value (without :)', (done) => {
+      it('Autocomplete on default value (without :)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -140,21 +132,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'name'; // len: 4
-        const completion = parseSetup(content, 10);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', 'name: ${1:yaml}', 0, 0, 0, 4, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 10);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', 'name: ${1:yaml}', 0, 0, 0, 4, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on default value (without value content)', (done) => {
+      it('Autocomplete on default value (without value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -165,18 +153,14 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'name: '; // len: 6
-        const completion = parseSetup(content, 12);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('yaml', 'yaml', 0, 6, 0, 6, 12, 2, {
-                detail: 'Default value',
-              })
-            );
+        const result = await parseSetup(content, 12);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('yaml', 'yaml', 0, 6, 0, 6, 12, 2, {
+            detail: 'Default value',
           })
-          .then(done, done);
+        );
       });
 
       it('Autocomplete on default value with \\"', async () => {
@@ -221,7 +205,7 @@ describe('Auto Completion Tests', () => {
         );
       });
 
-      it('Autocomplete on default value (with value content)', (done) => {
+      it('Autocomplete on default value (with value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -232,21 +216,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'name: ya'; // len: 8
-        const completion = parseSetup(content, 15);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('yaml', 'yaml', 0, 6, 0, 8, 12, 2, {
-                detail: 'Default value',
-              })
-            );
+        const result = await parseSetup(content, 15);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('yaml', 'yaml', 0, 6, 0, 8, 12, 2, {
+            detail: 'Default value',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on default value (with value content contains dash)', (done) => {
+      it('Autocomplete on default value (with value content contains dash)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -257,21 +237,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'name: yaml-';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('yaml-language', 'yaml-language', 0, 6, 0, 11, 12, 2, {
-                detail: 'Default value',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('yaml-language', 'yaml-language', 0, 6, 0, 11, 12, 2, {
+            detail: 'Default value',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on boolean value (without value content)', (done) => {
+      it('Autocomplete on boolean value (without value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -281,27 +257,23 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'yaml: '; // len: 6
-        const completion = parseSetup(content, 11);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('true', 'true', 0, 6, 0, 6, 12, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('false', 'false', 0, 6, 0, 6, 12, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 11);
+        assert.equal(result.items.length, 2);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('true', 'true', 0, 6, 0, 6, 12, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('false', 'false', 0, 6, 0, 6, 12, 2, {
+            documentation: '',
+          })
+        );
       });
 
-      it('Autocomplete on boolean value with key of `null`', () => {
+      it('Autocomplete on boolean value with key of `null`', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -318,14 +290,12 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = ''; // len: 0
-        const completion = parseSetup(content, 0);
-        completion.then(function (result) {
-          expect(result.items.length).equal(1);
-          expect(result.items[0].insertText).equal('validation:\n  \\"null\\": ${1:false}');
-        });
+        const result = await parseSetup(content, 0);
+        expect(result.items.length).equal(1);
+        expect(result.items[0].insertText).equal('validation:\n  "null": ${1:false}');
       });
 
-      it('Autocomplete on boolean value (with value content)', (done) => {
+      it('Autocomplete on boolean value (with value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -335,27 +305,23 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'yaml: fal'; // len: 9
-        const completion = parseSetup(content, 11);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('true', 'true', 0, 6, 0, 9, 12, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('false', 'false', 0, 6, 0, 9, 12, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 11);
+        assert.equal(result.items.length, 2);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('true', 'true', 0, 6, 0, 9, 12, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('false', 'false', 0, 6, 0, 9, 12, 2, {
+            documentation: '',
+          })
+        );
       });
 
-      it('Autocomplete on number value (without value content)', (done) => {
+      it('Autocomplete on number value (without value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -366,21 +332,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'timeout: '; // len: 9
-        const completion = parseSetup(content, 9);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('60000', '60000', 0, 9, 0, 9, 12, 2, {
-                detail: 'Default value',
-              })
-            );
+        const result = await parseSetup(content, 9);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('60000', '60000', 0, 9, 0, 9, 12, 2, {
+            detail: 'Default value',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on number value (with value content)', (done) => {
+      it('Autocomplete on number value (with value content)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -391,21 +353,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'timeout: 6'; // len: 10
-        const completion = parseSetup(content, 10);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('60000', '60000', 0, 9, 0, 10, 12, 2, {
-                detail: 'Default value',
-              })
-            );
+        const result = await parseSetup(content, 10);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('60000', '60000', 0, 9, 0, 10, 12, 2, {
+            detail: 'Default value',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete key in middle of file', (done) => {
+      it('Autocomplete key in middle of file', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -421,21 +379,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts:\n  |s|ample'; // len: 17, pos: 11
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('sample', 'sample: ${1:test}', 1, 2, 1, 8, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('sample', 'sample: ${1:test}', 1, 2, 1, 8, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete key with default value in middle of file', (done) => {
+      it('Autocomplete key with default value in middle of file', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -451,18 +405,14 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts:\n  |s|am'; // len: 14, pos: 11
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('sample', 'sample: ${1:test}', 1, 2, 1, 5, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('sample', 'sample: ${1:test}', 1, 2, 1, 5, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
       it('Autocomplete without default value - not required', async () => {
@@ -527,7 +477,7 @@ describe('Auto Completion Tests', () => {
         );
       });
 
-      it('Autocomplete second key in middle of file', (done) => {
+      it('Autocomplete second key in middle of file', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -547,21 +497,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts:\n  sample: test\n  myOth|e|r'; // len: 33, pos: 31
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('myOtherSample', 'myOtherSample: ${1:test}', 2, 2, 2, 9, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('myOtherSample', 'myOtherSample: ${1:test}', 2, 2, 2, 9, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete does not happen right after key object', (done) => {
+      it('Autocomplete does not happen right after key object', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -572,15 +518,11 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'timeout:'; // len: 8
-        const completion = parseSetup(content, 9);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 9);
+        assert.equal(result.items.length, 0);
       });
 
-      it('Autocomplete does not happen right after : under an object', (done) => {
+      it('Autocomplete does not happen right after : under an object', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -600,15 +542,11 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts:\n  sample:'; // len: 18
-        const completion = parseSetup(content, 21);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 21);
+        assert.equal(result.items.length, 0);
       });
 
-      it('Autocomplete with defaultSnippet markdown', (done) => {
+      it('Autocomplete with defaultSnippet markdown', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -626,17 +564,13 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts: ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.equal(result.items[0].insertText, '\n  myOtherSample:');
-            assert.equal((result.items[0].documentation as MarkupContent).value, 'snippet\n```yaml\nmyOtherSample:\n```\n');
-          })
-          .then(done, done);
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 1);
+        assert.equal(result.items[0].insertText, '\n  myOtherSample:');
+        assert.equal((result.items[0].documentation as MarkupContent).value, 'snippet\n```yaml\nmyOtherSample:\n```\n');
       });
 
-      it('Autocomplete on multi yaml documents in a single file on root', (done) => {
+      it('Autocomplete on multi yaml documents in a single file on root', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -647,21 +581,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = '---\ntimeout: 10\n...\n---\n...'; // len: 27
-        const completion = parseSetup(content, 28);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('timeout', 'timeout: ${1:60000}', 4, 0, 4, 3, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 28);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('timeout', 'timeout: ${1:60000}', 4, 0, 4, 3, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocomplete on multi yaml documents in a single file on scalar', (done) => {
+      it('Autocomplete on multi yaml documents in a single file on scalar', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -672,21 +602,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = '---\ntimeout: 10\n...\n---\nti|m|e \n...'; // len: 33, pos: 26
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('timeout', 'timeout: ${1:60000}', 4, 0, 4, 4, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('timeout', 'timeout: ${1:60000}', 4, 0, 4, 4, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocompletion has no results on value when they are not available', (done) => {
+      it('Autocompletion has no results on value when they are not available', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -696,15 +622,11 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'time: '; // len: 6
-        const completion = parseSetup(content, 6);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 6);
+        assert.equal(result.items.length, 0);
       });
 
-      it('Test that properties that have multiple types get auto completed properly', (done) => {
+      it('Test that properties that have multiple types get auto completed properly', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -715,18 +637,14 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'scripts: '; // len: 9
-        const completion = parseSetup(content, 9);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 3);
-            assert.equal(result.items[0].label, 'test');
-            assert.equal(result.items[1].label, 'false');
-            assert.equal(result.items[2].label, 'true');
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 9);
+        assert.equal(result.items.length, 3);
+        assert.equal(result.items[0].label, 'test');
+        assert.equal(result.items[1].label, 'false');
+        assert.equal(result.items[2].label, 'true');
       });
 
-      it('Test that properties that have multiple enums get auto completed properly', (done) => {
+      it('Test that properties that have multiple enums get auto completed properly', async () => {
         const schema = {
           definitions: {
             ImageBuild: {
@@ -759,168 +677,140 @@ describe('Auto Completion Tests', () => {
         };
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = 'kind: '; // len: 6
-        const validator = parseSetup(content, 6);
-        validator
-          .then(function (result) {
-            assert.equal(result.items.length, 4);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('ImageBuild', 'ImageBuild', 0, 6, 0, 6, 12, 2, {
-                documentation: undefined,
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('ImageBuilder', 'ImageBuilder', 0, 6, 0, 6, 12, 2, {
-                documentation: undefined,
-              })
-            );
-            assert.deepEqual(
-              result.items[2],
-              createExpectedCompletion('ImageStream', 'ImageStream', 0, 6, 0, 6, 12, 2, {
-                documentation: undefined,
-              })
-            );
-            assert.deepEqual(
-              result.items[3],
-              createExpectedCompletion('ImageStreamBuilder', 'ImageStreamBuilder', 0, 6, 0, 6, 12, 2, {
-                documentation: undefined,
-              })
-            );
+        const result = await parseSetup(content, 6);
+        assert.equal(result.items.length, 4);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('ImageBuild', 'ImageBuild', 0, 6, 0, 6, 12, 2, {
+            documentation: undefined,
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('ImageBuilder', 'ImageBuilder', 0, 6, 0, 6, 12, 2, {
+            documentation: undefined,
+          })
+        );
+        assert.deepEqual(
+          result.items[2],
+          createExpectedCompletion('ImageStream', 'ImageStream', 0, 6, 0, 6, 12, 2, {
+            documentation: undefined,
+          })
+        );
+        assert.deepEqual(
+          result.items[3],
+          createExpectedCompletion('ImageStreamBuilder', 'ImageStreamBuilder', 0, 6, 0, 6, 12, 2, {
+            documentation: undefined,
+          })
+        );
       });
 
-      it('Insert required attributes at correct level', (done) => {
+      it('Insert required attributes at correct level', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testRequiredProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- top:\n    prop1: demo\n- ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('top', 'top:\n      prop1: ', 2, 2, 2, 2, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('top', 'top:\n      prop1: ', 2, 2, 2, 2, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Insert required attributes at correct level even on first element', (done) => {
+      it('Insert required attributes at correct level even on first element', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testRequiredProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('top', 'top:\n    prop1: ', 0, 2, 0, 2, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('top', 'top:\n    prop1: ', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Provide the 3 types when none provided', (done) => {
+      it('Provide the 3 types when none provided', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 3);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('prop1', 'prop1: ', 0, 2, 0, 2, 10, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('prop2', 'prop2: ', 0, 2, 0, 2, 10, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[2],
-              createExpectedCompletion('prop3', 'prop3: ', 0, 2, 0, 2, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 3);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('prop1', 'prop1: ', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('prop2', 'prop2: ', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
+          })
+        );
+        assert.deepEqual(
+          result.items[2],
+          createExpectedCompletion('prop3', 'prop3: ', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
+          })
+        );
       });
 
-      it('Provide the 2 types when one is provided', (done) => {
+      it('Provide the 2 types when one is provided', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- prop1:\n  ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('prop2', 'prop2: ', 1, 2, 1, 2, 10, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('prop3', 'prop3: ', 1, 2, 1, 2, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 2);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('prop2', 'prop2: ', 1, 2, 1, 2, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('prop3', 'prop3: ', 1, 2, 1, 2, 10, 2, {
+            documentation: '',
+          })
+        );
       });
 
-      it('Provide the 2 types when one is provided and the second is typed', (done) => {
+      it('Provide the 2 types when one is provided and the second is typed', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- prop1:\n  p';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('prop2', 'prop2: ', 1, 2, 1, 3, 10, 2, {
-                documentation: '',
-              })
-            );
-            assert.deepEqual(
-              result.items[1],
-              createExpectedCompletion('prop3', 'prop3: ', 1, 2, 1, 3, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 2);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('prop2', 'prop2: ', 1, 2, 1, 3, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('prop3', 'prop3: ', 1, 2, 1, 3, 10, 2, {
+            documentation: '',
+          })
+        );
       });
 
-      it('Provide no completion when maxProperties reached', (done) => {
+      it('Provide no completion when maxProperties reached', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = '- prop1:\n  prop2:\n  ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 0);
       });
 
       it('Autocompletion should escape @', async () => {
@@ -1052,20 +942,16 @@ describe('Auto Completion Tests', () => {
     });
 
     describe('Array Specific Tests', function () {
-      it('Should insert empty array item', (done) => {
+      it('Should insert empty array item', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testStringArray.json'));
         schemaProvider.addSchema(SCHEMA_ID, schema);
         const content = 'fooBa'; // len: 5
-        const completion = parseSetup(content, content.lastIndexOf('Ba') + 2); // pos: 3+2
-        completion
-          .then(function (result) {
-            assert.strictEqual('fooBar:\n  - ${1}', result.items[0].insertText);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, content.lastIndexOf('Ba') + 2); // pos: 3+2
+        assert.strictEqual('fooBar:\n  - ${1}', result.items[0].insertText);
       });
 
-      it('Array autocomplete without word and extra space', (done) => {
+      it('Array autocomplete without word and extra space', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1083,21 +969,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - '; // len: 13
-        const completion = parseSetup(content, 14);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', 'name: ', 1, 4, 1, 4, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 14);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', 'name: ', 1, 4, 1, 4, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete without word and autocompletion beside -', (done) => {
+      it('Array autocomplete without word and autocompletion beside -', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1115,21 +997,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  -'; // len: 12
-        const completion = parseSetup(content, 13);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', ' name: ', 1, 3, 1, 3, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 13);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', ' name: ', 1, 3, 1, 3, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete without word on space before array symbol', (done) => {
+      it('Array autocomplete without word on space before array symbol', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1150,21 +1028,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - name: test\n  '; // len: 26
-        const completion = parseSetup(content, 26);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('- (array item) object', '- ', 2, 2, 2, 2, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
-              })
-            );
+        const result = await parseSetup(content, 26);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('- (array item) object', '- ', 2, 2, 2, 2, 9, 2, {
+            documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete on empty node with array from schema', (done) => {
+      it('Array autocomplete on empty node with array from schema', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1185,21 +1059,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n'; // len: 9
-        const completion = parseSetup(content, 9);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('- (array item) object', '- ', 1, 0, 1, 0, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
-              })
-            );
+        const result = await parseSetup(content, 9);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('- (array item) object', '- ', 1, 0, 1, 0, 9, 2, {
+            documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- \n```' },
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete with letter', (done) => {
+      it('Array autocomplete with letter', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1217,21 +1087,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - n'; // len: 14
-        const completion = parseSetup(content, 14);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('name', 'name: ', 1, 4, 1, 5, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 14);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('name', 'name: ', 1, 4, 1, 5, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete without word (second item)', (done) => {
+      it('Array autocomplete without word (second item)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1252,21 +1118,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - name: test\n    '; // len: 28
-        const completion = parseSetup(content, 32);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('email', 'email: ', 2, 4, 2, 4, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 32);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('email', 'email: ', 2, 4, 2, 4, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Array autocomplete with letter (second item)', (done) => {
+      it('Array autocomplete with letter (second item)', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1287,21 +1149,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - name: test\n   | |e'; // len: 29, pos: 27
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('email', 'email: ', 2, 3, 2, 3, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('email', 'email: ', 2, 3, 2, 3, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocompletion after array', (done) => {
+      it('Autocompletion after array', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1325,21 +1183,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'authors:\n  - name: test\n'; // len: 24
-        const completion = parseSetup(content, 24);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('load', 'load: ', 2, 0, 2, 0, 10, 2, {
-                documentation: '',
-              })
-            );
+        const result = await parseSetup(content, 24);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('load', 'load: ', 2, 0, 2, 0, 10, 2, {
+            documentation: '',
           })
-          .then(done, done);
+        );
       });
 
-      it('Autocompletion after array with depth - no indent', (done) => {
+      it('Autocompletion after array with depth - no indent', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1367,19 +1221,15 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'archive:\n  exclude:\n    - name: test\n|\n|'; // len: 38, pos: 37
-        const completion = parseSetup(content); //don't test on the last row
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            const expectedCompletion = createExpectedCompletion('include', 'include: ${1:test}', 3, 0, 3, 0, 10, 2, {
-              documentation: '',
-            });
-            assert.deepEqual(result.items[0], expectedCompletion);
-          })
-          .then(done, done);
+        const result = await parseSetup(content); //don't test on the last row
+        assert.equal(result.items.length, 1);
+        const expectedCompletion = createExpectedCompletion('include', 'include: ${1:test}', 3, 0, 3, 0, 10, 2, {
+          documentation: '',
+        });
+        assert.deepEqual(result.items[0], expectedCompletion);
       });
 
-      it('Autocompletion after array with depth - indent', (done) => {
+      it('Autocompletion after array with depth - indent', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1406,21 +1256,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'archive:\n  exclude:\n    - nam\n    | |'; // len: 35, pos: 34
-        const completion = parseSetup(content);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('- (array item) object', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
-                documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- name: test\n```' },
-              })
-            );
+        const result = await parseSetup(content);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('- (array item) object', '- name: ${1:test}', 3, 4, 3, 5, 9, 2, {
+            documentation: { kind: 'markdown', value: 'Create an item of an array type `object`\n ```\n- name: test\n```' },
           })
-          .then(done, done);
+        );
       });
 
-      it('Array of enum autocomplete without word on array symbol', (done) => {
+      it('Array of enum autocomplete without word on array symbol', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1433,21 +1279,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'references:\n  -'; // len: 15
-        const completion = parseSetup(content, 29);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('Test', ' Test', 1, 3, 1, 3, 12, 2, {
-                documentation: undefined,
-              })
-            );
+        const result = await parseSetup(content, 29);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('Test', ' Test', 1, 3, 1, 3, 12, 2, {
+            documentation: undefined,
           })
-          .then(done, done);
+        );
       });
 
-      it('Array of enum autocomplete without word', (done) => {
+      it('Array of enum autocomplete without word', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1460,21 +1302,17 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'references:\n  - '; // len: 16
-        const completion = parseSetup(content, 30);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('Test', 'Test', 1, 4, 1, 4, 12, 2, {
-                documentation: undefined,
-              })
-            );
+        const result = await parseSetup(content, 30);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('Test', 'Test', 1, 4, 1, 4, 12, 2, {
+            documentation: undefined,
           })
-          .then(done, done);
+        );
       });
 
-      it('Array of enum autocomplete with letter', (done) => {
+      it('Array of enum autocomplete with letter', async () => {
         schemaProvider.addSchema(SCHEMA_ID, {
           type: 'object',
           properties: {
@@ -1487,18 +1325,14 @@ describe('Auto Completion Tests', () => {
           },
         });
         const content = 'references:\n  - T'; // len: 17
-        const completion = parseSetup(content, 31);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 1);
-            assert.deepEqual(
-              result.items[0],
-              createExpectedCompletion('Test', 'Test', 1, 4, 1, 5, 12, 2, {
-                documentation: undefined,
-              })
-            );
+        const result = await parseSetup(content, 31);
+        assert.equal(result.items.length, 1);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('Test', 'Test', 1, 4, 1, 5, 12, 2, {
+            documentation: undefined,
           })
-          .then(done, done);
+        );
       });
 
       it('Array of objects autocomplete with 4 space indentation check', async () => {
@@ -1863,7 +1697,7 @@ describe('Auto Completion Tests', () => {
   });
 
   describe('JSON Schema 7 Specific Tests', function () {
-    it('Autocomplete works with examples', (done) => {
+    it('Autocomplete works with examples', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1875,23 +1709,19 @@ describe('Auto Completion Tests', () => {
         },
       });
       const content = 'foodItems: '; // len: 11
-      const completion = parseSetup(content, 12);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 3);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('Carrot', 'Carrot', 0, 11, 0, 11, 12, 2, {
-              detail: 'Default value',
-            })
-          );
-          assert.deepEqual(result.items[1], createExpectedCompletion('Apple', 'Apple', 0, 11, 0, 11, 12, 2, {}));
-          assert.deepEqual(result.items[2], createExpectedCompletion('Banana', 'Banana', 0, 11, 0, 11, 12, 2, {}));
+      const result = await parseSetup(content, 12);
+      assert.equal(result.items.length, 3);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('Carrot', 'Carrot', 0, 11, 0, 11, 12, 2, {
+          detail: 'Default value',
         })
-        .then(done, done);
+      );
+      assert.deepEqual(result.items[1], createExpectedCompletion('Apple', 'Apple', 0, 11, 0, 11, 12, 2, {}));
+      assert.deepEqual(result.items[2], createExpectedCompletion('Banana', 'Banana', 0, 11, 0, 11, 12, 2, {}));
     });
 
-    it('Autocomplete works with const', (done) => {
+    it('Autocomplete works with const', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1901,20 +1731,16 @@ describe('Auto Completion Tests', () => {
         },
       });
       const content = 'fruit: Ap|p|'; // len: 10, pos: 9
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('Apple', 'Apple', 0, 7, 0, 10, 12, 2, {
-              documentation: undefined,
-            })
-          );
+      const result = await parseSetup(content);
+      assert.equal(result.items.length, 1);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('Apple', 'Apple', 0, 7, 0, 10, 12, 2, {
+          documentation: undefined,
         })
-        .then(done, done);
+      );
     });
-    it('Autocomplete should suggest prop with const value', (done) => {
+    it('Autocomplete should suggest prop with const value', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1924,18 +1750,14 @@ describe('Auto Completion Tests', () => {
         },
       });
       const content = '';
-      const completion = parseSetup(content, 0);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('fruit', 'fruit: Apple', 0, 0, 0, 0, 10, 2, {
-              documentation: '',
-            })
-          );
+      const result = await parseSetup(content, 0);
+      assert.equal(result.items.length, 1);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('fruit', 'fruit: Apple', 0, 0, 0, 0, 10, 2, {
+          documentation: '',
         })
-        .then(done, done);
+      );
     });
     it('Should insert quotation value if there is special char', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
@@ -1960,95 +1782,71 @@ describe('Auto Completion Tests', () => {
   });
 
   describe('Indentation Specific Tests', function () {
-    it('Indent should be considered with position relative to slash', (done) => {
+    it('Indent should be considered with position relative to slash', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'install:\n  - he'; // len: 15
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 13+2
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('helm', 'helm:\n    name: ', 1, 4, 1, 6, 10, 2, {
-              documentation: '',
-            })
-          );
+      const result = await parseSetup(content, content.lastIndexOf('he') + 2); // pos: 13+2
+      assert.equal(result.items.length, 2);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('helm', 'helm:\n    name: ', 1, 4, 1, 6, 10, 2, {
+          documentation: '',
         })
-        .then(done, done);
+      );
     });
 
-    it('Large indent should be considered with position relative to slash', (done) => {
+    it('Large indent should be considered with position relative to slash', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'install:\n -            he'; // len: 25
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 23+2
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('helm', 'helm:\n               name: ', 1, 14, 1, 16, 10, 2, {
-              documentation: '',
-            })
-          );
+      const result = await parseSetup(content, content.lastIndexOf('he') + 2); // pos: 23+2
+      assert.equal(result.items.length, 2);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('helm', 'helm:\n               name: ', 1, 14, 1, 16, 10, 2, {
+          documentation: '',
         })
-        .then(done, done);
+      );
     });
 
-    it('Tab indent should be considered with position relative to slash', (done) => {
+    it('Tab indent should be considered with position relative to slash', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayIndent.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'install:\n -\t             he'; // len: 27
-      const completion = parseSetup(content, content.lastIndexOf('he') + 2); // pos: 25+2
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('helm', 'helm:\n \t               name: ', 1, 16, 1, 18, 10, 2, {
-              documentation: '',
-            })
-          );
+      const result = await parseSetup(content, content.lastIndexOf('he') + 2); // pos: 25+2
+      assert.equal(result.items.length, 2);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('helm', 'helm:\n \t               name: ', 1, 16, 1, 18, 10, 2, {
+          documentation: '',
         })
-        .then(done, done);
+      );
     });
   });
 
   describe('Yaml schema defined in file', function () {
     const uri = toFsPath(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
 
-    it('Provide completion from schema declared in file', (done) => {
+    it('Provide completion from schema declared in file', async () => {
       const content = `# yaml-language-server: $schema=${uri}\n- `;
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 3);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 3);
     });
 
-    it('Provide completion from schema declared in file with $schema: format', (done) => {
+    it('Provide completion from schema declared in file with $schema: format', async () => {
       const content = `# $schema: ${uri}\n- `;
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 3);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 3);
     });
 
-    it('Provide completion from schema declared in file with several attributes', (done) => {
+    it('Provide completion from schema declared in file with several attributes', async () => {
       const content = `# yaml-language-server: $schema=${uri} anothermodeline=value\n- `;
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 3);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 3);
     });
 
     it('Provide completion from schema declared in file with several documents', async () => {
@@ -2246,7 +2044,7 @@ describe('Auto Completion Tests', () => {
       );
     });
 
-    it('Object completion', (done) => {
+    it('Object completion', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -2260,21 +2058,17 @@ describe('Auto Completion Tests', () => {
       });
 
       const content = 'env: '; // len: 5
-      const completion = parseSetup(content, 5);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('Default value', '\n  ${1:KEY}: ${2:VALUE}\n', 0, 5, 0, 5, 9, 2, {
-              detail: 'Default value',
-            })
-          );
+      const result = await parseSetup(content, 5);
+      assert.equal(result.items.length, 1);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('Default value', '\n  ${1:KEY}: ${2:VALUE}\n', 0, 5, 0, 5, 9, 2, {
+          detail: 'Default value',
         })
-        .then(done, done);
+      );
     });
 
-    it('Complex default object completion', (done) => {
+    it('Complex default object completion', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -2292,28 +2086,24 @@ describe('Auto Completion Tests', () => {
       });
 
       const content = 'env: '; // len: 5
-      const completion = parseSetup(content, 5);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion(
-              'Default value',
-              '\n  ${1:KEY}: ${2:VALUE}\n  ${3:KEY2}:\n    ${4:TEST}: ${5:TEST2}\n  ${6:KEY3}:\n    - ${7:Test}\n    - ${8:Test2}\n',
-              0,
-              5,
-              0,
-              5,
-              9,
-              2,
-              {
-                detail: 'Default value',
-              }
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 5);
+      assert.equal(result.items.length, 1);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion(
+          'Default value',
+          '\n  ${1:KEY}: ${2:VALUE}\n  ${3:KEY2}:\n    ${4:TEST}: ${5:TEST2}\n  ${6:KEY3}:\n    - ${7:Test}\n    - ${8:Test2}\n',
+          0,
+          5,
+          0,
+          5,
+          9,
+          2,
+          {
+            detail: 'Default value',
+          }
+        )
+      );
     });
 
     it('should handle array schema without items', async () => {
@@ -2921,135 +2711,99 @@ describe('Auto Completion Tests', () => {
   });
 
   describe('Array completion', () => {
-    it('Simple array object completion with "-" without any item', (done) => {
+    it('Simple array object completion with "-" without any item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_simpleArrayObject:\n  -';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].label, 'obj1');
-          assert.equal(result.items[0].insertText, ' obj1:\n    ');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 2);
+      assert.equal(result.items[0].label, 'obj1');
+      assert.equal(result.items[0].insertText, ' obj1:\n    ');
     });
 
-    it('Simple array object completion without "-" after array item', (done) => {
+    it('Simple array object completion without "-" after array item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_simpleArrayObject:\n  - obj1:\n      name: 1\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item) obj1');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, '- (array item) obj1');
     });
 
-    it('Simple array object completion with "-" after array item', (done) => {
+    it('Simple array object completion with "-" after array item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_simpleArrayObject:\n  - obj1:\n      name: 1\n  -';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].label, 'obj1');
-          assert.equal(result.items[0].insertText, ' obj1:\n    ');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 2);
+      assert.equal(result.items[0].label, 'obj1');
+      assert.equal(result.items[0].insertText, ' obj1:\n    ');
     });
 
-    it('Array anyOf two objects completion with "- " without any item', (done) => {
+    it('Array anyOf two objects completion with "- " without any item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_anyOf_2objects:\n  - ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 4);
-          assert.equal(result.items[0].label, 'obj1');
-          assert.equal(result.items[0].kind, 10);
-          assert.equal(result.items[1].label, 'obj1');
-          assert.equal(result.items[1].kind, 7);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 4);
+      assert.equal(result.items[0].label, 'obj1');
+      assert.equal(result.items[0].kind, 10);
+      assert.equal(result.items[1].label, 'obj1');
+      assert.equal(result.items[1].kind, 7);
     });
 
-    it('Array anyOf two objects completion with "-" without any item', (done) => {
+    it('Array anyOf two objects completion with "-" without any item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_anyOf_2objects:\n  -';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 4);
-          assert.equal(result.items[0].label, 'obj1');
-          assert.equal(result.items[0].insertText, ' obj1:\n    ');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 4);
+      assert.equal(result.items[0].label, 'obj1');
+      assert.equal(result.items[0].insertText, ' obj1:\n    ');
     });
 
-    it('Simple array object completion without "-" befor array empty item', (done) => {
+    it('Simple array object completion without "-" befor array empty item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_simpleArrayObject:\n  |\n|  -'; // len: 30, pos: 26
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, '- (array item) obj1');
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, '- (array item) obj1');
     });
 
-    it('Array anyOf two objects completion without "-" after array item', (done) => {
+    it('Array anyOf two objects completion without "-" after array item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_anyOf_2objects:\n  - obj1:\n      name: 1\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2']);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2']);
     });
 
-    it('Array nested anyOf without "-" should return all array items', (done) => {
+    it('Array nested anyOf without "-" should return all array items', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_nested_anyOf:\n  - obj1:\n    name:1\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2', '- (array item) obj3']);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      expect(result.items.map((i) => i.label)).deep.eq(['- (array item) obj1', '- (array item) obj2', '- (array item) obj3']);
     });
 
-    it('Array anyOf two objects completion with "-" after array item', (done) => {
+    it('Array anyOf two objects completion with "-" after array item', async () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const schema = require(path.join(__dirname, './fixtures/testArrayCompletionSchema.json'));
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test_array_anyOf_2objects:\n  - obj1:\n      name: 1\n  -';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 4);
-          assert.equal(result.items[0].label, 'obj1');
-          assert.equal(result.items[0].insertText, ' obj1:\n    ');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 4);
+      assert.equal(result.items[0].label, 'obj1');
+      assert.equal(result.items[0].insertText, ' obj1:\n    ');
     });
 
     it('Array anyOf two objects completion indentation', async () => {
@@ -3064,7 +2818,7 @@ describe('Auto Completion Tests', () => {
       expect(obj1.textEdit.newText).equal('obj1:\n    ');
     });
 
-    it('Autocomplete key in nested object while typing', (done) => {
+    it('Autocomplete key in nested object while typing', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -3085,18 +2839,14 @@ describe('Auto Completion Tests', () => {
         },
       });
       const content = 'parent:\n  child:\n    p';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.strictEqual(result.items.length, 1);
-          assert.deepEqual(
-            result.items[0],
-            createExpectedCompletion('prop', 'prop: ${1:test}', 2, 4, 2, 5, 10, 2, {
-              documentation: '',
-            })
-          );
+      const result = await parseSetup(content, content.length);
+      assert.strictEqual(result.items.length, 1);
+      assert.deepEqual(
+        result.items[0],
+        createExpectedCompletion('prop', 'prop: ${1:test}', 2, 4, 2, 5, 10, 2, {
+          documentation: '',
         })
-        .then(done, done);
+      );
     });
   });
 

--- a/test/customTags.test.ts
+++ b/test/customTags.test.ts
@@ -33,77 +33,49 @@ describe('Custom Tag tests Tests', () => {
   }
 
   describe('Test that validation does not throw errors', function () {
-    it('Custom Tags without type not specified', (done) => {
+    it('Custom Tags without type not specified', async () => {
       const content = 'scalar_test: !Test test_example';
-      const validator = parseSetup(content, ['!Test']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!Test']);
+      assert.equal(result.length, 0);
     });
 
-    it('Custom Tags with one type', (done) => {
+    it('Custom Tags with one type', async () => {
       const content = 'resolvers: !Ref\n  - test';
-      const validator = parseSetup(content, ['!Ref sequence']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!Ref sequence']);
+      assert.equal(result.length, 0);
     });
 
-    it('Custom Tags with multiple types', (done) => {
+    it('Custom Tags with multiple types', async () => {
       const content = 'resolvers: !Ref\n  - test';
-      const validator = parseSetup(content, ['!Ref sequence', '!Ref mapping', '!Ref scalar']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!Ref sequence', '!Ref mapping', '!Ref scalar']);
+      assert.equal(result.length, 0);
     });
 
-    it('Custom Tags with input and return types', (done) => {
+    it('Custom Tags with input and return types', async () => {
       const content = 'resolvers: !Ref\n  - test';
-      const validator = parseSetup(content, ['!Ref sequence:string']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!Ref sequence:string']);
+      assert.equal(result.length, 0);
     });
 
-    it('Allow multiple different custom tag types with different use', (done) => {
+    it('Allow multiple different custom tag types with different use', async () => {
       const content = '!test\nhello: !test\n  world';
-      const validator = parseSetup(content, ['!test scalar', '!test mapping']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!test scalar', '!test mapping']);
+      assert.equal(result.length, 0);
     });
 
-    it('Allow multiple different custom tag types with multiple different uses', (done) => {
+    it('Allow multiple different custom tag types with multiple different uses', async () => {
       const content = '!test\nhello: !test\n  world\nsequence: !ref\n  - item1';
-      const validator = parseSetup(content, ['!test scalar', '!test mapping', '!ref sequence', '!ref mapping']);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, ['!test scalar', '!test mapping', '!ref sequence', '!ref mapping']);
+      assert.equal(result.length, 0);
     });
   });
 
   describe('Test that validation does throw errors', function () {
-    it('Error when custom tag is not available', (done) => {
+    it('Error when custom tag is not available', async () => {
       const content = '!test';
-      const validator = parseSetup(content, []);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(result[0], createExpectedError('Unresolved tag: !test', 0, 0, 0, 5));
-        })
-        .then(done, done);
+      const result = await parseSetup(content, []);
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], createExpectedError('Unresolved tag: !test', 0, 0, 0, 5));
     });
   });
 });

--- a/test/defaultSnippets.test.ts
+++ b/test/defaultSnippets.test.ts
@@ -50,336 +50,224 @@ describe('Default Snippet Tests', () => {
       });
     }
 
-    it('Snippet in array schema should autocomplete with -', (done) => {
+    it('Snippet in array schema should autocomplete with -', async () => {
       const content = 'array:\n  - '; // len: 11
-      const completion = parseSetup(content, 11);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 11);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
 
-    it('Snippet in array schema should autocomplete with - if none is present', (done) => {
+    it('Snippet in array schema should autocomplete with - if none is present', async () => {
       const content = 'array:\n  '; // len: 9
-      const completion = parseSetup(content, 9);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 9);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
 
-    it('Snippet in array schema should autocomplete on same line as array', (done) => {
+    it('Snippet in array schema should autocomplete on same line as array', async () => {
       const content = 'array: | |'; // len: 8, pos: 7
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, '\n  - item1: $1\n    item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, '\n  - item1: $1\n    item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
 
-    it('Snippet in array schema should autocomplete correctly on array level ', (done) => {
+    it('Snippet in array schema should autocomplete correctly on array level ', async () => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, '- item1: $1\n  item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
-    it('Snippet in array schema should suggest nothing inside array item if YAML already contains all props', (done) => {
+    it('Snippet in array schema should suggest nothing inside array item if YAML already contains all props', async () => {
       const content = 'array:\n  - item1: asd\n    item2: asd\n    ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 0);
     });
-    it('Snippet in array schema should suggest only some of the props inside an array item if YAML already contains some of the props', (done) => {
+    it('Snippet in array schema should suggest only some of the props inside an array item if YAML already contains some of the props', async () => {
       const content = 'array:\n  - item1: asd\n    ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'item2: $2');
-          assert.equal(result.items[0].label, 'My array item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, 'item2: $2');
+      assert.equal(result.items[0].label, 'My array item');
     });
-    it('Snippet in anyOf array schema should autocomplete correctly with "-" symbol', (done) => {
+    it('Snippet in anyOf array schema should autocomplete correctly with "-" symbol', async () => {
       const content = 'anyOf_arrayObj:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, '- key: ');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, '- key: ');
     });
-    it('Snippet custom suggestionKind', (done) => {
+    it('Snippet custom suggestionKind', async () => {
       const content = 'anyOf_arrayObj:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.strictEqual(result.items.length, 1);
-          assert.strictEqual(result.items[0].kind, 9);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.strictEqual(result.items.length, 1);
+      assert.strictEqual(result.items[0].kind, 9);
     });
-    it('Snippet custom sort', (done) => {
+    it('Snippet custom sort', async () => {
       const content = 'arrayNestedObjectSnippet:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.strictEqual(result.items.length, 1);
-          assert.strictEqual(result.items[0].sortText, 'custom');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.strictEqual(result.items.length, 1);
+      assert.strictEqual(result.items[0].sortText, 'custom');
     });
 
-    it('Snippet in object schema should autocomplete on next line ', (done) => {
+    it('Snippet in object schema should autocomplete on next line ', async () => {
       const content = 'object:\n  '; // len: 10
-      const completion = parseSetup(content, 11);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
-          assert.equal(result.items[0].label, 'Object item');
-          assert.equal(result.items[1].insertText, 'key:\n  ');
-          assert.equal(result.items[1].label, 'key');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 11);
+      assert.equal(result.items.length, 2);
+      assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
+      assert.equal(result.items[0].label, 'Object item');
+      assert.equal(result.items[1].insertText, 'key:\n  ');
+      assert.equal(result.items[1].label, 'key');
     });
 
-    it('Snippet in object schema should autocomplete on next line with depth', (done) => {
+    it('Snippet in object schema should autocomplete on next line with depth', async () => {
       const content = 'object:\n  key:\n    '; // len: 19
-      const completion = parseSetup(content, 20);
-      completion
-        .then(function (result) {
-          assert.notEqual(result.items.length, 0);
-          assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
-          assert.equal(result.items[0].label, 'Object item');
-          assert.equal(result.items[1].insertText, 'key:\n  ');
-          assert.equal(result.items[1].label, 'key');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 20);
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].insertText, 'key1: $1\nkey2: $2');
+      assert.equal(result.items[0].label, 'Object item');
+      assert.equal(result.items[1].insertText, 'key:\n  ');
+      assert.equal(result.items[1].label, 'key');
     });
 
-    it('Snippet in object schema should suggest some of the snippet props because some of them are already in the YAML', (done) => {
+    it('Snippet in object schema should suggest some of the snippet props because some of them are already in the YAML', async () => {
       const content = 'object:\n  key:\n    key2: value\n    ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.notEqual(result.items.length, 0);
-          assert.equal(result.items[0].insertText, 'key1: ');
-          assert.equal(result.items[0].label, 'Object item');
-          assert.equal(result.items[1].insertText, 'key:\n  ');
-          assert.equal(result.items[1].label, 'key');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].insertText, 'key1: ');
+      assert.equal(result.items[0].label, 'Object item');
+      assert.equal(result.items[1].insertText, 'key:\n  ');
+      assert.equal(result.items[1].label, 'key');
     });
-    it('Snippet in object schema should not suggest snippet props because all of them are already in the YAML', (done) => {
+    it('Snippet in object schema should not suggest snippet props because all of them are already in the YAML', async () => {
       const content = 'object:\n  key:\n    key1: value\n    key2: value\n    ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'key:\n  ');
-          assert.equal(result.items[0].label, 'key');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, 'key:\n  ');
+      assert.equal(result.items[0].label, 'key');
     });
 
-    it('Snippet in object schema should autocomplete on same line', (done) => {
+    it('Snippet in object schema should autocomplete on same line', async () => {
       const content = 'object:  '; // len: 9
-      const completion = parseSetup(content, 8);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 8);
+      assert.equal(result.items.length, 1);
     });
 
-    it('Snippet in object schema should not autocomplete on children', (done) => {
+    it('Snippet in object schema should not autocomplete on children', async () => {
       const content = 'object_any:\n someProp: ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 0);
     });
 
-    it('Snippet in string schema should autocomplete on same line', (done) => {
+    it('Snippet in string schema should autocomplete on same line', async () => {
       const content = 'string: | |'; // len: 9, pos: 8
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.notEqual(result.items.length, 0);
-          assert.equal(result.items[0].insertText, 'test ');
-          assert.equal(result.items[0].label, 'My string item');
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].insertText, 'test ');
+      assert.equal(result.items[0].label, 'My string item');
     });
 
-    it('Snippet in boolean schema should autocomplete on same line', (done) => {
+    it('Snippet in boolean schema should autocomplete on same line', async () => {
       const content = 'boolean: | |'; // len: 10, pos: 9
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.notEqual(result.items.length, 0);
-          assert.equal(result.items[0].label, 'My boolean item');
-          assert.equal(result.items[0].insertText, 'false');
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.notEqual(result.items.length, 0);
+      assert.equal(result.items[0].label, 'My boolean item');
+      assert.equal(result.items[0].insertText, 'false');
     });
 
-    it('Snippet in longSnipet schema should autocomplete on same line', (done) => {
+    it('Snippet in longSnipet schema should autocomplete on same line', async () => {
       const content = 'longSnippet: | |'; // len: 14, pos: 13
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, 'apply-manifests');
-          assert.equal(
-            result.items[0].insertText,
-            '\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, 'apply-manifests');
+      assert.equal(
+        result.items[0].insertText,
+        '\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
+      );
     });
 
-    it('Snippet in short snippet schema should autocomplete on same line', (done) => {
+    it('Snippet in short snippet schema should autocomplete on same line', async () => {
       const content = 'lon| | '; // len: 5, pos: 3
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 15); // This is just checking the total number of snippets in the defaultSnippets.json
-          assert.equal(result.items[4].label, 'longSnippet');
-          assert.equal(
-            result.items[4].insertText,
-            'longSnippet:\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.items.length, 15); // This is just checking the total number of snippets in the defaultSnippets.json
+      assert.equal(result.items[4].label, 'longSnippet');
+      assert.equal(
+        result.items[4].insertText,
+        'longSnippet:\n  name: $1\n  taskRef:\n    name: apply-manifests\n  resources:\n    inputs:\n      - name: source\n        resource: $3\n  params:\n    - name: manifest_dir\n      value: $2'
+      );
     });
 
-    it('Test array of arrays on properties completion', (done) => {
+    it('Test array of arrays on properties completion', async () => {
       const content = 'arrayArrayS| | '; // len: 13, pos: 11
-      const completion = parseSetup(content);
-      completion
-        .then(function (result) {
-          assert.equal(result.items[5].label, 'arrayArraySnippet');
-          assert.equal(result.items[5].insertText, 'arrayArraySnippet:\n  apple:\n    - - name: source\n        resource: $3');
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.items[5].label, 'arrayArraySnippet');
+      assert.equal(result.items[5].insertText, 'arrayArraySnippet:\n  apple:\n    - - name: source\n        resource: $3');
     });
 
-    it('Test array of arrays on value completion', (done) => {
+    it('Test array of arrays on value completion', async () => {
       const content = 'arrayArraySnippet: '; // len: 19
-      const completion = parseSetup(content, 20);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, 'Array Array Snippet');
-          assert.equal(result.items[0].insertText, '\n  apple:\n    - - name: source\n        resource: $3');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 20);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, 'Array Array Snippet');
+      assert.equal(result.items[0].insertText, '\n  apple:\n    - - name: source\n        resource: $3');
     });
 
-    it('Test array of arrays on indented completion', (done) => {
+    it('Test array of arrays on indented completion', async () => {
       const content = 'arrayArraySnippet:\n  '; // len: 21
-      const completion = parseSetup(content, 21);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, 'Array Array Snippet');
-          assert.equal(result.items[0].insertText, 'apple:\n  - - name: source\n      resource: $3');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 21);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, 'Array Array Snippet');
+      assert.equal(result.items[0].insertText, 'apple:\n  - - name: source\n      resource: $3');
     });
 
-    it('Test array of strings', (done) => {
+    it('Test array of strings', async () => {
       const content = 'arrayStringSnippet:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'fruits:\n  - banana\n  - orange');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, 'fruits:\n  - banana\n  - orange');
     });
 
-    it('Test array nested object indented completion', (done) => {
+    it('Test array nested object indented completion', async () => {
       const content = 'arrayNestedObjectSnippet:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(
-            result.items[0].insertText,
-            'apple:\n  - name: source\n    resource:\n      prop1: value1\n      prop2: value2'
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(
+        result.items[0].insertText,
+        'apple:\n  - name: source\n    resource:\n      prop1: value1\n      prop2: value2'
+      );
     });
 
-    it('Test snippet in array indented completion', (done) => {
+    it('Test snippet in array indented completion', async () => {
       const content = 'arrayWithSnippet:\n  - ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 2);
-          assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
-          assert.equal(result.items[1].insertText, '\n  item1: $1\n  item2: $2');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 2);
+      assert.equal(result.items[0].insertText, 'item1: $1\n  item2: $2');
+      assert.equal(result.items[1].insertText, '\n  item1: $1\n  item2: $2');
     });
 
-    it('Test array of objects extra new line', (done) => {
+    it('Test array of objects extra new line', async () => {
       const content = 'arrayObjectSnippet:\n  ';
-      const completion = parseSetup(content, content.length);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].insertText, 'apple:\n  - name: source\n  - name: source2');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, content.length);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].insertText, 'apple:\n  - name: source\n  - name: source2');
     });
 
-    it('Test string with boolean in string should insert string', (done) => {
+    it('Test string with boolean in string should insert string', async () => {
       const content = 'simpleBooleanString: '; // len: 21
-      const completion = parseSetup(content, 21);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, 'Simple boolean string');
-          assert.equal(result.items[0].insertText, '\n  test: "true"');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 21);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, 'Simple boolean string');
+      assert.equal(result.items[0].insertText, '\n  test: "true"');
     });
 
-    it('Test string with boolean NOT in string should insert boolean', (done) => {
+    it('Test string with boolean NOT in string should insert boolean', async () => {
       const content = 'simpleBoolean: '; // len: 15
-      const completion = parseSetup(content, 15);
-      completion
-        .then(function (result) {
-          assert.equal(result.items.length, 1);
-          assert.equal(result.items[0].label, 'Simple string');
-          assert.equal(result.items[0].insertText, '\n  test: true');
-        })
-        .then(done, done);
+      const result = await parseSetup(content, 15);
+      assert.equal(result.items.length, 1);
+      assert.equal(result.items[0].label, 'Simple string');
+      assert.equal(result.items[0].insertText, '\n  test: true');
     });
 
     it('should preserve space after ":" with prefix', async () => {

--- a/test/documentSymbols.test.ts
+++ b/test/documentSymbols.test.ts
@@ -51,11 +51,10 @@ describe('Document Symbols Tests', () => {
       });
     }
 
-    it('Document is empty', (done) => {
+    it('Document is empty', () => {
       const content = '';
       const symbols = parseNonHierarchicalSetup(content);
       assert.deepStrictEqual(symbols, []);
-      done();
     });
 
     it('Simple document symbols', () => {
@@ -159,11 +158,10 @@ describe('Document Symbols Tests', () => {
       });
     }
 
-    it('Document is empty', (done) => {
+    it('Document is empty', () => {
       const content = '';
       const symbols = parseHierarchicalSetup(content);
       assert.deepStrictEqual(symbols, []);
-      done();
     });
 
     it('Simple document symbols', () => {

--- a/test/findLinks.test.ts
+++ b/test/findLinks.test.ts
@@ -30,26 +30,22 @@ describe('Find Links Tests', () => {
   }
 
   describe('Jump to definition', function () {
-    it('Find source definition', (done) => {
+    it('Find source definition', async () => {
       const content =
         "definitions:\n  link:\n    type: string\ntype: object\nproperties:\n  uri:\n    $ref: '#/definitions/link'\n";
-      const definitions = findLinks(content);
-      definitions
-        .then(function (results) {
-          assert.equal(results.length, 1);
-          assert.deepEqual(results[0].range, {
-            start: {
-              line: 6,
-              character: 11,
-            },
-            end: {
-              line: 6,
-              character: 29,
-            },
-          });
-          assert.deepEqual(results[0].target, 'file://~/Desktop/vscode-k8s/test.yaml#3,5');
-        })
-        .then(done, done);
+      const results = await findLinks(content);
+      assert.equal(results.length, 1);
+      assert.deepEqual(results[0].range, {
+        start: {
+          line: 6,
+          character: 11,
+        },
+        end: {
+          line: 6,
+          character: 29,
+        },
+      });
+      assert.deepEqual(results[0].target, 'file://~/Desktop/vscode-k8s/test.yaml#3,5');
     });
   });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -51,95 +51,59 @@ describe('Kubernetes Integration Tests', () => {
 
     //Validating basic nodes
     describe('Test that validation does not throw errors', function () {
-      it('Basic test', (done) => {
+      it('Basic test', async () => {
         const content = 'apiVersion: v1';
-        const validator = parseSetup(content);
-        validator
-          .then(function (result) {
-            assert.equal(result.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content);
+        assert.equal(result.length, 0);
       });
 
-      it('Basic test on nodes with children', (done) => {
+      it('Basic test on nodes with children', async () => {
         const content = 'metadata:\n  name: hello';
-        const validator = parseSetup(content);
-        validator
-          .then(function (result) {
-            assert.equal(result.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content);
+        assert.equal(result.length, 0);
       });
 
-      it('Advanced test on nodes with children', (done) => {
+      it('Advanced test on nodes with children', async () => {
         const content = 'apiVersion: v1\nmetadata:\n  name: test1';
-        const validator = parseSetup(content);
-        validator
-          .then(function (result) {
-            assert.equal(result.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content);
+        assert.equal(result.length, 0);
       });
 
-      it('Type string validates under children', (done) => {
+      it('Type string validates under children', async () => {
         const content = 'apiVersion: v1\nkind: Pod\nmetadata:\n  resourceVersion: test';
-        const validator = parseSetup(content);
-        validator
-          .then(function (result) {
-            assert.equal(result.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content);
+        assert.equal(result.length, 0);
       });
 
       describe('Type tests', function () {
-        it('Type String does not error on valid node', (done) => {
+        it('Type String does not error on valid node', async () => {
           const content = 'apiVersion: v1';
-          const validator = parseSetup(content);
-          validator
-            .then(function (result) {
-              assert.equal(result.length, 0);
-            })
-            .then(done, done);
+          const result = await parseSetup(content);
+          assert.equal(result.length, 0);
         });
 
-        it('Type Boolean does not error on valid node', (done) => {
+        it('Type Boolean does not error on valid node', async () => {
           const content = 'readOnlyRootFilesystem: false';
-          const validator = parseSetup(content);
-          validator
-            .then(function (result) {
-              assert.equal(result.length, 0);
-            })
-            .then(done, done);
+          const result = await parseSetup(content);
+          assert.equal(result.length, 0);
         });
 
-        it('Type Number does not error on valid node', (done) => {
+        it('Type Number does not error on valid node', async () => {
           const content = 'generation: 5';
-          const validator = parseSetup(content);
-          validator
-            .then(function (result) {
-              assert.equal(result.length, 0);
-            })
-            .then(done, done);
+          const result = await parseSetup(content);
+          assert.equal(result.length, 0);
         });
 
-        it('Type Object does not error on valid node', (done) => {
+        it('Type Object does not error on valid node', async () => {
           const content = 'metadata:\n  name: tes';
-          const validator = parseSetup(content);
-          validator
-            .then(function (result) {
-              assert.equal(result.length, 0);
-            })
-            .then(done, done);
+          const result = await parseSetup(content);
+          assert.equal(result.length, 0);
         });
 
-        it('Type Array does not error on valid node', (done) => {
+        it('Type Array does not error on valid node', async () => {
           const content = 'items:\n  - apiVersion: v1';
-          const validator = parseSetup(content);
-          validator
-            .then(function (result) {
-              assert.equal(result.length, 0);
-            })
-            .then(done, done);
+          const result = await parseSetup(content);
+          assert.equal(result.length, 0);
         });
       });
     });
@@ -150,61 +114,47 @@ describe('Kubernetes Integration Tests', () => {
      * No longer has those types of validation
      */
     // describe('Test that validation DOES throw errors', function () {
-    //     it('Error when theres no value for a node', done => {
+    //     it('Error when theres no value for a node', async () => {
     //         const content = 'apiVersion:';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Error on incorrect value type (number)', done => {
+    //     it('Error on incorrect value type (number)', async () => {
     //         const content = 'apiVersion: 1000';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Error on incorrect value type (boolean)', done => {
+    //     it('Error on incorrect value type (boolean)', async () => {
     //         const content = 'apiVersion: False';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Error on incorrect value type (string)', done => {
+    //     it('Error on incorrect value type (string)', async () => {
     //         const content = 'isNonResourceURL: hello_world';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Error on incorrect value type (object)', done => {
+    //     it('Error on incorrect value type (object)', async () => {
     //         const content = 'apiVersion: v1\nkind: Pod\nmetadata:\n  name: False';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Error on incorrect value type in multiple yaml documents', done => {
+    //     it('Error on incorrect value type in multiple yaml documents', async () => {
     //         const content = '---\napiVersion: v1\n...\n---\napiVersion: False\n...';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.notEqual(result.length, 0);
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.notEqual(result.length, 0);
     //     });
 
-    //     it('Property error message should be \"Property unknown_node is not allowed.\" when property is not allowed ', done => {
+    //     it('Property error message should be \"Property unknown_node is not allowed.\" when property is not allowed ', async () => {
     //         const content = 'unknown_node: test';
-    //         const validator = parseSetup(content);
-    //         validator.then(function (result){
-    //             assert.equal(result.length, 1);
-    //             assert.equal(result[0].message, 'Property unknown_node is not allowed.');
-    //         }).then(done, done);
+    //         const result = await parseSetup(content);
+    //         assert.equal(result.length, 1);
+    //         assert.equal(result[0].message, 'Property unknown_node is not allowed.');
     //     });
 
     // });
@@ -225,20 +175,16 @@ describe('Kubernetes Integration Tests', () => {
       /**
        * Known issue: https://github.com/redhat-developer/yaml-language-server/issues/51
        */
-      // it('Autocomplete on root node without word', done => {
+      // it('Autocomplete on root node without word', async () => {
       //     const content = '';
-      //     const completion = parseSetup(content, 0);
-      //     completion.then(function (result){
-      //         assert.notEqual(result.items.length, 0);
-      //     }).then(done, done);
+      //     const result = await parseSetup(content, 0);
+      //     assert.notEqual(result.items.length, 0);
       // });
 
-      // it('Autocomplete on root node with word', done => {
+      // it('Autocomplete on root node with word', async () => {
       //     const content = 'api';
-      //     const completion = parseSetup(content, 6);
-      //     completion.then(function (result){
-      //         assert.notEqual(result.items.length, 0);
-      //     }).then(done, done);
+      //     const result = await parseSetup(content, 6);
+      //     assert.notEqual(result.items.length, 0);
       // });
 
       /**
@@ -246,62 +192,40 @@ describe('Kubernetes Integration Tests', () => {
        * https://github.com/redhat-developer/yaml-language-server/pull/108
        * No longer has those types of completion
        */
-      // it('Autocomplete on default value (without value content)', done => {
+      // it('Autocomplete on default value (without value content)', async () => {
       //     const content = 'apiVersion: ';
-      //     const completion = parseSetup(content, 10);
-      //     completion.then(function (result){
-      //         assert.notEqual(result.items.length, 0);
-      //     }).then(done, done);
+      //     const result = await parseSetup(content, 10);
+      //     assert.notEqual(result.items.length, 0);
       // });
 
-      it('Autocomplete on default value (with value content)', (done) => {
+      it('Autocomplete on default value (with value content)', async () => {
         const content = 'apiVersion: v1\nkind: Depl';
-        const completion = parseSetup(content, 19);
-        completion
-          .then(function (result) {
-            assert.notEqual(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 19);
+        assert.notEqual(result.items.length, 0);
       });
 
-      it('Autocomplete on boolean value (without value content)', (done) => {
+      it('Autocomplete on boolean value (without value content)', async () => {
         const content = 'apiVersion: apps/v1\nkind: Deployment\nspec:\n  paused: ';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 2);
       });
 
-      it('Autocomplete on boolean value (with value content)', (done) => {
+      it('Autocomplete on boolean value (with value content)', async () => {
         const content = 'apiVersion: apps/v1\nkind: Deployment\nspec:\n  paused: fal';
-        const completion = parseSetup(content, content.length);
-        completion
-          .then(function (result) {
-            assert.equal(result.items.length, 2);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, content.length);
+        assert.equal(result.items.length, 2);
       });
 
-      it('Autocomplete key in middle of file', (done) => {
+      it('Autocomplete key in middle of file', async () => {
         const content = 'metadata:\n  nam';
-        const completion = parseSetup(content, 14);
-        completion
-          .then(function (result) {
-            assert.notEqual(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 14);
+        assert.notEqual(result.items.length, 0);
       });
 
-      it('Autocomplete key in middle of file 2', (done) => {
+      it('Autocomplete key in middle of file 2', async () => {
         const content = 'metadata:\n  name: test\n  cluster';
-        const completion = parseSetup(content, 31);
-        completion
-          .then(function (result) {
-            assert.notEqual(result.items.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup(content, 31);
+        assert.notEqual(result.items.length, 0);
       });
     });
   });

--- a/test/multipleDocuments.test.ts
+++ b/test/multipleDocuments.test.ts
@@ -66,59 +66,43 @@ describe('Multiple Documents Validation Tests', () => {
       });
     }
 
-    it('Should validate multiple documents', (done) => {
+    it('Should validate multiple documents', async () => {
       const content = `
 name: jack
 age: 22
 ---
 cwd: test
             `;
-      const validator = validatorSetup(content);
-      validator
-        .then((result) => {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await validatorSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Should find errors in both documents', (done) => {
+    it('Should find errors in both documents', async () => {
       const content = `name1: jack
 age: asd
 ---
 cwd: False`;
-      const validator = validatorSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 3);
-        })
-        .then(done, done);
+      const result = await validatorSetup(content);
+      assert.equal(result.length, 3);
     });
 
-    it('Should find errors in first document', (done) => {
+    it('Should find errors in first document', async () => {
       const content = `name: jack
 age: age
 ---
 cwd: test`;
-      const validator = validatorSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-        })
-        .then(done, done);
+      const result = await validatorSetup(content);
+      assert.equal(result.length, 1);
     });
 
-    it('Should find errors in second document', (done) => {
+    it('Should find errors in second document', async () => {
       const content = `name: jack
 age: 22
 ---
 cwd: False
 `;
-      const validator = validatorSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-        })
-        .then(done, done);
+      const result = await validatorSetup(content);
+      assert.equal(result.length, 1);
     });
 
     it('Should hover in first document', async () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -65,7 +65,7 @@ describe('JSON Schema', () => {
     languageService = langService;
   });
 
-  it('Resolving $refs', function (testDone) {
+  it('Resolving $refs', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
@@ -86,30 +86,19 @@ describe('JSON Schema', () => {
       },
     });
 
-    service
-      .getResolvedSchema('https://myschemastore/main')
-      .then((solvedSchema) => {
-        assert.deepEqual(solvedSchema.schema.properties['child'], {
-          id: 'https://myschemastore/child',
-          type: 'bool',
-          description: 'Test description',
-          _$ref: 'https://myschemastore/child',
-          url: 'https://myschemastore/child',
-          _baseUri: 'https://myschemastore/child',
-          _sourceUri: 'https://myschemastore/child',
-        });
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const solvedSchema = await service.getResolvedSchema('https://myschemastore/main');
+    assert.deepEqual(solvedSchema.schema.properties['child'], {
+      id: 'https://myschemastore/child',
+      type: 'bool',
+      description: 'Test description',
+      _$ref: 'https://myschemastore/child',
+      url: 'https://myschemastore/child',
+      _baseUri: 'https://myschemastore/child',
+      _sourceUri: 'https://myschemastore/child',
+    });
   });
 
-  it('Resolving $refs 2', function (testDone) {
+  it('Resolving $refs 2', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
@@ -136,33 +125,22 @@ describe('JSON Schema', () => {
       },
     });
 
-    service
-      .getResolvedSchema('https://json.schemastore.org/swagger-2.0')
-      .then((fs) => {
-        assert.deepEqual(fs.schema.properties['responseValue'], {
-          type: 'object',
-          required: ['$ref'],
-          properties: {
-            $ref: {
-              type: 'string',
-              _sourceUri: 'https://json.schemastore.org/swagger-2.0',
-            },
-          },
-          _$ref: '#/definitions/jsonReference',
+    const fs = await service.getResolvedSchema('https://json.schemastore.org/swagger-2.0');
+    assert.deepEqual(fs.schema.properties['responseValue'], {
+      type: 'object',
+      required: ['$ref'],
+      properties: {
+        $ref: {
+          type: 'string',
           _sourceUri: 'https://json.schemastore.org/swagger-2.0',
-        });
-      })
-      .then(
-        () => {
-          return testDone();
         },
-        (error) => {
-          testDone(error);
-        }
-      );
+      },
+      _$ref: '#/definitions/jsonReference',
+      _sourceUri: 'https://json.schemastore.org/swagger-2.0',
+    });
   });
 
-  it('Resolving $refs 3', function (testDone) {
+  it('Resolving $refs 3', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
@@ -193,45 +171,34 @@ describe('JSON Schema', () => {
       },
     });
 
-    service
-      .getResolvedSchema('https://myschemastore/main/schema1.json')
-      .then((fs) => {
-        assert.deepEqual(fs.schema.properties['p1'], {
-          type: 'string',
-          enum: ['object'],
-          _$ref: 'schema2.json#/definitions/hello',
-          _baseUri: 'https://myschemastore/main/schema2.json',
-          _sourceUri: 'https://myschemastore/main/schema2.json',
-          url: 'https://myschemastore/main/schema2.json',
-        });
-        assert.deepEqual(fs.schema.properties['p2'], {
-          type: 'string',
-          enum: ['object'],
-          _$ref: './schema2.json#/definitions/hello',
-          _baseUri: 'https://myschemastore/main/schema2.json',
-          _sourceUri: 'https://myschemastore/main/schema2.json',
-          url: 'https://myschemastore/main/schema2.json',
-        });
-        assert.deepEqual(fs.schema.properties['p3'], {
-          type: 'string',
-          enum: ['object'],
-          _$ref: '/main/schema2.json#/definitions/hello',
-          _baseUri: 'https://myschemastore/main/schema2.json',
-          _sourceUri: 'https://myschemastore/main/schema2.json',
-          url: 'https://myschemastore/main/schema2.json',
-        });
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getResolvedSchema('https://myschemastore/main/schema1.json');
+    assert.deepEqual(fs.schema.properties['p1'], {
+      type: 'string',
+      enum: ['object'],
+      _$ref: 'schema2.json#/definitions/hello',
+      _baseUri: 'https://myschemastore/main/schema2.json',
+      _sourceUri: 'https://myschemastore/main/schema2.json',
+      url: 'https://myschemastore/main/schema2.json',
+    });
+    assert.deepEqual(fs.schema.properties['p2'], {
+      type: 'string',
+      enum: ['object'],
+      _$ref: './schema2.json#/definitions/hello',
+      _baseUri: 'https://myschemastore/main/schema2.json',
+      _sourceUri: 'https://myschemastore/main/schema2.json',
+      url: 'https://myschemastore/main/schema2.json',
+    });
+    assert.deepEqual(fs.schema.properties['p3'], {
+      type: 'string',
+      enum: ['object'],
+      _$ref: '/main/schema2.json#/definitions/hello',
+      _baseUri: 'https://myschemastore/main/schema2.json',
+      _sourceUri: 'https://myschemastore/main/schema2.json',
+      url: 'https://myschemastore/main/schema2.json',
+    });
   });
 
-  it('Resolving absolute-path $refs without top-level id', function (testDone) {
+  it('Resolving absolute-path $refs without top-level id', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
@@ -252,31 +219,20 @@ describe('JSON Schema', () => {
       },
     });
 
-    service
-      .getResolvedSchema('file:///main/schema.json')
-      .then((fs) => {
-        assert.deepEqual(fs.errors, []);
-        assert.deepEqual(fs.schema.properties['name'], {
-          type: 'string',
-          enum: ['alice', 'bob'],
-          description: 'Allowed names.',
-          _$ref: '/main/schema2.json',
-          _baseUri: 'file:///main/schema2.json',
-          _sourceUri: 'file:///main/schema2.json',
-          url: 'file:///main/schema2.json',
-        });
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getResolvedSchema('file:///main/schema.json');
+    assert.deepEqual(fs.errors, []);
+    assert.deepEqual(fs.schema.properties['name'], {
+      type: 'string',
+      enum: ['alice', 'bob'],
+      description: 'Allowed names.',
+      _$ref: '/main/schema2.json',
+      _baseUri: 'file:///main/schema2.json',
+      _sourceUri: 'file:///main/schema2.json',
+      url: 'file:///main/schema2.json',
+    });
   });
 
-  it('Preserves markdownDescription on $ref siblings', function (testDone) {
+  it('Preserves markdownDescription on $ref siblings', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     service.setSchemaContributions({
       schemas: {
@@ -302,24 +258,13 @@ describe('JSON Schema', () => {
       },
     });
 
-    service
-      .getResolvedSchema('https://myschemastore/main/schema.json')
-      .then((resolvedSchema) => {
-        assert.strictEqual(resolvedSchema.schema.properties['bar'].description, 'bar desc');
-        assert.strictEqual(
-          resolvedSchema.schema.properties['bar'].markdownDescription,
-          'bar md desc **bold** \n * line \n* another \n\n'
-        );
-        assert.deepStrictEqual(resolvedSchema.schema.properties['bar'].enum, ['potato', 'carrot']);
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const resolvedSchema = await service.getResolvedSchema('https://myschemastore/main/schema.json');
+    assert.strictEqual(resolvedSchema.schema.properties['bar'].description, 'bar desc');
+    assert.strictEqual(
+      resolvedSchema.schema.properties['bar'].markdownDescription,
+      'bar md desc **bold** \n * line \n* another \n\n'
+    );
+    assert.deepStrictEqual(resolvedSchema.schema.properties['bar'].enum, ['potato', 'carrot']);
   });
 
   describe('Compound Schema Documents', () => {
@@ -605,7 +550,7 @@ address:
     });
   });
 
-  it('FileSchema', function (testDone) {
+  it('FileSchema', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
     service.setSchemaContributions({
@@ -628,23 +573,12 @@ address:
       },
     });
 
-    service
-      .getResolvedSchema('main')
-      .then((fs) => {
-        const section = fs.getSection(['child', 'grandchild']);
-        assert.equal(section.description, 'Meaning of Life');
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getResolvedSchema('main');
+    const section = fs.getSection(['child', 'grandchild']);
+    assert.equal(section.description, 'Meaning of Life');
   });
 
-  it('Array FileSchema', function (testDone) {
+  it('Array FileSchema', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
     service.setSchemaContributions({
@@ -670,23 +604,12 @@ address:
       },
     });
 
-    service
-      .getResolvedSchema('main')
-      .then((fs) => {
-        const section = fs.getSection(['child', '0', 'grandchild']);
-        assert.equal(section.description, 'Meaning of Life');
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getResolvedSchema('main');
+    const section = fs.getSection(['child', '0', 'grandchild']);
+    assert.equal(section.description, 'Meaning of Life');
   });
 
-  it('Missing subschema', function (testDone) {
+  it('Missing subschema', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
     service.setSchemaContributions({
@@ -703,23 +626,12 @@ address:
       },
     });
 
-    service
-      .getResolvedSchema('main')
-      .then((fs) => {
-        const section = fs.getSection(['child', 'grandchild']);
-        assert.strictEqual(section, undefined);
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getResolvedSchema('main');
+    const section = fs.getSection(['child', 'grandchild']);
+    assert.strictEqual(section, undefined);
   });
 
-  it('Preloaded Schema', function (testDone) {
+  it('Preloaded Schema', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     const id = 'https://myschemastore/test1';
     const schema: JsonSchema.JSONSchema = {
@@ -739,20 +651,9 @@ address:
 
     service.registerExternalSchema(id, ['*.json'], schema);
 
-    service
-      .getSchemaForResource('test.json', undefined)
-      .then((schema) => {
-        const section = schema.getSection(['child', 'grandchild']);
-        assert.equal(section.description, 'Meaning of Life');
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const fs = await service.getSchemaForResource('test.json', undefined);
+    const section = fs.getSection(['child', 'grandchild']);
+    assert.equal(section.description, 'Meaning of Life');
   });
 
   it('Schema has url', async () => {
@@ -780,43 +681,21 @@ address:
     expect(result.schema.url).equal(id);
   });
 
-  it('Null Schema', function (testDone) {
+  it('Null Schema', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
-    service
-      .getSchemaForResource('test.json', undefined)
-      .then((schema) => {
-        assert.equal(schema, null);
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const schema = await service.getSchemaForResource('test.json', undefined);
+    assert.equal(schema, null);
   });
 
-  it('Schema not found', function (testDone) {
+  it('Schema not found', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
 
-    service
-      .loadSchema('test.json')
-      .then((schema) => {
-        assert.notEqual(schema.errors.length, 0);
-      })
-      .then(
-        () => {
-          return testDone();
-        },
-        (error) => {
-          testDone(error);
-        }
-      );
+    const schema = await service.loadSchema('test.json');
+    assert.notEqual(schema.errors.length, 0);
   });
 
-  it('Schema with non uri registers correctly', function (testDone) {
+  it('Schema with non uri registers correctly', async function () {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
     const non_uri = 'non_uri';
     service.registerExternalSchema(non_uri, ['*.yml', '*.yaml'], {
@@ -827,10 +706,8 @@ address:
         },
       },
     });
-    service.getResolvedSchema(non_uri).then((schema) => {
-      assert.notEqual(schema, undefined);
-      testDone();
-    });
+    const schema = await service.getResolvedSchema(non_uri);
+    assert.notEqual(schema, undefined);
   });
   it('Modifying schema', async () => {
     const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -81,7 +81,7 @@ describe('Validation Tests', () => {
   });
 
   describe('Boolean tests', () => {
-    it('Boolean true test', (done) => {
+    it('Boolean true test', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -91,15 +91,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: true';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Basic false test', (done) => {
+    it('Basic false test', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -109,15 +105,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: false';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Test that boolean value without quotations is valid', (done) => {
+    it('Test that boolean value without quotations is valid', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -127,15 +119,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = '%YAML 1.1\n---\nanalytics: no';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Test that boolean value in quotations is interpreted as string not boolean', (done) => {
+    it('Test that boolean value in quotations is interpreted as string not boolean', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -145,28 +133,24 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: "no"';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.strictEqual(result.length, 1);
-          assert.deepStrictEqual(
-            result[0],
-            createDiagnosticWithData(
-              BooleanTypeError,
-              0,
-              11,
-              0,
-              15,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.strictEqual(result.length, 1);
+      assert.deepStrictEqual(
+        result[0],
+        createDiagnosticWithData(
+          BooleanTypeError,
+          0,
+          11,
+          0,
+          15,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
 
-    it('Error on incorrect value type (boolean)', (done) => {
+    it('Error on incorrect value type (boolean)', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -176,28 +160,24 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'cwd: False';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              StringTypeError,
-              0,
-              5,
-              0,
-              10,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          StringTypeError,
+          0,
+          5,
+          0,
+          10,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
 
-    it('Test that boolean value can be used in enum', (done) => {
+    it('Test that boolean value can be used in enum', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -207,15 +187,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: true';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.deepStrictEqual(result, []);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
     });
 
-    it('Test that boolean value can be used in const', (done) => {
+    it('Test that boolean value can be used in const', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -225,12 +201,8 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: true';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.deepStrictEqual(result, []);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
     });
 
     it('Test that YAML 1.1 boolean "True" can be used in enum', async () => {
@@ -301,7 +273,7 @@ describe('Validation Tests', () => {
   });
 
   describe('String tests', () => {
-    it('Test that boolean inside of quotations is of type string', (done) => {
+    it('Test that boolean inside of quotations is of type string', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -311,15 +283,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: "no"';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Type string validates under children', (done) => {
+    it('Type string validates under children', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -334,15 +302,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'registry:\n  register: file://test_url';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Type String does not error on valid node', (done) => {
+    it('Type String does not error on valid node', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -352,15 +316,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'cwd: this';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Error on incorrect value type (string)', (done) => {
+    it('Error on incorrect value type (string)', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -370,28 +330,24 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: hello';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              BooleanTypeError,
-              0,
-              11,
-              0,
-              16,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          BooleanTypeError,
+          0,
+          11,
+          0,
+          16,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
 
-    it('Test that boolean is invalid when no strings present and schema wants string', (done) => {
+    it('Test that boolean is invalid when no strings present and schema wants string', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -401,30 +357,26 @@ describe('Validation Tests', () => {
         },
       });
       const content = '%YAML 1.1\n---\ncwd: no';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              StringTypeError,
-              2,
-              5,
-              2,
-              7,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          StringTypeError,
+          2,
+          5,
+          2,
+          7,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
   });
 
   describe('Pattern tests', () => {
-    it('Test a valid Unicode pattern', (done) => {
+    it('Test a valid Unicode pattern', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -434,13 +386,11 @@ describe('Validation Tests', () => {
           },
         },
       });
-      parseSetup('prop: "tesT"')
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      parseSetup('prop: "tesT"').then(function (result) {
+        assert.equal(result.length, 0);
+      });
     });
-    it('Test an invalid Unicode pattern', (done) => {
+    it('Test an invalid Unicode pattern', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -450,28 +400,26 @@ describe('Validation Tests', () => {
           },
         },
       });
-      parseSetup('prop: "tes "')
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.ok(result[0].message.startsWith('String does not match the pattern'));
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              result[0].message,
-              0,
-              6,
-              0,
-              12,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      parseSetup('prop: "tes "').then(function (result) {
+        assert.equal(result.length, 1);
+        assert.ok(result[0].message.startsWith('String does not match the pattern'));
+        assert.deepEqual(
+          result[0],
+          createDiagnosticWithData(
+            result[0].message,
+            0,
+            6,
+            0,
+            12,
+            DiagnosticSeverity.Error,
+            `yaml-schema: file:///${SCHEMA_ID}`,
+            `file:///${SCHEMA_ID}`
+          )
+        );
+      });
     });
 
-    it('Test a valid Unicode patternProperty', (done) => {
+    it('Test a valid Unicode patternProperty', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         patternProperties: {
@@ -479,13 +427,11 @@ describe('Validation Tests', () => {
         },
         additionalProperties: false,
       });
-      parseSetup('tesT: true')
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      parseSetup('tesT: true').then(function (result) {
+        assert.equal(result.length, 0);
+      });
     });
-    it('Test an invalid Unicode patternProperty', (done) => {
+    it('Test an invalid Unicode patternProperty', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         patternProperties: {
@@ -493,27 +439,25 @@ describe('Validation Tests', () => {
         },
         additionalProperties: false,
       });
-      parseSetup('tes9: true')
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              'Property tes9 is not allowed.',
-              0,
-              0,
-              0,
-              4,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`,
-              ErrorCode.PropertyExpected
-            )
-          );
-        })
-        .then(done, done);
+      parseSetup('tes9: true').then(function (result) {
+        assert.equal(result.length, 1);
+        assert.deepEqual(
+          result[0],
+          createDiagnosticWithData(
+            'Property tes9 is not allowed.',
+            0,
+            0,
+            0,
+            4,
+            DiagnosticSeverity.Error,
+            `yaml-schema: file:///${SCHEMA_ID}`,
+            `file:///${SCHEMA_ID}`,
+            ErrorCode.PropertyExpected
+          )
+        );
+      });
     });
-    it('Test inline pattern modifiers', (done) => {
+    it('Test inline pattern modifiers', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -575,13 +519,11 @@ describe('Validation Tests', () => {
         '  end',
         '  more text',
       ].join('\n');
-      parseSetup(content)
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      parseSetup(content).then(function (result) {
+        assert.equal(result.length, 0);
+      });
     });
-    it('Test an unsupported pattern', (done) => {
+    it('Test an unsupported pattern', () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -591,29 +533,27 @@ describe('Validation Tests', () => {
           },
         },
       });
-      parseSetup('unsupportedPattern: text content')
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              'Invalid pattern: "(?x)text .*"',
-              0,
-              20,
-              0,
-              32,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      parseSetup('unsupportedPattern: text content').then(function (result) {
+        assert.equal(result.length, 1);
+        assert.deepEqual(
+          result[0],
+          createDiagnosticWithData(
+            'Invalid pattern: "(?x)text .*"',
+            0,
+            20,
+            0,
+            32,
+            DiagnosticSeverity.Error,
+            `yaml-schema: file:///${SCHEMA_ID}`,
+            `file:///${SCHEMA_ID}`
+          )
+        );
+      });
     });
   });
 
   describe('Number tests', () => {
-    it('Type Number does not error on valid node', (done) => {
+    it('Type Number does not error on valid node', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -623,15 +563,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'timeout: 60000';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Error on incorrect value type (number)', (done) => {
+    it('Error on incorrect value type (number)', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -641,30 +577,26 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'cwd: 100000';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              StringTypeError,
-              0,
-              5,
-              0,
-              11,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          StringTypeError,
+          0,
+          5,
+          0,
+          11,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
   });
 
   describe('Null tests', () => {
-    it('Basic test on nodes with null', (done) => {
+    it('Basic test on nodes with null', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         additionalProperties: false,
@@ -702,17 +634,13 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'columns:\n  ColumnA: { int, id }\n  ColumnB: { long, unique }\n  ColumnC: { long, unique }';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
   });
 
   describe('Object tests', () => {
-    it('Basic test on nodes with children', (done) => {
+    it('Basic test on nodes with children', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -730,15 +658,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'scripts:\n  preinstall: test1\n  postinstall: test2';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Test with multiple nodes with children', (done) => {
+    it('Test with multiple nodes with children', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -762,15 +686,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'analytics: true\ncwd: this\nscripts:\n  preinstall: test1\n  postinstall: test2';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Type Object does not error on valid node', (done) => {
+    it('Type Object does not error on valid node', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -785,15 +705,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'registry:\n  search: file://test_url';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Error on incorrect value type (object)', (done) => {
+    it('Error on incorrect value type (object)', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         title: 'Object',
@@ -809,30 +725,26 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'scripts: test';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              'Incorrect type. Expected "object(Object)".',
-              0,
-              9,
-              0,
-              13,
-              DiagnosticSeverity.Error,
-              `yaml-schema: Object`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          'Incorrect type. Expected "object(Object)".',
+          0,
+          9,
+          0,
+          13,
+          DiagnosticSeverity.Error,
+          `yaml-schema: Object`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
   });
 
   describe('Array tests', () => {
-    it('Type Array does not error on valid node', (done) => {
+    it('Type Array does not error on valid node', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -845,15 +757,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'resolvers:\n  - test\n  - test\n  - test';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Error on incorrect value type (array)', (done) => {
+    it('Error on incorrect value type (array)', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -863,30 +771,26 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'resolvers: test';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              ArrayTypeError,
-              0,
-              11,
-              0,
-              15,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          ArrayTypeError,
+          0,
+          11,
+          0,
+          15,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
   });
 
   describe('Anchor tests', () => {
-    it('Anchor should not error', (done) => {
+    it('Anchor should not error', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -901,15 +805,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'default: &DEFAULT\n  name: Anchor\nanchor_test:\n  <<: *DEFAULT';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Anchor with multiple references should not error', (done) => {
+    it('Anchor with multiple references should not error', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -924,15 +824,11 @@ describe('Validation Tests', () => {
         },
       });
       const content = 'default: &DEFAULT\n  name: Anchor\nanchor_test:\n  <<: *DEFAULT\nanchor_test2:\n  <<: *DEFAULT';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Multiple Anchor in array of references should not error', (done) => {
+    it('Multiple Anchor in array of references should not error', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -948,12 +844,8 @@ describe('Validation Tests', () => {
       });
       const content =
         'default: &DEFAULT\n  name: Anchor\ncustomname: &CUSTOMNAME\n  custom_name: Anchor\nanchor_test:\n  <<: [*DEFAULT, *CUSTOMNAME]';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
     it('Multiple Anchors being referenced in same level at same time for yaml 1.1', async () => {
@@ -1031,7 +923,7 @@ describe('Validation Tests', () => {
       assert.strictEqual(validator.length, 0);
     });
 
-    it('Anchor reference with a validation error in a sub-object emits the error in the right location', (done) => {
+    it('Anchor reference with a validation error in a sub-object emits the error in the right location', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1056,29 +948,25 @@ describe('Validation Tests', () => {
         dest:
           <<: *src
       `;
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          // The key thing we're checking is *where* the validation error gets reported.
-          // "outer" isn't required to contain "otherkey" inside "src", but it is inside
-          // "dest". Since "outer" doesn't appear inside "dest" because of the alias, we
-          // need to move the error into "src".
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              MissingRequiredPropWarning.replace('{0}', 'otherkey'),
-              2,
-              10,
-              2,
-              15,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      // The key thing we're checking is *where* the validation error gets reported.
+      // "outer" isn't required to contain "otherkey" inside "src", but it is inside
+      // "dest". Since "outer" doesn't appear inside "dest" because of the alias, we
+      // need to move the error into "src".
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          MissingRequiredPropWarning.replace('{0}', 'otherkey'),
+          2,
+          10,
+          2,
+          15,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
 
     it('Array Anchor merge', async () => {
@@ -1146,7 +1034,7 @@ obj:
       );
     });
 
-    it('Custom Tags with type', (done) => {
+    it('Custom Tags with type', async () => {
       configureCustomTags(['!Ref sequence']);
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
@@ -1160,15 +1048,11 @@ obj:
         },
       });
       const content = 'resolvers: !Ref\n  - test';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Include with value should not error', (done) => {
+    it('Include with value should not error', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1178,23 +1062,15 @@ obj:
         },
       });
       const content = 'customize: !include customize.yaml';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Include without value should error', (done) => {
+    it('Include without value should error', async () => {
       const content = 'customize: !include';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(result[0], createExpectedError(IncludeWithoutValueError, 0, 11, 0, 19));
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], createExpectedError(IncludeWithoutValueError, 0, 11, 0, 19));
     });
 
     it('Custom Tags with return type validate against evaluated schema type', async () => {
@@ -1230,7 +1106,7 @@ obj:
   });
 
   describe('Multiple type tests', function () {
-    it('Do not error when there are multiple types in schema and theyre valid', (done) => {
+    it('Do not error when there are multiple types in schema and theyre valid', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1240,17 +1116,13 @@ obj:
         },
       });
       const content = 'license: MIT';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
   });
 
   describe('Invalid YAML errors', function () {
-    it('Error when theres a finished untyped item', (done) => {
+    it('Error when theres a finished untyped item', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1263,16 +1135,12 @@ obj:
         },
       });
       const content = 'cwd: hello\nan';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(result[0], createExpectedError(BlockMappingEntryError, 1, 0, 1, 2));
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], createExpectedError(BlockMappingEntryError, 1, 0, 1, 2));
     });
 
-    it('Error when theres no value for a node', (done) => {
+    it('Error when theres no value for a node', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1282,43 +1150,35 @@ obj:
         },
       });
       const content = 'cwd:';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(
-            result[0],
-            createDiagnosticWithData(
-              StringTypeError,
-              0,
-              4,
-              0,
-              4,
-              DiagnosticSeverity.Error,
-              `yaml-schema: file:///${SCHEMA_ID}`,
-              `file:///${SCHEMA_ID}`
-            )
-          );
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(
+        result[0],
+        createDiagnosticWithData(
+          StringTypeError,
+          0,
+          4,
+          0,
+          4,
+          DiagnosticSeverity.Error,
+          `yaml-schema: file:///${SCHEMA_ID}`,
+          `file:///${SCHEMA_ID}`
+        )
+      );
     });
   });
 
   describe('Test with no schemas', () => {
-    it('Duplicate properties are reported', (done) => {
+    it('Duplicate properties are reported', async () => {
       const content = 'kind: a\ncwd: b\nkind: c';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.deepEqual(result[0], createExpectedError(DuplicateKeyError, 2, 0, 2, 7));
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.deepEqual(result[0], createExpectedError(DuplicateKeyError, 2, 0, 2, 7));
     });
   });
 
   describe('Test anchors', function () {
-    it('Test that anchors with a schema do not report Property << is not allowed', (done) => {
+    it('Test that anchors with a schema do not report Property << is not allowed', async () => {
       const schema = {
         type: 'object',
         properties: {
@@ -1339,12 +1199,8 @@ obj:
       };
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'test: &test\n  prop1: hello\nsample:\n  <<: *test\n  prop2: another_test';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
   });
 
@@ -1353,7 +1209,7 @@ obj:
       languageSettingsSetup.languageSettings.schemas.pop();
       languageService.configure(languageSettingsSetup.languageSettings);
     });
-    it('Test that properties that match multiple enums get validated properly', (done) => {
+    it('Test that properties that match multiple enums get validated properly', async () => {
       languageService.configure(languageSettingsSetup.withKubernetes().languageSettings);
       yamlSettings.specificValidatorPaths = ['*.yml', '*.yaml'];
 
@@ -1389,13 +1245,9 @@ obj:
       };
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'kind: ';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 2);
-          assert.equal(result[1].message, `Value is not accepted. Valid values: "ImageStreamImport", "ImageStreamLayers".`);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 2);
+      assert.equal(result[1].message, `Value is not accepted. Valid values: "ImageStreamImport", "ImageStreamLayers".`);
     });
 
     it('does not report error for direct Kubernetes standalone-strict/all.json schema associations', async () => {
@@ -1467,7 +1319,7 @@ spec:
       }
     });
 
-    it('Test that it validates against the correct schema based on the GroupVersionKind', (done) => {
+    it('Test that it validates against the correct schema based on the GroupVersionKind', async () => {
       languageService.configure(
         languageSettingsSetup.withKubernetes().withSchemaFileMatch({ uri: KUBERNETES_SCHEMA_URL, fileMatch: ['*.yml', '*.yaml'] })
           .languageSettings
@@ -1492,20 +1344,16 @@ spec:
       target:
         type: Utilization
         averageUtilization: 80`;
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 1);
-          assert.equal(result[0].message, `Property foo is not allowed.`);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].message, `Property foo is not allowed.`);
     });
   });
 
   // https://github.com/redhat-developer/yaml-language-server/issues/118
   describe('Null literals', () => {
     ['NULL', 'Null', 'null', '~', ''].forEach((content) => {
-      it(`Test type null is parsed from [${content}]`, (done) => {
+      it(`Test type null is parsed from [${content}]`, async () => {
         const schema = {
           type: 'object',
           properties: {
@@ -1515,16 +1363,12 @@ spec:
           },
         };
         schemaProvider.addSchema(SCHEMA_ID, schema);
-        const validator = parseSetup('nulltest: ' + content);
-        validator
-          .then(function (result) {
-            assert.equal(result.length, 0);
-          })
-          .then(done, done);
+        const result = await parseSetup('nulltest: ' + content);
+        assert.equal(result.length, 0);
       });
     });
 
-    it('Test type null is working correctly in array', (done) => {
+    it('Test type null is working correctly in array', async () => {
       const schema = {
         properties: {
           values: {
@@ -1538,17 +1382,13 @@ spec:
       };
       schemaProvider.addSchema(SCHEMA_ID, schema);
       const content = 'values: [Null, NULL, null, ~,]';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
   });
 
   describe('Multi Document schema validation tests', () => {
-    it('Document does not error when --- is present with schema', (done) => {
+    it('Document does not error when --- is present with schema', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1558,15 +1398,11 @@ spec:
         },
       });
       const content = '---\n# this is a test\ncwd: this';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
 
-    it('Multi Document does not error when --- is present with schema', (done) => {
+    it('Multi Document does not error when --- is present with schema', async () => {
       schemaProvider.addSchema(SCHEMA_ID, {
         type: 'object',
         properties: {
@@ -1576,12 +1412,8 @@ spec:
         },
       });
       const content = '---\n# this is a test\ncwd: this...\n---\n# second comment\ncwd: hello\n...';
-      const validator = parseSetup(content);
-      validator
-        .then(function (result) {
-          assert.equal(result.length, 0);
-        })
-        .then(done, done);
+      const result = await parseSetup(content);
+      assert.equal(result.length, 0);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

The goal is to eventually move to the builtin Node.js test runner. This test runner uses a syntax very similar to Mocha, but it doesn’t provide a done callback. Instead, we must use promises.

Mocha also supports promises, so we can already rewrite the tests like that.

Also promise based tests just look nicer. :)

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

```sh
npm test
```
