### PR TITLE
Use npm 12 to fix OIDC publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,9 @@ jobs:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Use npm 12
+      run: npm install npm@^12
+
     - name: Install dependencies
       run: npm ci
 
@@ -88,6 +91,9 @@ jobs:
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
+
+    - name: Use npm 12
+      run: npm install npm@^12
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
### What does this PR do?
This PR updates the release build to use npm v12.

OIDC publishing support wasn't added to npm until 11.5.1, but GitHub Actions uses 10.9.8 as of now.
Version 12 is the latest major release and supports Node 22, so we might as well update to it.

### What issues does this PR fix or reference?
Publishing (hopefully)

### Is it tested? How?
No