### PR TITLE
Prepare for OIDC authentication for publishing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,7 +11,8 @@ on:
     branches: [main]
 
 permissions:
-    contents: read
+  id-token: write  # Required for OIDC
+  contents: read
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
     tags:
       - '*'
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
### What does this PR do?
Adds the necessary permissions to the GitHub Actions to authenticate using OIDC, so that we can switch over authentication for publishing to NPM over to OIDC.

### What issues does this PR fix or reference?
Fixes #1292

### Is it tested? How?
Nope, we'll have to try it once we have OIDC set up.