### PR TITLE
Fix: ignore modeline schema comment in the middle of file after yaml content

### DIFF
--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -28,6 +28,7 @@ export class SingleYAMLDocument extends JSONDocument {
   public root: ASTNode;
   public currentDocIndex: number;
   private _lineComments: string[];
+  private _documentHeaderComments: string[] = [];
 
   constructor(lineCounter?: LineCounter) {
     super(null, []);
@@ -44,6 +45,7 @@ export class SingleYAMLDocument extends JSONDocument {
     copy.uri = this.uri;
     copy.currentDocIndex = this.currentDocIndex;
     copy._lineComments = this.lineComments.slice();
+    copy._documentHeaderComments = this.documentHeaderComments.slice();
     // this will re-create root node
     copy.internalDocument = this._internalDocument.clone();
     return copy;
@@ -98,6 +100,12 @@ export class SingleYAMLDocument extends JSONDocument {
   }
   set lineComments(val: string[]) {
     this._lineComments = val;
+  }
+  get documentHeaderComments(): string[] {
+    return this._documentHeaderComments;
+  }
+  set documentHeaderComments(val: string[]) {
+    this._documentHeaderComments = val;
   }
   get errors(): YAMLDocDiagnostic[] {
     return this.internalDocument.errors.map(YAMLErrorToYamlDocDiagnostics);

--- a/src/languageservice/parser/yamlParser07.ts
+++ b/src/languageservice/parser/yamlParser07.ts
@@ -4,7 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import type { Document, ParseOptions, DocumentOptions, SchemaOptions } from 'yaml';
+import type { CST, Document, ParseOptions, DocumentOptions, SchemaOptions } from 'yaml';
 import { Parser, Composer, LineCounter } from 'yaml';
 import { YAMLDocument, SingleYAMLDocument } from './yaml-documents';
 import { getCustomTags } from './custom-tag-provider';
@@ -47,15 +47,55 @@ export function parse(text: string, parserOptions: ParserOptions = defaultOption
   const tokens = parser.parse(text);
   const tokensArr = Array.from(tokens);
   const docs = composer.compose(tokensArr, true, text.length);
+  const documentHeaderComments = getDocumentHeaderComments(tokensArr);
   // Generate the SingleYAMLDocs from the AST nodes
-  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc) => parsedDocToSingleYAMLDocument(doc, lineCounter));
+  const yamlDocs: SingleYAMLDocument[] = Array.from(docs, (doc, index) =>
+    parsedDocToSingleYAMLDocument(doc, lineCounter, documentHeaderComments[index] ?? [])
+  );
 
   // Consolidate the SingleYAMLDocs
   return new YAMLDocument(yamlDocs, tokensArr);
 }
 
-function parsedDocToSingleYAMLDocument(parsedDoc: Document, lineCounter: LineCounter): SingleYAMLDocument {
+function parsedDocToSingleYAMLDocument(
+  parsedDoc: Document,
+  lineCounter: LineCounter,
+  documentHeaderComments: string[]
+): SingleYAMLDocument {
   const syd = new SingleYAMLDocument(lineCounter);
+  syd.documentHeaderComments = documentHeaderComments;
   syd.internalDocument = parsedDoc;
   return syd;
+}
+
+function getDocumentHeaderComments(tokens: CST.Token[]): string[][] {
+  const documentHeaderComments: string[][] = [];
+  let pendingComments: string[] = [];
+
+  for (const token of tokens) {
+    if (token.type === 'comment') {
+      pendingComments.push(token.source);
+      continue;
+    }
+    if (token.type === 'newline' || token.type === 'space' || token.type === 'byte-order-mark' || token.type === 'directive') {
+      continue;
+    }
+    if (token.type === 'doc-end') {
+      pendingComments = [];
+      continue;
+    }
+    if (token.type === 'document') {
+      const startComments = token.start
+        .filter((startToken) => startToken.type === 'comment')
+        .map((startToken) => startToken.source);
+      documentHeaderComments.push([...pendingComments, ...startComments]);
+      pendingComments = [];
+      continue;
+    }
+    pendingComments = [];
+  }
+  if (pendingComments.length > 0) {
+    documentHeaderComments.push(pendingComments);
+  }
+  return documentHeaderComments;
 }

--- a/src/languageservice/services/modelineUtil.ts
+++ b/src/languageservice/services/modelineUtil.ts
@@ -13,11 +13,11 @@ import type { JSONDocument } from '../parser/jsonDocument';
  */
 export function getSchemaFromModeline(doc: SingleYAMLDocument | JSONDocument): string | undefined {
   if (doc instanceof SingleYAMLDocument) {
-    const yamlLanguageServerModeline = doc.lineComments.find((lineComment) => {
+    const yamlLanguageServerModeline = doc.documentHeaderComments.find((lineComment) => {
       return isModeline(lineComment);
     });
     if (yamlLanguageServerModeline != undefined) {
-      const schemaMatches = yamlLanguageServerModeline.match(/\$schema(?:=|:\s*)(\S+)/);
+      const schemaMatches = yamlLanguageServerModeline.match(/\$schema(?:=|:[^\S\r\n]*)(\S+)/);
       if (schemaMatches !== null && schemaMatches.length === 2) {
         return schemaMatches[1];
       }

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -19,7 +19,6 @@ import type { SettingsState } from '../src/yamlSettings';
 import { TextDocumentTestManager } from '../src/yamlSettings';
 import type { Diagnostic, MarkupContent } from 'vscode-languageserver-types';
 import { Position } from 'vscode-languageserver-types';
-import { LineCounter } from 'yaml';
 import { getSchemaFromModeline } from '../src/languageservice/services/modelineUtil';
 import { getGroupVersionKindFromDocument } from '../src/languageservice/services/k8sSchemaUtil';
 
@@ -1178,6 +1177,10 @@ address:
       checkReturnSchemaUrl('# yaml-language-server: $schema=expectedUrl', 'expectedUrl');
     });
 
+    it('simple $schema case', async () => {
+      checkReturnSchemaUrl('# $schema: expectedUrl', 'expectedUrl');
+    });
+
     it('with several spaces between # and yaml-language-server', async () => {
       checkReturnSchemaUrl('#    yaml-language-server: $schema=expectedUrl', 'expectedUrl');
     });
@@ -1221,9 +1224,31 @@ address:
       checkReturnSchemaUrl('# yaml-language-server: $notschema=url1', undefined);
     });
 
-    function checkReturnSchemaUrl(modeline: string, expectedResult: string): void {
-      const yamlDoc = new parser.SingleYAMLDocument(new LineCounter());
-      yamlDoc.lineComments = [modeline];
+    it('uses first modeline from initial comment block', async () => {
+      const yamlDoc = parser.parse('# first comment\n# yaml-language-server: $schema=expectedUrl\nfoo: bar').documents[0];
+      assert.strictEqual(getSchemaFromModeline(yamlDoc), 'expectedUrl');
+    });
+
+    it('uses first modeline when initial comment block has multiple modelines', async () => {
+      const yamlDoc = parser.parse(
+        '# first comment\n # second comment\n# yaml-language-server: $schema=expectedUrl\n# yaml-language-server: $schema=unexpectedUrl\nfoo: bar'
+      ).documents[0];
+      assert.strictEqual(getSchemaFromModeline(yamlDoc), 'expectedUrl');
+    });
+
+    it('no schema returned if modeline is in the middle of the file after yaml content', async () => {
+      checkReturnSchemaUrl('foo: bar\n# yaml-language-server: $schema=unexpectedUrl', undefined);
+    });
+
+    it('no schema returned from commented out $schema block after yaml content', async () => {
+      checkReturnSchemaUrl(
+        ['- title: test', '  output:', '    scores:', '      $lte: 0.3', '     # $schema:', '     #   type: array'].join('\n'),
+        undefined
+      );
+    });
+
+    function checkReturnSchemaUrl(modeline: string, expectedResult: string, documentIndex?: number): void {
+      const yamlDoc = parser.parse(modeline).documents[documentIndex ?? 0];
       assert.strictEqual(getSchemaFromModeline(yamlDoc), expectedResult);
     }
   });

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -491,24 +491,56 @@ describe('YAML Schema Service', () => {
       expect(schemaUris.some((uri) => uri.startsWith('schemaservice:///'))).to.be.false;
     });
 
-    it('should handle modeline schema comment in the middle of file', () => {
+    it('should ignore modeline schema comment in the middle of file after yaml content', async () => {
       const documentContent = `foo:\n  bar\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
       const content = `${documentContent}`;
       const yamlDock = parse(content);
 
       const service = new SchemaService.YAMLSchemaService(requestServiceMock);
-      service.getSchemaForResource('', yamlDock.documents[0]);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).not.called;
+    });
+
+    it('should ignore modeline schema comment using $schema in the middle of file after yaml content', async () => {
+      const documentContent = `foo:\n  bar\n# $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const content = `${documentContent}`;
+      const yamlDock = parse(content);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).not.called;
+    });
+
+    it('should handle modeline schema comment in multiline comments at document header', async () => {
+      const documentContent = `#first comment\n# second comment\n\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const content = `${documentContent}`;
+      const yamlDock = parse(content);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
 
       expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });
 
-    it('should handle modeline schema comment in multiline comments', () => {
+    it('should ignore modeline schema comment in multiline comments after yaml content', async () => {
       const documentContent = `foo:\n  bar\n#first comment\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
       const content = `${documentContent}`;
       const yamlDock = parse(content);
 
       const service = new SchemaService.YAMLSchemaService(requestServiceMock);
-      service.getSchemaForResource('', yamlDock.documents[0]);
+      await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(requestServiceMock).not.called;
+    });
+
+    it('should handle modeline schema comment after document separator', () => {
+      const documentContent = `foo:\n  bar\n---\n# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#\naa:bbb\n`;
+      const yamlDock = parse(documentContent);
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      service.getSchemaForResource('', yamlDock.documents[1]);
 
       expect(requestServiceMock).calledOnceWith('https://json-schema.org/draft-07/schema#');
     });


### PR DESCRIPTION
### What does this PR do?
Modeline schema comment should only be supported in the document header comment.

Ignore modeline schema comment if it is in the middle of file after yaml content, e.g.
```yaml
foo:
  bar
# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#
aa:bbb
```
or
```yaml
foo:
  bar
# $schema=https://json-schema.org/draft-07/schema#
aa:bbb
```

Modeline schema comment in multiline comments at document header is still handled, e.g.
```yaml
# foo:
#   bar
# yaml-language-server: $schema=https://json-schema.org/draft-07/schema#
aa:bbb
```

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/vscode-yaml/issues/1260

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Tested manaully