### PR TITLE
fix: do not depend on specific working dir within container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM node:lts
 
-WORKDIR /yaml-language-server
+COPY . /yaml-language-server
 
-COPY . .
-
-RUN npm install && \
+RUN cd /yaml-language-server && \
+    npm install && \
     npm run build
 
-ENTRYPOINT [ "node", "./out/server/src/server.js" ]
+ENTRYPOINT [ "node", "/yaml-language-server/out/server/src/server.js" ]
 CMD [ "--stdio" ]


### PR DESCRIPTION
### What does this PR do?
It replaces the relative path within the `ENTRYPOINT` instruction with a absolute one and removes the `WORKDIR`.

### What issues does this PR fix or reference?
None

### Is it tested? How?
I use the container image with a patched `ENTRYPOINT` and set `--workdir` on command line for quite some time without issues.
