### PR TITLE
fix: Type diagnostic reports schema filenames instead of `"object"` when mult...

### DIFF
--- a/src/languageservice/parser/schemaValidation/baseValidator.ts
+++ b/src/languageservice/parser/schemaValidation/baseValidator.ts
@@ -568,7 +568,8 @@ export abstract class BaseValidator {
       }
     } else if (schema.type) {
       if (!matchesType(schema.type as string)) {
-        const schemaType = schema.type === 'object' ? getSchemaTypeName(schema) : schema.type;
+        // ignore file name refs so that a schema associated by file name reports "object", not the file name
+        const schemaType = schema.type === 'object' ? getSchemaTypeName(schema, true) : schema.type;
         validationResult.problems.push({
           location: { offset: node.offset, length: node.length },
           severity: DiagnosticSeverity.Warning,

--- a/src/languageservice/utils/schemaUtils.ts
+++ b/src/languageservice/utils/schemaUtils.ts
@@ -2,22 +2,32 @@ import { URI } from 'vscode-uri';
 import type { JSONSchema } from '../jsonSchema';
 import * as path from 'path';
 
-export function getSchemaTypeName(schema: JSONSchema): string {
+export function getSchemaTypeName(schema: JSONSchema, ignoreFileNameRefs = false): string {
   const closestTitleWithType = schema.type && schema.closestTitle;
   if (schema.title) {
     return schema.title;
   }
-  if (schema.$id) {
+  if (schema.$id && !(ignoreFileNameRefs && isSchemaFileRef(schema.$id))) {
     return getSchemaRefTypeTitle(schema.$id);
   }
-  if (schema.$ref || schema._$ref) {
-    return getSchemaRefTypeTitle(schema.$ref || schema._$ref);
+  const ref = schema.$ref || schema._$ref;
+  if (ref && !(ignoreFileNameRefs && isSchemaFileRef(ref))) {
+    return getSchemaRefTypeTitle(ref);
   }
   return Array.isArray(schema.type)
     ? schema.type.join(' | ')
     : closestTitleWithType
       ? schema.type.concat('(', schema.closestTitle, ')')
       : schema.type || schema.closestTitle; //object
+}
+
+/**
+ * A `$id`/`$ref` pointing at a whole schema document (no `#/...` fragment) yields a
+ * plain file name such as `schema1.json` or `schema1.schema.json`, which is a schema
+ * file name rather than a type name.
+ */
+function isSchemaFileRef($ref: string): boolean {
+  return !$ref.includes('#');
 }
 
 /**

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -10,6 +10,7 @@ import {
   StringTypeError,
   BooleanTypeError,
   ArrayTypeError,
+  ObjectTypeError,
   IncludeWithoutValueError,
   BlockMappingEntryError,
   DuplicateKeyError,
@@ -1837,6 +1838,56 @@ spec:
         'file:///sharedSchema.json',
         'file:///default_schema_id.yaml',
       ]);
+    });
+    it('should report "object" instead of schema file names when multiple schemas expect an object', async () => {
+      schemaProvider.addSchemaWithUri(SCHEMA_ID, 'file:///schema1.json', {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      });
+      schemaProvider.addSchemaWithUri(SCHEMA_ID, 'file:///schema2.json', {
+        type: 'object',
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+        },
+      });
+      const content = '- invalid';
+      const result = await parseSetup(content);
+
+      assert.ok(result.length >= 1);
+      for (const diagnostic of result) {
+        assert.strictEqual(diagnostic.message, ObjectTypeError);
+      }
+    });
+    it('should report "object" instead of schema file names when schema files use the ".schema.json" extension', async () => {
+      schemaProvider.addSchemaWithUri(SCHEMA_ID, 'file:///schema1.schema.json', {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      });
+      schemaProvider.addSchemaWithUri(SCHEMA_ID, 'file:///schema2.schema.json', {
+        type: 'object',
+        properties: {
+          enabled: {
+            type: 'boolean',
+          },
+        },
+      });
+      const content = '- invalid';
+      const result = await parseSetup(content);
+
+      assert.ok(result.length >= 1);
+      for (const diagnostic of result) {
+        assert.strictEqual(diagnostic.message, ObjectTypeError);
+      }
     });
   });
 


### PR DESCRIPTION
Fixes #1317.

## Summary

Type diagnostic reports schema filenames instead of `"object"` when multiple schemas match

## Validation

- Mechanical gate: +67/-5, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->