### PR TITLE
Fix schema priority lookup for normalized file URIs

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -1483,12 +1483,13 @@ export class YAMLSchemaService implements IJSONSchemaService {
 
   // Set the priority of a schema in the schema service
   public addSchemaPriority(uri: string, priority: number): void {
-    let currSchemaArray = this.schemaPriorityMapping.get(uri);
+    const id = normalizeId(uri);
+    const currSchemaArray = this.schemaPriorityMapping.get(id);
     if (currSchemaArray) {
-      currSchemaArray = currSchemaArray.add(priority);
-      this.schemaPriorityMapping.set(uri, currSchemaArray);
+      currSchemaArray.add(priority);
+      this.schemaPriorityMapping.set(id, currSchemaArray);
     } else {
-      this.schemaPriorityMapping.set(uri, new Set<SchemaPriority>().add(priority));
+      this.schemaPriorityMapping.set(id, new Set<SchemaPriority>().add(priority));
     }
   }
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -870,6 +870,32 @@ address:
       languageSettingsSetup = new ServiceSetup().withCompletion();
     });
 
+    for (const { description, uri } of [
+      { description: 'encoded Windows drive colon', uri: 'file:///c%3A/Users/user1/schema.json' },
+      { description: 'unencoded Windows drive colon', uri: 'file:///c:/Users/user1/schema.json' },
+    ]) {
+      it(`Preserves settings priority for ${description}`, async () => {
+        languageSettingsSetup
+          .withSchemaFileMatch({
+            fileMatch: ['test.yaml'],
+            uri: 'https://example.test/schema-store.json',
+            priority: SchemaPriority.SchemaStore,
+            schema: schemaStoreSample,
+          })
+          .withSchemaFileMatch({
+            fileMatch: ['test.yaml'],
+            uri,
+            priority: SchemaPriority.Settings,
+            schema: schemaSettingsSample,
+          });
+        languageService.configure(languageSettingsSetup.languageSettings);
+        const document = setupTextDocument('');
+        const result = await languageService.doComplete(document, Position.create(0, 0), false);
+        assert.strictEqual(result.items.length, 1);
+        assert.strictEqual(result.items[0].label, 'settings');
+      });
+    }
+
     it('Modeline Schema takes precendence over all other schema APIs', async () => {
       languageSettingsSetup
         .withSchemaFileMatch({

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -135,6 +135,31 @@ describe('YAML Schema Service', () => {
       expect(schema.schema.type).eqls('array');
     });
 
+    for (const { description, uri } of [
+      { description: 'encoded Windows drive colon', uri: 'file:///c%3A/Users/user1/schema.json' },
+      { description: 'unencoded Windows drive colon', uri: 'file:///c:/Users/user1/schema.json' },
+    ]) {
+      it(`should resolve a schema URI with an ${description}`, async () => {
+        const yamlDock = parse('foo: bar');
+        const normalizedUri = 'file:///c:/Users/user1/schema.json';
+        requestServiceMock = sandbox.fake.resolves(
+          JSON.stringify({
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+          })
+        );
+
+        const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+        service.registerExternalSchema(uri, ['test.yaml']);
+        const schema = await service.getSchemaForResource('test.yaml', yamlDock.documents[0]);
+
+        expect(requestServiceMock).calledOnceWithExactly(normalizedUri);
+        expect(schema.schema.properties.foo).to.include({ type: 'string' });
+      });
+    }
+
     it('should use local sibling schema path before remote $id ref', async () => {
       const content = `# yaml-language-server: $schema=file:///schemas/primary.json\nmode: stage`;
       const yamlDock = parse(content);


### PR DESCRIPTION
### What does this PR do?

Before the fix, schema registration normalizes URIs to skip encodings, however, schema priorities were stored using the original URI. For an encoded Windows file URI, this produced different keys:

```text
Priority key:  file:///c%3A/Users/.../schema.json
Registered ID: file:///c:/Users/.../schema.json
```

As a result, the configured schema's priority could not be found and defaulted to `0`. Another matching schema could then incorrectly take precedence over the schema configured through `yaml.schemas`.

This PR normalizes URIs consistently when recording schema priorities, ensuring encoded and unencoded forms of the same URI use the same key.

### What issues does this PR fix or reference?

Related to https://github.com/redhat-developer/vscode-yaml/issues/1274

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Tested manually on Mac using the following setting:
  ```json
  "yaml.schemas": {
      "file:///Users/.../encoded%3Aschema.json": "test.yaml",
      "file:///Users/.../schema.json": "test.yaml"
  }
  ```
  Expected `test.yaml` to be validated against `Multiple JSON Schemas` (both `encoded:schema.json` and `schema.json`), instead of just `schema.json`.