### PR TITLE
Fix resolution of percent-encoded schema paths in modelines

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -483,9 +483,9 @@ export class YAMLSchemaService implements IJSONSchemaService {
       }
       if (!path.isAbsolute(schemaRef)) {
         const resUri = URI.parse(resource);
-        schemaRef = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaRef)).toString();
+        schemaRef = URI.file(path.resolve(path.parse(resUri.fsPath).dir, schemaRef)).toString(true);
       } else {
-        schemaRef = URI.file(schemaRef).toString();
+        schemaRef = URI.file(schemaRef).toString(true);
       }
       if (appendix.length > 0) {
         schemaRef += '#' + appendix;

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -9,6 +9,7 @@ import * as sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import * as url from 'url';
 import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
 import * as YAML from 'yaml';
 import type { JSONSchema } from '../src/languageservice/jsonSchema';
 import { parse } from '../src/languageservice/parser/yamlParser07';
@@ -133,6 +134,54 @@ describe('YAML Schema Service', () => {
       }
 
       expect(schema.schema.type).eqls('array');
+    });
+
+    it('should resolve encoded characters in a relative modeline schema path', async () => {
+      const content = `# yaml-language-server: $schema=./encoded%20schema.json\nfoo: bar`;
+      const yamlDock = parse(content);
+      const resource = URI.file(path.join(__dirname, 'test.yaml')).toString();
+      const expectedSchemaPath = URI.parse(URI.file(path.join(__dirname, 'encoded schema.json')).toString()).fsPath;
+      requestServiceMock = sandbox.fake.resolves(
+        JSON.stringify({
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+          },
+        })
+      );
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      const schema = await service.getSchemaForResource(resource, yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledOnce;
+      expect(URI.parse(requestServiceMock.firstCall.args[0]).fsPath).equals(expectedSchemaPath);
+      expect(schema.schema.properties.foo).to.include({ type: 'string' });
+    });
+
+    it('should resolve encoded characters in an absolute modeline schema path', async () => {
+      const rootPath = path.parse(__dirname).root.replace(/\\/g, '/');
+      const encodedSchemaPath = path.posix.join(rootPath, 'encoded%20schema.json');
+      const content = `# yaml-language-server: $schema=${encodedSchemaPath}\nfoo: bar`;
+      const yamlDock = parse(content);
+      const resource = URI.file(path.join(__dirname, 'test.yaml')).toString();
+      const expectedSchemaPath = URI.parse(
+        URI.file(path.join(path.parse(__dirname).root, 'encoded schema.json')).toString()
+      ).fsPath;
+      requestServiceMock = sandbox.fake.resolves(
+        JSON.stringify({
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+          },
+        })
+      );
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock);
+      const schema = await service.getSchemaForResource(resource, yamlDock.documents[0]);
+
+      expect(requestServiceMock).calledOnce;
+      expect(URI.parse(requestServiceMock.firstCall.args[0]).fsPath).equals(expectedSchemaPath);
+      expect(schema.schema.properties.foo).to.include({ type: 'string' });
     });
 
     for (const { description, uri } of [

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -127,7 +127,7 @@ describe('YAML Schema Service', () => {
       if (process.platform === 'win32') {
         const driveLetter = path.parse(__dirname).root.split(':')[0].toLowerCase();
         expect(requestServiceMock).calledWithExactly(`file:///${driveLetter}:/schema.json`);
-        expect(requestServiceMock).calledWithExactly(`file:///${driveLetter}%3A/schema.json#/definitions/schemaArray`);
+        expect(requestServiceMock).calledWithExactly(`file:///${driveLetter}:/schema.json#/definitions/schemaArray`);
       } else {
         expect(requestServiceMock).calledWithExactly('file:///schema.json');
         expect(requestServiceMock).calledWithExactly('file:///schema.json#/definitions/schemaArray');


### PR DESCRIPTION
### What does this PR do?
Prevents percent-encoded schema paths in modelines from being encoded a second time when converted to file URIs.

For example, this following percent-encoded modeline should resolve to a schema named `encoded:schema.json`:

```yaml
# yaml-language-server: $schema=./encoded%3Aschema.json
```

Previously, the existing percent escape was encoded again:

```text
./encoded%3Aschema.json
        ↓
file:///.../encoded%253Aschema.json
```

Consequently, the schema request targeted a file literally named `encoded%3Aschema.json` instead of decoding `%3A` to `:`.

### What issues does this PR fix or reference?
Related to https://github.com/redhat-developer/vscode-yaml/issues/1274
This is a separate modeline path case discovered while investigating encoded schema URIs in `yaml.schemas`.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests
- [x] Tested manually:
    1. Created a schema named `encoded:schema.json` (For Windows, use `encoded schema.json` because `:` is invalid in filenames on Windows)
    2. Create a yaml file with a percent-encoded modeline that points to the file `# yaml-language-server: $schema=./encoded%3Aschema.json` (or `# yaml-language-server: $schema=./encoded%20schema.json` for Windows)
    3. Expect the yaml to resolve against the schema correctly