### PR TITLE
Improve handling of schemas written using YAML

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -1702,17 +1702,8 @@ export class YAMLSchemaService implements IJSONSchemaService {
     return this.getAssociatedSchemas(resource);
   }
 
-  private async loadJSONSchema(url: string): Promise<UnresolvedSchema> {
-    if (!this.requestService) {
-      const errorMessage = l10n.t("Unable to load schema from '{0}'. No schema request service available", toDisplayString(url));
-      return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, url)]);
-    }
+  private async loadJSONSchema(url: string, content: string): Promise<UnresolvedSchema> {
     try {
-      let content = await this.requestService(url);
-      if (!content) {
-        const errorMessage = l10n.t("Unable to load schema from '{0}': No content.", toDisplayString(url));
-        return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, url)]);
-      }
       const errors = [];
       if (content.charCodeAt(0) === 65279) {
         errors.push(
@@ -1754,51 +1745,97 @@ export class YAMLSchemaService implements IJSONSchemaService {
     }
   }
 
+  async loadYAMLSchema(url: string, content: string): Promise<UnresolvedSchema> {
+    try {
+      try {
+        const schemaContent = parse(content);
+        return new UnresolvedSchema(schemaContent, []);
+      } catch (yamlError) {
+        const errorMessage = l10n.t("Unable to parse content from '{0}': {1}.", toDisplayString(url), yamlError);
+        return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, url)]);
+      }
+    } catch (error) {
+      let errorMessage = error.toString();
+      const errorSplit = error.toString().split('Error: ');
+      if (errorSplit.length > 1) {
+        // more concise error message, URL and context are attached by caller anyways
+        errorMessage = errorSplit[1];
+      }
+      return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, url)]);
+    }
+  }
+
   async loadSchema(schemaUri: string): Promise<UnresolvedSchema> {
     const requestService = this.requestService;
-    const unresolvedJsonSchema = await this.loadJSONSchema(schemaUri);
-    // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
-    // If the YAML file starts with %YAML 1.x or contains a comment with a number the schema will
-    // contain a number instead of being undefined, so we need to check for that too.
-    if (
-      unresolvedJsonSchema.errors &&
-      (unresolvedJsonSchema.schema === undefined || typeof unresolvedJsonSchema.schema === 'number')
-    ) {
+    let probablyYaml = false;
+    try {
+      const extension = path.extname(URI.parse(schemaUri).path);
+      probablyYaml = extension === '.yaml' || extension === '.yml';
+    } catch {
+      // url parse or path parse error; do nothing
+    }
+
+    let unresolvedSchema: UnresolvedSchema;
+    if (!requestService) {
+      const errorMessage = l10n.t(
+        "Unable to load schema from '{0}'. No schema request service available",
+        toDisplayString(schemaUri)
+      );
+      unresolvedSchema = new UnresolvedSchema(<JSONSchema>{}, [
+        toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, schemaUri),
+      ]);
+    } else {
+      let content = undefined;
+      let caughtError = undefined;
       try {
-        const content = await requestService(schemaUri);
-        if (!content) {
-          const errorMessage = l10n.t(
-            "Unable to load schema from '{0}': No content. {1}",
-            toDisplayString(schemaUri),
-            unresolvedJsonSchema.errors.map((error) => error.message).join(', ')
-          );
-          return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, schemaUri)]);
+        content = await this.requestService(schemaUri);
+      } catch (e) {
+        caughtError = e;
+      }
+      if (!content) {
+        if (caughtError) {
+          let message = typeof caughtError.message === 'string' ? caughtError.message : caughtError.toString();
+          const { code } = caughtError;
+          const errorSplit = message.split('Error: ');
+          if (errorSplit.length > 1) {
+            // more concise error message, URL and context are attached by caller anyways
+            message = errorSplit[1];
+          }
+          if (message.endsWith('.')) {
+            message = message.slice(0, -1);
+          }
+          const errorCode = ErrorCode.SchemaResolveError + (typeof code === 'number' && code < 0x10000 ? code : 0);
+          const errorMessage = l10n.t("Unable to load schema from '{0}': {1}.", toDisplayString(schemaUri), message);
+          unresolvedSchema = new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, errorCode, schemaUri)]);
+        } else {
+          const errorMessage = l10n.t("Unable to load schema from '{0}': No content.", toDisplayString(schemaUri));
+          unresolvedSchema = new UnresolvedSchema(<JSONSchema>{}, [
+            toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, schemaUri),
+          ]);
         }
-        try {
-          const schemaContent = parse(content);
-          return new UnresolvedSchema(schemaContent, []);
-        } catch (yamlError) {
-          const errorMessage = l10n.t("Unable to parse content from '{0}': {1}.", toDisplayString(schemaUri), yamlError);
-          return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, schemaUri)]);
+      } else {
+        if (!probablyYaml) {
+          unresolvedSchema = await this.loadJSONSchema(schemaUri, content);
+          // If json-language-server failed to parse the schema, attempt to parse it as YAML instead.
+          // If the YAML file starts with %YAML 1.x or contains a comment with a number the schema will
+          // contain a number instead of being undefined, so we need to check for that too.
+          if (unresolvedSchema.errors && (unresolvedSchema.schema === undefined || typeof unresolvedSchema.schema === 'number')) {
+            unresolvedSchema = await this.loadYAMLSchema(schemaUri, content);
+          }
+        } else {
+          unresolvedSchema = await this.loadYAMLSchema(schemaUri, content);
         }
-      } catch (error) {
-        let errorMessage = error.toString();
-        const errorSplit = error.toString().split('Error: ');
-        if (errorSplit.length > 1) {
-          // more concise error message, URL and context are attached by caller anyways
-          errorMessage = errorSplit[1];
-        }
-        return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, ErrorCode.SchemaResolveError, schemaUri)]);
       }
     }
-    unresolvedJsonSchema.uri = schemaUri;
+
+    unresolvedSchema.uri = schemaUri;
     if (this.schemaUriToNameAndDescription.has(schemaUri)) {
       const { name, description, versions } = this.schemaUriToNameAndDescription.get(schemaUri);
-      unresolvedJsonSchema.schema.title = name ?? unresolvedJsonSchema.schema.title;
-      unresolvedJsonSchema.schema.description = description ?? unresolvedJsonSchema.schema.description;
-      unresolvedJsonSchema.schema.versions = versions ?? unresolvedJsonSchema.schema.versions;
-    } else if (unresolvedJsonSchema.errors && unresolvedJsonSchema.errors.length > 0) {
-      const schemaError = unresolvedJsonSchema.errors[0];
+      unresolvedSchema.schema.title = name ?? unresolvedSchema.schema.title;
+      unresolvedSchema.schema.description = description ?? unresolvedSchema.schema.description;
+      unresolvedSchema.schema.versions = versions ?? unresolvedSchema.schema.versions;
+    } else if (unresolvedSchema.errors && unresolvedSchema.errors.length > 0) {
+      const schemaError = unresolvedSchema.errors[0];
       let errorMessage = schemaError.message;
       if (errorMessage.toLowerCase().indexOf('load') !== -1) {
         errorMessage = l10n.t("Unable to load schema from '{0}': No content.", toDisplayString(schemaUri));
@@ -1819,7 +1856,7 @@ export class YAMLSchemaService implements IJSONSchemaService {
       }
       return new UnresolvedSchema(<JSONSchema>{}, [toDiagnostic(errorMessage, schemaError.code, schemaUri)]);
     }
-    return unresolvedJsonSchema;
+    return unresolvedSchema;
   }
 
   registerExternalSchema(

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -2,16 +2,18 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as sinon from 'sinon';
 import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
+import * as JSONC from 'jsonc-parser';
 import * as path from 'path';
+import * as sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import * as url from 'url';
-import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
-import { parse } from '../src/languageservice/parser/yamlParser07';
-import { SettingsState } from '../src/yamlSettings';
-import { DEFAULT_KUBERNETES_SCHEMA_VERSION, getSchemaUrls } from '../src/languageservice/utils/schemaUrls';
+import * as YAML from 'yaml';
 import type { JSONSchema } from '../src/languageservice/jsonSchema';
+import { parse } from '../src/languageservice/parser/yamlParser07';
+import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
+import { DEFAULT_KUBERNETES_SCHEMA_VERSION, getSchemaUrls } from '../src/languageservice/utils/schemaUrls';
+import { SettingsState } from '../src/yamlSettings';
 
 const BASE_KUBERNETES_SCHEMA_URL = `https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${DEFAULT_KUBERNETES_SCHEMA_VERSION}-standalone-strict/`;
 const KUBERNETES_SCHEMA_URL = BASE_KUBERNETES_SCHEMA_URL + 'all.json';
@@ -907,6 +909,120 @@ spec:
 
       const roleTaskUris = service.getSchemaURIsForResource('project/playbooks/roles/demo/tasks/main.yml');
       expect(roleTaskUris).to.not.include(playbookSchemaUri);
+    });
+
+    it('should only request the content of a YAML schema once', async () => {
+      const content = `# yaml-language-server: $schema=file:///dir/my-schema.yaml\nname: John\nage: -1`;
+      const yamlDock = parse(content);
+
+      const mySchema = {
+        $id: 'https://example.com/schemas/my-schema.yaml',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer', minimum: 0 },
+        },
+        required: ['name', 'age'],
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'file:///dir/my-schema.yaml') {
+          return Promise.resolve(YAML.stringify(mySchema));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      const resolvedSchema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.include('file:///dir/my-schema.yaml');
+      expect(requestedUris.length).to.equal(1);
+      expect(resolvedSchema.errors.length).to.equal(0);
+    });
+
+    it('should match a schema written in YAML that parses incorrectly as JSON', async () => {
+      const content = `# yaml-language-server: $schema=file:///dir/my-schema.yaml\nname: John\nage: -1`;
+      const yamlDock = parse(content);
+
+      const mySchema = `
+---
+"$id": https://github.com/apis-json/api-json/blob/develop/spec/
+"$schema": https://json-schema.org/draft/2020-12/schema
+title: JSON Schema for APIs.json 0.21
+type: object
+additionalProperties: false
+patternProperties:
+  "^X-":
+    type: object
+
+$defs:
+  contact:
+    description: Information on contacting the API support
+    required:
+    - FN
+    additionalProperties: true
+    patternProperties:
+      "^X-":
+        type: string
+    properties:
+      FN:
+        type: string
+        minLength: 1
+      email:
+        type: string
+        format: email
+      organizationName:
+        type: string
+        minLength: 1
+      adr:
+        type: string
+      tel:
+        type: string
+        minLength: 1
+      X-twitter:
+        type: string
+      X-github:
+        type: string
+      photo:
+        type: string
+        pattern: "^(http)|(https)://(.*)$"
+      vCard:
+        type: string
+        pattern: "^(http)|(https)://(.*)$"
+      url:
+        type: string
+        pattern: "^(http)|(https)://(.*)$"
+
+required:
+- maintainers
+
+properties:
+  maintainers:
+    type: array
+    items:
+      "$ref": "#/$defs/contact"
+    description: Maintainers of the apis.json file`;
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'file:///dir/my-schema.yaml') {
+          return Promise.resolve(mySchema);
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      const resolvedSchema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+
+      const errors = [];
+      const parsedSchema = JSONC.parse(mySchema, errors);
+      expect(errors.length).to.be.greaterThan(0);
+      expect(typeof parsedSchema === 'string');
+      expect(requestedUris).to.include('file:///dir/my-schema.yaml');
+      expect(requestedUris.length).to.equal(1);
+      expect(resolvedSchema.errors.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
- Use the file extension of the schema to determine if the schema was written using JSON or YAML
- Refactor the schema resolution logic to be a bit simpler
  - Avoid requesting the content twice

### What issues does this PR fix or reference?
Fixes redhat-developer/vscode-yaml#1275

### Is it tested? How?
- [x] Unit tests