### PR TITLE
Fix fileMatch single-star glob matching across directories

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -209,7 +209,6 @@ export class FilePatternAssociation {
         .filter((p) => p.length > 0);
 
       this.isMatch = picomatch(processedPatterns, {
-        bash: true,
         noglobstar: false,
       });
 

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -896,5 +896,17 @@ spec:
       const nestedConfigUris = service.getSchemaURIsForResource('nested/repo/.github/ISSUE_TEMPLATE/config.yml');
       expect(nestedConfigUris).to.not.include('https://json.schemastore.org/github-issue-forms.json');
     });
+
+    it('should not match a single star across path separators', () => {
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      const playbookSchemaUri = 'https://json.schemastore.org/ansible-playbook.json';
+      service.registerExternalSchema(playbookSchemaUri, ['**/playbooks/*.yml'], {});
+
+      const playbookUris = service.getSchemaURIsForResource('project/playbooks/site.yml');
+      expect(playbookUris).to.include(playbookSchemaUri);
+
+      const roleTaskUris = service.getSchemaURIsForResource('project/playbooks/roles/demo/tasks/main.yml');
+      expect(roleTaskUris).to.not.include(playbookSchemaUri);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
The configured picomatch with `bash: true` makes a single `*` behave like `**` and match across directory separators.
Removed `bash: true` so `*` only matches within one directory level.

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1295

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] Existing tests
- [x] Manually tested with the case reported in https://github.com/redhat-developer/yaml-language-server/issues/1295
- [x] Added a test covering direct and nested paths