### PR TITLE
Sarif ignore suppressed ESLint violations

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -51,6 +51,8 @@ jobs:
       - name: Generate SARIF
         if: matrix.os == 'ubuntu-latest'
         run: npm run lint-ci
+        env:
+          SARIF_ESLINT_IGNORE_SUPPRESSED: 'true'
 
       - name: Upload SARIF file
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
### What does this PR do?

By default `@microsoft/eslint-formatter-sarif` reports suppressed ESLint violations. This means that even if a local ESLint run or editor integration says there are no ESLint errors, CI still reports violations suppressed by ESLint comments.

Setting the `SARIF_ESLINT_IGNORE_SUPPRESSED` environment variables prevents this.

### What issues does this PR fix or reference?

N/A

### Is it tested? How?

GitHub Actions
