### PR TITLE
Fix Kubernetes schema priority after resource-specific schema resolution

### DIFF
--- a/src/languageservice/services/k8sSchemaUtil.ts
+++ b/src/languageservice/services/k8sSchemaUtil.ts
@@ -28,6 +28,10 @@ export function autoDetectKubernetesSchema(
   if (builtinResource) {
     return builtinResource;
   }
+  // core resources cannot be CRDs: fall back to all.json for unknown core kinds
+  if (gvk.group === 'core') {
+    return undefined;
+  }
   const customResource = autoDetectCustomResource(gvk, crdCatalogURI);
   if (customResource) {
     return customResource;
@@ -115,7 +119,8 @@ export function getGroupVersionKindFromDocument(doc: SingleYAMLDocument | JSONDo
         return undefined;
       }
 
-      const [group, version] = groupVersion.split('/');
+      const groupVersionParts = groupVersion.split('/');
+      const [group, version] = groupVersionParts.length === 1 ? ['core', groupVersionParts[0]] : groupVersionParts;
       if (!group || !version) {
         return undefined;
       }

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -31,7 +31,10 @@ export class YamlCodeLens {
 
         const schemaUrls = getSchemaUrls(schema.schema);
         const documentOffset = currentYAMLDoc.root?.offset ?? currentYAMLDoc.internalDocument?.range?.[0] ?? 0;
-        const documentPosition = document.positionAt(documentOffset);
+        let documentPosition = document.positionAt(documentOffset);
+        if (currentYAMLDoc.root?.length === 0 && documentPosition.character > 0) {
+          documentPosition = { line: documentPosition.line + 1, character: 0 };
+        }
         const documentRange = Range.create(documentPosition, documentPosition);
 
         for (const urlToSchema of schemaUrls) {

--- a/src/languageservice/services/yamlCodeLens.ts
+++ b/src/languageservice/services/yamlCodeLens.ts
@@ -8,7 +8,6 @@ import { CodeLens, Range } from 'vscode-languageserver-types';
 import { YamlCommands } from '../../commands';
 import { yamlDocumentsCache } from '../parser/yaml-documents';
 import type { YAMLSchemaService } from './yamlSchemaService';
-import type { JSONSchema } from '../jsonSchema';
 import type { Telemetry } from '../telemetry';
 import { getSchemaUrls } from '../utils/schemaUrls';
 import { getSchemaTitle } from '../utils/schemaUtils';
@@ -23,22 +22,27 @@ export class YamlCodeLens {
     const result = [];
     try {
       const yamlDocument = yamlDocumentsCache.getYamlDocument(document);
-      let schemaUrls = new Map<string, JSONSchema>();
-      for (const currentYAMLDoc of yamlDocument.documents) {
+      for (const [index, currentYAMLDoc] of yamlDocument.documents.entries()) {
+        currentYAMLDoc.currentDocIndex = index;
         const schema = await this.schemaService.getSchemaForResource(document.uri, currentYAMLDoc);
-        if (schema?.schema) {
-          // merge schemas from all docs to avoid duplicates
-          schemaUrls = new Map([...getSchemaUrls(schema?.schema), ...schemaUrls]);
+        if (!schema?.schema) {
+          continue;
         }
-      }
-      for (const urlToSchema of schemaUrls) {
-        const lens = CodeLens.create(Range.create(0, 0, 0, 0));
-        lens.command = {
-          title: getSchemaTitle(urlToSchema[1], urlToSchema[0]),
-          command: YamlCommands.JUMP_TO_SCHEMA,
-          arguments: [urlToSchema[0]],
-        };
-        result.push(lens);
+
+        const schemaUrls = getSchemaUrls(schema.schema);
+        const documentOffset = currentYAMLDoc.root?.offset ?? currentYAMLDoc.internalDocument?.range?.[0] ?? 0;
+        const documentPosition = document.positionAt(documentOffset);
+        const documentRange = Range.create(documentPosition, documentPosition);
+
+        for (const urlToSchema of schemaUrls) {
+          const lens = CodeLens.create(documentRange);
+          lens.command = {
+            title: getSchemaTitle(urlToSchema[1], urlToSchema[0]),
+            command: YamlCommands.JUMP_TO_SCHEMA,
+            arguments: [urlToSchema[0]],
+          };
+          result.push(lens);
+        }
       }
     } catch (err) {
       this.telemetry?.sendError('yaml.codeLens.error', err);

--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -124,6 +124,11 @@ interface SchemaStoreSchema {
   versions?: SchemaVersions;
 }
 
+interface SchemaCandidate {
+  uri: string;
+  prioritySource: string;
+}
+
 export interface IJSONSchemaService {
   /**
    * Clears all cached schema files
@@ -506,6 +511,35 @@ export class YAMLSchemaService implements IJSONSchemaService {
     }
   }
 
+  private async getSchemaCandidatesForResource(resource: string, doc: JSONDocument): Promise<SchemaCandidate[]> {
+    const seen = new Set<string>();
+    const candidates: SchemaCandidate[] = [];
+    for (const entry of this.filePatternAssociations) {
+      if (entry.matchesPattern(resource)) {
+        for (const schemaId of entry.getURIs()) {
+          if (!seen.has(schemaId)) {
+            let schemaUri = schemaId;
+            if (this.yamlSettings?.kubernetesCRDStoreEnabled && isKubernetes(schemaId)) {
+              const kubernetesSchema = await this.getResolvedSchema(schemaId);
+              if (kubernetesSchema) {
+                schemaUri =
+                  autoDetectKubernetesSchema(
+                    doc,
+                    kubernetesSchema,
+                    schemaId,
+                    this.yamlSettings.kubernetesCRDStoreUrl ?? CRD_CATALOG_URL
+                  ) ?? schemaId;
+              }
+            }
+            candidates.push({ uri: schemaUri, prioritySource: schemaId });
+            seen.add(schemaId);
+          }
+        }
+      }
+    }
+    return candidates;
+  }
+
   private async getSchemaIdsForResource(resource: string, doc: JSONDocument): Promise<string[]> {
     const modelineSchema = this.resolveModelineSchema(resource, doc);
     if (modelineSchema) {
@@ -535,20 +569,8 @@ export class YAMLSchemaService implements IJSONSchemaService {
       }
     }
 
-    const seen: { [schemaId: string]: boolean } = Object.create(null);
-    const schemas: string[] = [];
-    for (const entry of this.filePatternAssociations) {
-      if (entry.matchesPattern(resource)) {
-        for (const schemaId of entry.getURIs()) {
-          if (!seen[schemaId]) {
-            schemas.push(schemaId);
-            seen[schemaId] = true;
-          }
-        }
-      }
-    }
-
-    return schemas.length > 0 ? this.highestPrioritySchemas(schemas) : [];
+    const candidates = await this.getSchemaCandidatesForResource(resource, doc);
+    return this.highestPrioritySchemas(candidates);
   }
 
   public async getSchemaDescriptionsForResource(resource: string, doc: JSONDocument): Promise<JSONSchemaDescription[]> {
@@ -1390,51 +1412,13 @@ export class YAMLSchemaService implements IJSONSchemaService {
       return this.finalizeResolvedSchema(schema, schemaHandle.uri, doc, false);
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const resolveSchema = async (): Promise<any> => {
-      const seen: { [schemaId: string]: boolean } = Object.create(null);
-      const schemas: string[] = [];
-      let k8sAllSchema: ResolvedSchema = undefined;
-      let k8sSchemaUrl: string | undefined = undefined;
-
-      for (const entry of this.filePatternAssociations) {
-        if (entry.matchesPattern(resource)) {
-          for (const schemaId of entry.getURIs()) {
-            if (!seen[schemaId]) {
-              if (this.yamlSettings?.kubernetesCRDStoreEnabled && isKubernetes(schemaId)) {
-                if (!k8sAllSchema) {
-                  k8sSchemaUrl = schemaId;
-                  k8sAllSchema = await this.getResolvedSchema(schemaId);
-                }
-                const kubeSchema = autoDetectKubernetesSchema(
-                  doc,
-                  k8sAllSchema,
-                  k8sSchemaUrl ?? schemaId,
-                  this.yamlSettings.kubernetesCRDStoreUrl ?? CRD_CATALOG_URL
-                );
-                if (kubeSchema) {
-                  schemas.push(kubeSchema);
-                  seen[schemaId] = true;
-                } else {
-                  schemas.push(schemaId);
-                  seen[schemaId] = true;
-                }
-              } else {
-                schemas.push(schemaId);
-                seen[schemaId] = true;
-              }
-            }
-          }
-        }
-      }
-
+    const resolveSchema = async (): Promise<ResolvedSchema> => {
+      const candidates = await this.getSchemaCandidatesForResource(resource, doc);
+      const schemas = this.highestPrioritySchemas(candidates);
       if (schemas.length > 0) {
-        // Join all schemas with the highest priority.
-        const highestPrioSchemas = this.highestPrioritySchemas(schemas);
-        return resolveSchemaForResource(highestPrioSchemas);
+        return resolveSchemaForResource(schemas);
       }
-
-      return Promise.resolve(null);
+      return null;
     };
     const modelineSchema = this.resolveModelineSchema(resource, doc);
     if (modelineSchema) {
@@ -1511,12 +1495,12 @@ export class YAMLSchemaService implements IJSONSchemaService {
   /**
    * Search through all the schemas and find the ones with the highest priority
    */
-  private highestPrioritySchemas(schemas: string[]): string[] {
+  private highestPrioritySchemas(candidates: SchemaCandidate[]): string[] {
     let highestPrio = 0;
     const priorityMapping = new Map<SchemaPriority, string[]>();
-    schemas.forEach((schema) => {
+    candidates.forEach((candidate) => {
       // If the schema does not have a priority then give it a default one of [0]
-      const priority = this.schemaPriorityMapping.get(schema) || [0];
+      const priority = this.schemaPriorityMapping.get(candidate.prioritySource) || [0];
       priority.forEach((prio) => {
         if (prio > highestPrio) {
           highestPrio = prio;
@@ -1525,10 +1509,10 @@ export class YAMLSchemaService implements IJSONSchemaService {
         // Build up a mapping of priority to schemas so that we can easily get the highest priority schemas easier
         let currPriorityArray = priorityMapping.get(prio);
         if (currPriorityArray) {
-          currPriorityArray = (currPriorityArray as string[]).concat(schema);
+          currPriorityArray = (currPriorityArray as string[]).concat(candidate.uri);
           priorityMapping.set(prio, currPriorityArray);
         } else {
-          priorityMapping.set(prio, [schema]);
+          priorityMapping.set(prio, [candidate.uri]);
         }
       });
     });

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -47,9 +47,11 @@ export function getSchemaTitle(schema: JSONSchema, url: string): string {
   const uri = URI.parse(url);
   const baseName = path.basename(uri.fsPath);
   const fragmentName = uri.fragment.split('/').filter(Boolean).pop();
-  const kubernetesVersion = uri.path.match(/\/(v\d+\.\d+\.\d+)-standalone-strict\/_definitions\.json$/)?.[1];
-  if (fragmentName && kubernetesVersion) {
-    return `${fragmentName.split('.').pop()} (Kubernetes ${kubernetesVersion})`;
+  const kubernetesVersion = uri.path.match(/\/(v\d+\.\d+\.\d+)-standalone-strict\/(?:_definitions|all)\.json$/)?.[1];
+  if (kubernetesVersion) {
+    return fragmentName
+      ? `${fragmentName.split('.').pop()} (Kubernetes ${kubernetesVersion})`
+      : `Kubernetes ${kubernetesVersion}`;
   }
   if (Object.getOwnPropertyDescriptor(schema, 'name')) {
     return Object.getOwnPropertyDescriptor(schema, 'name').value + ` (${baseName})`;

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -45,9 +45,11 @@ export function getSchemaRefTypeTitle($ref: string): string {
 
 export function getSchemaTitle(schema: JSONSchema, url: string): string {
   const uri = URI.parse(url);
-  let baseName = path.basename(uri.fsPath);
-  if (!path.extname(uri.fsPath)) {
-    baseName += '.json';
+  const baseName = path.basename(uri.fsPath);
+  const fragmentName = uri.fragment.split('/').filter(Boolean).pop();
+  const kubernetesVersion = uri.path.match(/\/(v\d+\.\d+\.\d+)-standalone-strict\/_definitions\.json$/)?.[1];
+  if (fragmentName && kubernetesVersion) {
+    return `${fragmentName.split('.').pop()} (Kubernetes ${kubernetesVersion})`;
   }
   if (Object.getOwnPropertyDescriptor(schema, 'name')) {
     return Object.getOwnPropertyDescriptor(schema, 'name').value + ` (${baseName})`;

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1081,8 +1081,8 @@ address:
   });
 
   describe('Test getGroupVersionKindFromDocument', function () {
-    it('builtin kubernetes resource group should not get resolved', async () => {
-      checkReturnGroupVersionKind('apiVersion: v1\nkind: Pod', true, undefined, 'v1', 'Pod');
+    it('should resolve the implicit core group for builtin kubernetes resources', async () => {
+      checkReturnGroupVersionKind('apiVersion: v1\nkind: Pod', false, 'core', 'v1', 'Pod');
     });
 
     it('builtin kubernetes resource with complex apiVersion should get resolved ', async () => {

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -144,6 +144,20 @@ describe('YAML CodeLens', () => {
     );
   });
 
+  it('should place a CodeLens after the separator for a trailing empty document', async () => {
+    const doc = setupTextDocument('foo: bar\n---\nfoo: bar\n---\n');
+    const schema: JSONSchema = {
+      url: 'some://url/to/schema.json',
+    };
+    yamlSchemaService.getSchemaForResource.resolves(createResolvedSchema(schema));
+
+    const codeLens = new YamlCodeLens(yamlSchemaService as unknown as YAMLSchemaService, telemetry);
+    const result = await codeLens.getCodeLens(doc);
+
+    expect(result).to.have.length(3);
+    expect(result[2].range).to.deep.equal(Range.create(4, 0, 4, 0));
+  });
+
   it('should show document-specific Kubernetes schemas in document order', async () => {
     const doc = setupTextDocument(
       'apiVersion: v1\nkind: Pod\n---\napiVersion: admissionregistration.k8s.io/v1\nkind: MutatingAdmissionPolicy'

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -165,6 +165,15 @@ describe('YAML CodeLens', () => {
     expect((yamlSchemaService.getSchemaForResource.secondCall.args[1] as SingleYAMLDocument).currentDocIndex).to.eq(1);
   });
 
+  it('should show the Kubernetes version for the generic all.json schema', async () => {
+    const doc = setupTextDocument('apiVersion: v1\nkind: UnknownCoreResource');
+    const schemaUrl = 'https://example.com/v1.36.1-standalone-strict/all.json';
+    yamlSchemaService.getSchemaForResource.resolves(createResolvedSchema({ url: schemaUrl }));
+    const codeLens = new YamlCodeLens(yamlSchemaService as unknown as YAMLSchemaService, telemetry);
+    const result = await codeLens.getCodeLens(doc);
+    expect(result).is.deep.equal([createCodeLens('Kubernetes v1.36.1', YamlCommands.JUMP_TO_SCHEMA, schemaUrl)]);
+  });
+
   it('command name should contains schema title', async () => {
     const doc = setupTextDocument('foo: bar');
     const schema = {

--- a/test/yamlCodeLens.test.ts
+++ b/test/yamlCodeLens.test.ts
@@ -19,6 +19,7 @@ import { LanguageHandlers } from '../src/languageserver/handlers/languageHandler
 import type { ValidationHandler } from '../src/languageserver/handlers/validationHandlers';
 import type { LanguageService } from '../src/languageservice/yamlLanguageService';
 import { SettingsState, TextDocumentTestManager } from '../src/yamlSettings';
+import type { SingleYAMLDocument } from '../src/languageservice/parser/yaml-documents';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -47,8 +48,8 @@ describe('YAML CodeLens', () => {
     };
   }
 
-  function createCodeLens(title: string, command: string, arg: string): CodeLens {
-    const lens = CodeLens.create(Range.create(0, 0, 0, 0));
+  function createCodeLens(title: string, command: string, arg: string, line = 0): CodeLens {
+    const lens = CodeLens.create(Range.create(line, 0, line, 0));
     lens.command = createCommand(title, command, arg);
     return lens;
   }
@@ -124,7 +125,7 @@ describe('YAML CodeLens', () => {
     expect(result).deep.equal([expected]);
   });
 
-  it('should place one CodeLens at beginning of the file for multiple documents', async () => {
+  it('should place a CodeLens at the beginning of each document', async () => {
     const doc = setupTextDocument('foo: bar\n---\nfoo: bar');
     const schema: JSONSchema = {
       url: 'some://url/to/schema.json',
@@ -132,11 +133,36 @@ describe('YAML CodeLens', () => {
     yamlSchemaService.getSchemaForResource.resolves(createResolvedSchema(schema));
     const codeLens = new YamlCodeLens(yamlSchemaService as unknown as YAMLSchemaService, telemetry);
     const result = await codeLens.getCodeLens(doc);
-    expect(result.length).to.eq(1);
+    expect(result.length).to.eq(2);
     expect(result[0].range).is.deep.equal(Range.create(0, 0, 0, 0));
+    expect(result[1].range).is.deep.equal(Range.create(2, 0, 2, 0));
     expect(result[0].command).is.deep.equal(
       createCommand('schema.json', YamlCommands.JUMP_TO_SCHEMA, 'some://url/to/schema.json')
     );
+    expect(result[1].command).is.deep.equal(
+      createCommand('schema.json', YamlCommands.JUMP_TO_SCHEMA, 'some://url/to/schema.json')
+    );
+  });
+
+  it('should show document-specific Kubernetes schemas in document order', async () => {
+    const doc = setupTextDocument(
+      'apiVersion: v1\nkind: Pod\n---\napiVersion: admissionregistration.k8s.io/v1\nkind: MutatingAdmissionPolicy'
+    );
+    const podSchemaUrl = 'https://example.com/v1.36.1-standalone-strict/_definitions.json#/definitions/io.k8s.api.core.v1.Pod';
+    const policySchemaUrl =
+      'https://example.com/v1.36.1-standalone-strict/_definitions.json#/definitions/io.k8s.api.admissionregistration.v1.MutatingAdmissionPolicy';
+    yamlSchemaService.getSchemaForResource.onFirstCall().resolves(createResolvedSchema({ url: podSchemaUrl }));
+    yamlSchemaService.getSchemaForResource.onSecondCall().resolves(createResolvedSchema({ url: policySchemaUrl }));
+
+    const codeLens = new YamlCodeLens(yamlSchemaService as unknown as YAMLSchemaService, telemetry);
+    const result = await codeLens.getCodeLens(doc);
+
+    expect(result).is.deep.equal([
+      createCodeLens('Pod (Kubernetes v1.36.1)', YamlCommands.JUMP_TO_SCHEMA, podSchemaUrl),
+      createCodeLens('MutatingAdmissionPolicy (Kubernetes v1.36.1)', YamlCommands.JUMP_TO_SCHEMA, policySchemaUrl, 3),
+    ]);
+    expect((yamlSchemaService.getSchemaForResource.firstCall.args[1] as SingleYAMLDocument).currentDocIndex).to.eq(0);
+    expect((yamlSchemaService.getSchemaForResource.secondCall.args[1] as SingleYAMLDocument).currentDocIndex).to.eq(1);
   });
 
   it('command name should contains schema title', async () => {
@@ -165,6 +191,26 @@ describe('YAML CodeLens', () => {
     const result = await codeLens.getCodeLens(doc);
     expect(result[0].command).is.deep.equal(
       createCommand('fooBar - fooBarDescription (schema.json)', YamlCommands.JUMP_TO_SCHEMA, 'some://url/to/schema.json')
+    );
+  });
+
+  it('should not add a file extension to an extensionless schema URI', async () => {
+    const doc = setupTextDocument('foo: bar');
+    const schema = {
+      url: 'https://json-schema.org/draft/2020-12/schema',
+      title: 'JSON Schema Draft 2020-12',
+    } as JSONSchema;
+    yamlSchemaService.getSchemaForResource.resolves(createResolvedSchema(schema));
+
+    const codeLens = new YamlCodeLens(yamlSchemaService as unknown as YAMLSchemaService, telemetry);
+    const result = await codeLens.getCodeLens(doc);
+
+    expect(result[0].command).is.deep.equal(
+      createCommand(
+        'JSON Schema Draft 2020-12 (schema)',
+        YamlCommands.JUMP_TO_SCHEMA,
+        'https://json-schema.org/draft/2020-12/schema'
+      )
     );
   });
 

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -8,11 +8,13 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as url from 'url';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import * as YAML from 'yaml';
 import type { JSONSchema } from '../src/languageservice/jsonSchema';
 import { parse } from '../src/languageservice/parser/yamlParser07';
 import * as SchemaService from '../src/languageservice/services/yamlSchemaService';
 import { DEFAULT_KUBERNETES_SCHEMA_VERSION, getSchemaUrls } from '../src/languageservice/utils/schemaUrls';
+import { SchemaPriority } from '../src/languageservice/yamlLanguageService';
 import { SettingsState } from '../src/yamlSettings';
 
 const BASE_KUBERNETES_SCHEMA_URL = `https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${DEFAULT_KUBERNETES_SCHEMA_VERSION}-standalone-strict/`;
@@ -663,6 +665,20 @@ spec:
       expect(requestServiceMock.callCount).equals(4);
     });
 
+    it('should fall back to all.json instead of the CRD catalog for an unknown core resource', async () => {
+      const yamlDock = parse('apiVersion: v1\nkind: UnknownCoreResource');
+      const settings = new SettingsState();
+      settings.kubernetesCRDStoreEnabled = true;
+      requestServiceMock = sandbox.fake.resolves('{"oneOf": []}');
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+      service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['*.yaml']);
+      const resolvedSchema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema.url).equals(KUBERNETES_SCHEMA_URL);
+      expect(requestServiceMock).calledOnceWithExactly(KUBERNETES_SCHEMA_URL);
+    });
+
     it('should not get schema from crd catalog if definition in kubernetes schema (multiple oneOf)', async () => {
       const documentContent = 'apiVersion: apps/v1\nkind: Deployment';
       const content = `${documentContent}`;
@@ -867,6 +883,126 @@ spec:
       expect(resolvedSchema.schema.url).eqls(
         BASE_KUBERNETES_SCHEMA_URL + '_definitions.json#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler'
       );
+    });
+
+    describe('document-specific Kubernetes schema priority', () => {
+      const podDefinition = 'io.k8s.api.core.v1.Pod';
+      const mapiDefinition = 'io.k8s.api.admissionregistration.v1.MutatingAdmissionPolicy';
+      const aerleonSchemaURI = 'https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-policies.schema.json';
+      const pod = `apiVersion: v1
+kind: Pod
+metadata:
+  name: irrelevant
+spec:
+  foo1: bar
+  containers: []`;
+      const policy = `apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: irrelevant
+spec:
+  foo2: bar
+  failurePolicy: Fail`;
+
+      let service: SchemaService.YAMLSchemaService;
+
+      beforeEach(() => {
+        const definitionsSchema = JSON.stringify({
+          definitions: {
+            [podDefinition]: {
+              type: 'object',
+              properties: {
+                apiVersion: { type: 'string' },
+                kind: { type: 'string' },
+                metadata: { type: 'object' },
+                spec: {
+                  type: 'object',
+                  properties: {
+                    containers: { type: 'array' },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            },
+            [mapiDefinition]: {
+              type: 'object',
+              properties: {
+                apiVersion: { type: 'string' },
+                kind: { type: 'string' },
+                metadata: { type: 'object' },
+                spec: {
+                  type: 'object',
+                  properties: {
+                    failurePolicy: { type: 'string' },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            },
+          },
+        });
+        requestServiceMock = sandbox.fake((uri) => {
+          if (uri === KUBERNETES_SCHEMA_URL) {
+            return Promise.resolve(
+              JSON.stringify({
+                oneOf: [
+                  { $ref: `_definitions.json#/definitions/${podDefinition}` },
+                  { $ref: `_definitions.json#/definitions/${mapiDefinition}` },
+                ],
+              })
+            );
+          }
+          if (uri === BASE_KUBERNETES_SCHEMA_URL + '_definitions.json') {
+            return Promise.resolve(definitionsSchema);
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const settings = new SettingsState();
+        settings.kubernetesCRDStoreEnabled = true;
+        service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+        service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['templates/**']);
+        service.addSchemaPriority(KUBERNETES_SCHEMA_URL, SchemaPriority.SchemaAssociation);
+        service.registerExternalSchema(aerleonSchemaURI, ['**/policies/**/*.yaml'], { type: 'object' });
+        service.addSchemaPriority(aerleonSchemaURI, SchemaPriority.SchemaStore);
+      });
+
+      async function resolveAndValidate(content: string): Promise<{ schemaUrls: string[]; messages: string[] }> {
+        const yamlDock = parse(content);
+        const textDocument = TextDocument.create('file:///templates/policies/foo.yaml', 'yaml', 0, content);
+        const resolvedSchemas = await Promise.all(
+          yamlDock.documents.map((document) => service.getSchemaForResource('templates/policies/foo.yaml', document))
+        );
+        const messages = yamlDock.documents.flatMap((document, index) =>
+          document.validate(textDocument, resolvedSchemas[index].schema).map((diagnostic) => diagnostic.message)
+        );
+        return {
+          schemaUrls: resolvedSchemas.map((schema) => schema.schema.url),
+          messages,
+        };
+      }
+
+      it('should select and validate a document-specific Kubernetes schema for a single document', async () => {
+        const result = await resolveAndValidate(policy);
+
+        expect(result.schemaUrls).deep.equals([BASE_KUBERNETES_SCHEMA_URL + `_definitions.json#/definitions/${mapiDefinition}`]);
+        expect(result.messages).deep.equals(['Property foo2 is not allowed.']);
+      });
+
+      for (const [name, content] of [
+        ['Pod first', `${pod}\n---\n${policy}`],
+        ['MutatingAdmissionPolicy first', `${policy}\n---\n${pod}`],
+      ]) {
+        it(`should select and validate document-specific Kubernetes schemas with ${name}`, async () => {
+          const result = await resolveAndValidate(content);
+
+          expect(result.schemaUrls).to.have.members([
+            BASE_KUBERNETES_SCHEMA_URL + `_definitions.json#/definitions/${podDefinition}`,
+            BASE_KUBERNETES_SCHEMA_URL + `_definitions.json#/definitions/${mapiDefinition}`,
+          ]);
+          expect(result.messages).to.have.members(['Property foo1 is not allowed.', 'Property foo2 is not allowed.']);
+        });
+      }
     });
 
     it('should support extglob !(config) pattern', () => {


### PR DESCRIPTION
### What does this PR do?

Kubernetes auto-detection replaces the configured `all.json` URI with a document-specific `_definitions.json` or CRD URI. However, schema priorities are registered against the original `all.json` URI. Looking up priority using the document-specific URI caused it to receive the lowest priority, allowing other schema sources such as SchemaStore to incorrectly win.

This PR fixes the issue above and includes several related enhancements to Kubernetes support:

- Treats an omitted Kubernetes API group as the internal `core` group. For example, `apiVersion: v1` is parsed as `{ group: "core", version: "v1" }`, allowing a `Pod` to match the `io.k8s.api.core.v1.Pod` definition. Unknown core resources fall back to `all.json` instead of being searched for in the CRD catalog
- Creates a separate CodeLens entry at the beginning of each document in a multi-document YAML file
- Displays specific CodeLens titles for Kubernetes resources, such as `Pod (Kubernetes v1.36.1)` and `MutatingAdmissionPolicy (Kubernetes v1.36.1)`, instead of displaying the general `all.json` / `_definitions.json`
- Preserves extensionless schema URI names instead of incorrectly appending `.json`. For example, a schema URI ending in `schema` is displayed as `schema`, not `schema.json`, because schema resources may be JSON, YAML, or extensionless

### What issues does this PR fix or reference?
Fixes https://github.com/redhat-developer/yaml-language-server/issues/1298

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] Automated tests
- [x] Tested the case reported in https://github.com/redhat-developer/yaml-language-server/issues/1298. Verified that:
  1. Both documents are validated against their corresponding Kubernetes schemas, and validation errors are reported for both.
  2. A CodeLens appears at the top of each document and links to the corresponding schema.

- [x] Tested that an unknown core kind falls back to `all.json` instead of being resolved through the CRD catalog. For example, expected the following YAML reports a diagnostic on `Po`: `Value is not accepted. Valid values: "MutatingAdmissionPolicy", "MutatingAdmissionPolicyBinding", "MutatingWebhookConfiguration"...`, rather than attempting CRD validation:
  ```yaml
  apiVersion: v1
  kind: Po
  metadata:
    name: irrelevant
  ```