### PR TITLE
Fix: `yaml/get/all/jsonSchemas` returns schema association declared with inline `$schema`

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -516,6 +516,11 @@ export class YAMLSchemaService implements IJSONSchemaService {
       return [modelineSchema];
     }
 
+    const dollarSchema = this.resolveDollarSchema(resource, doc);
+    if (dollarSchema) {
+      return [dollarSchema];
+    }
+
     if (this.customSchemaProvider) {
       try {
         const schemaUri = await this.customSchemaProvider(resource);

--- a/test/schemaSelectionHandlers.test.ts
+++ b/test/schemaSelectionHandlers.test.ts
@@ -100,6 +100,49 @@ describe('Schema Selection Handlers', () => {
     });
   });
 
+  it('getSchemas should return an inline $schema', async () => {
+    const schemaUri = 'https://some.com/inline.json';
+    requestServiceMock = sandbox.fake((uri: string) => {
+      if (uri === schemaUri) {
+        return Promise.resolve(
+          JSON.stringify({
+            title: 'Schema name',
+            type: 'object',
+            properties: {
+              $schema: {
+                type: 'string',
+              },
+              firstName: {
+                type: 'string',
+              },
+            },
+            required: ['firstName'],
+            additionalProperties: false,
+          })
+        );
+      }
+      return Promise.reject(`Resource ${uri} not found.`);
+    });
+    service = new YAMLSchemaService(requestServiceMock);
+    const settings = new SettingsState();
+    const testTextDocument = setupSchemaIDTextDocument(`firstName: John\n$schema: ${schemaUri}`);
+    settings.documents = new TextDocumentTestManager();
+    (settings.documents as TextDocumentTestManager).set(testTextDocument);
+    const selection = new JSONSchemaSelection(service, settings, connection);
+
+    const result = await selection.getSchemas(testTextDocument.uri);
+
+    expect(result).to.eql([
+      {
+        uri: schemaUri,
+        name: 'Schema name',
+        description: undefined,
+        versions: undefined,
+      },
+    ]);
+    expect(requestServiceMock).calledOnceWith(schemaUri);
+  });
+
   it('getSchemas should not resolve schema references', async () => {
     requestServiceMock = sandbox.fake((uri: string) => {
       if (uri === 'https://some.com/some.json') {


### PR DESCRIPTION
### What does this PR do?

Fix: update `yaml/get/all/jsonSchemas` API when a schema is declared via inline `$schema` obejct

### What issues does this PR fix or reference?
Fixes a bug from https://github.com/redhat-developer/yaml-language-server/pull/970

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Tested manually with https://github.com/redhat-developer/vscode-yaml/pull/1263