### PR TITLE
fix: recognize Kubernetes CRD schema as builtin

### DIFF
--- a/src/languageservice/services/k8sSchemaUtil.ts
+++ b/src/languageservice/services/k8sSchemaUtil.ts
@@ -28,8 +28,8 @@ export function autoDetectKubernetesSchema(
   if (builtinResource) {
     return builtinResource;
   }
-  // core resources cannot be CRDs: fall back to all.json for unknown core kinds
-  if (gvk.group === 'core') {
+  // core and apiextensions resources cannot be CRDs: fall back to all.json for unknown kinds or versions
+  if (gvk.group === 'core' || gvk.group === 'apiextensions.k8s.io') {
     return undefined;
   }
   const customResource = autoDetectCustomResource(gvk, crdCatalogURI);
@@ -47,7 +47,9 @@ function autoDetectBuiltinResource(
   const { group, version, kind } = gvk;
 
   const groupWithoutK8sIO = group.replace('.k8s.io', '').replace('rbac.authorization', 'rbac');
-  const k8sTypeName = `io.k8s.api.${groupWithoutK8sIO.toLowerCase()}.${version.toLowerCase()}.${kind.toLowerCase()}`;
+  const normalizedGVK = `${groupWithoutK8sIO.toLowerCase()}.${version.toLowerCase()}.${kind.toLowerCase()}`;
+  const k8sTypePrefix = group === 'apiextensions.k8s.io' ? 'io.k8s.apiextensions-apiserver.pkg.apis' : 'io.k8s.api';
+  const k8sTypeName = `${k8sTypePrefix}.${normalizedGVK}`;
   const k8sSchema: JSONSchema = kubernetesSchema.schema;
   const matchingBuiltin: string | undefined = (k8sSchema.oneOf || [])
     .map((s) => {

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -739,6 +739,110 @@ spec:
       expect(requestServiceMock.callCount).equals(4);
     });
 
+    it('should treat CustomResourceDefinition as a builtin Kubernetes resource', async () => {
+      const documentContent = 'apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition';
+      const yamlDock = parse(documentContent);
+      const builtinDefinition =
+        '_definitions.json#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition';
+      const crdCatalogURL =
+        'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/apiextensions.k8s.io/customresourcedefinition_v1.json';
+
+      const settings = new SettingsState();
+      settings.schemaAssociations = {
+        kubernetes: ['*.yaml'],
+      };
+      settings.kubernetesCRDStoreEnabled = true;
+      requestServiceMock = sandbox.fake.resolves(
+        JSON.stringify({
+          oneOf: [{ $ref: builtinDefinition }],
+        })
+      );
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+      service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['*.yaml']);
+
+      const resolvedSchema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema.url).equals(BASE_KUBERNETES_SCHEMA_URL + builtinDefinition);
+      expect(requestServiceMock).not.calledWith(crdCatalogURL);
+    });
+
+    it('should treat an older CustomResourceDefinition version as builtin when present', async () => {
+      const documentContent = 'apiVersion: apiextensions.k8s.io/v1beta1\nkind: CustomResourceDefinition';
+      const yamlDock = parse(documentContent);
+      const builtinDefinition =
+        '_definitions.json#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition';
+      const crdCatalogURL =
+        'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/apiextensions.k8s.io/customresourcedefinition_v1beta1.json';
+
+      const settings = new SettingsState();
+      settings.schemaAssociations = {
+        kubernetes: ['*.yaml'],
+      };
+      settings.kubernetesCRDStoreEnabled = true;
+      requestServiceMock = sandbox.fake.resolves(
+        JSON.stringify({
+          oneOf: [{ $ref: builtinDefinition }],
+        })
+      );
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+      service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['*.yaml']);
+
+      const resolvedSchema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema.url).equals(BASE_KUBERNETES_SCHEMA_URL + builtinDefinition);
+      expect(requestServiceMock).not.calledWith(crdCatalogURL);
+    });
+
+    it('should fall back to all.json for an unsupported CustomResourceDefinition version', async () => {
+      const documentContent = 'apiVersion: apiextensions.k8s.io/v1beta1\nkind: CustomResourceDefinition';
+      const yamlDock = parse(documentContent);
+      const crdCatalogURL =
+        'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/apiextensions.k8s.io/customresourcedefinition_v1beta1.json';
+
+      const settings = new SettingsState();
+      settings.schemaAssociations = {
+        kubernetes: ['*.yaml'],
+      };
+      settings.kubernetesCRDStoreEnabled = true;
+      requestServiceMock = sandbox.fake.resolves('{"oneOf": []}');
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+      service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['*.yaml']);
+
+      const resolvedSchema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema.url).equals(KUBERNETES_SCHEMA_URL);
+      expect(requestServiceMock).not.calledWith(crdCatalogURL);
+    });
+
+    it('should still use the CRD catalog for a similarly named custom API group', async () => {
+      const documentContent = 'apiVersion: apiextensions.example.com/v1\nkind: CustomResourceDefinition';
+      const yamlDock = parse(documentContent);
+      const crdCatalogURL =
+        'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/apiextensions.example.com/customresourcedefinition_v1.json';
+
+      const settings = new SettingsState();
+      settings.schemaAssociations = {
+        kubernetes: ['*.yaml'],
+      };
+      settings.kubernetesCRDStoreEnabled = true;
+      requestServiceMock = sandbox.fake.resolves(
+        JSON.stringify({
+          oneOf: [
+            {
+              $ref: '_definitions.json#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition',
+            },
+          ],
+        })
+      );
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, undefined, undefined, settings);
+      service.registerExternalSchema(KUBERNETES_SCHEMA_URL, ['*.yaml']);
+
+      const resolvedSchema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema.url).equals(crdCatalogURL);
+      expect(requestServiceMock).calledWithExactly(crdCatalogURL);
+    });
+
     it('should fall back to all.json instead of the CRD catalog for an unknown core resource', async () => {
       const yamlDock = parse('apiVersion: v1\nkind: UnknownCoreResource');
       const settings = new SettingsState();


### PR DESCRIPTION
### What does this PR do?

Kubernetes publishes `CustomResourceDefinition` under the
`io.k8s.apiextensions-apiserver.pkg.apis` definition prefix rather than the
usual `io.k8s.api` prefix. The current exact matcher therefore misses this
builtin resource and falls back to a nonexistent entry in the external CRD
catalog.

This change:

- maps the exact `apiextensions.k8s.io` API group to its generated Kubernetes
  definition prefix;
- keeps the existing exact `io.k8s.api` matching behavior for every other
  group;
- falls back to `all.json` when an apiextensions kind or version is absent from
  the selected Kubernetes schema instead of treating it as a custom resource;
- preserves CRD catalog lookup for similarly named custom groups.

### What issues does this PR fix or reference?

Fixes #1310

### Is it tested? How?

- `npm run build`
- Node.js 22: ESLint, main/UMD/ESM TypeScript compilation
- 9 focused Kubernetes schema-selection scenarios
- 1,305 passing full-suite tests and 5 existing pending tests

The full suite currently has one unrelated live SchemaStore assertion for the
Drone schema. It reproduces unchanged on the exact `main` base commit because
the externally served diagnostic ordering no longer matches the fixture; the
1,305 remaining tests pass under Node.js 22.

AI assistance was used during implementation and review; I verified the
changes and all reported test results.
