### PR TITLE
(Hopefully) fix OIDC publishing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,10 +30,10 @@ jobs:
       - uses: actions/checkout@v7
 
       # Set up Node
-      - name: Use Node 20
-        uses: actions/setup-node@v5
+      - name: Use Node 22
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       # Run install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,11 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Use Node 20
-      uses: actions/setup-node@v5
+      # Set up Node
+    - name: Use Node 22
+      uses: actions/setup-node@v7
       with:
-        node-version: 20
+        node-version: 22
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@microsoft/eslint-formatter-sarif": "^3.0.0",
         "@types/chai": "^4.2.12",
         "@types/mocha": "8.2.2",
-        "@types/node": "18.x",
+        "@types/node": "22.x",
         "@types/picomatch": "^4.0.3",
         "@types/sinon": "^9.0.5",
         "@types/sinon-chai": "^3.2.5",
@@ -1332,13 +1332,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.119",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.119.tgz",
-      "integrity": "sha512-d0F6m9itIPaKnrvEMlzE48UjwZaAnFW7Jwibacw9MNdqadjKNpUm9tfJYDwmShJmgqcoqYUX3EMKO1+RWiuuNg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/picomatch": {
@@ -1758,9 +1758,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1775,9 +1772,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1792,9 +1786,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1809,9 +1800,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1826,9 +1814,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1843,9 +1828,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1860,9 +1842,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1877,9 +1856,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1894,9 +1870,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1911,9 +1884,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5777,9 +5747,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@microsoft/eslint-formatter-sarif": "^3.0.0",
     "@types/chai": "^4.2.12",
     "@types/mocha": "8.2.2",
-    "@types/node": "18.x",
+    "@types/node": "22.x",
     "@types/picomatch": "^4.0.3",
     "@types/sinon": "^9.0.5",
     "@types/sinon-chai": "^3.2.5",


### PR DESCRIPTION
### What does this PR do?
- I upgraded to Node 22. Node 22 needs to be used for trusted publishing (see https://docs.npmjs.com/trusted-publishers). It's also the oldest supported version (see https://endoflife.date/nodejs).
- Upgrade setup-node to v7 (see https://github.com/orgs/community/discussions/176761#discussioncomment-15064682)

### What issues does this PR fix or reference?
The publishing job is failing, this hopefully fixes it.

### Is it tested? How?
Kinda hard to...
