### PR TITLE
Fix #288: preserve $1 snippet placeholder when cursor is at end of a …

### DIFF
--- a/src/languageservice/services/yamlCompletion.ts
+++ b/src/languageservice/services/yamlCompletion.ts
@@ -257,8 +257,20 @@ export class YamlCompletion {
             const char = singleCharMatch[2];
             completionItem.insertText = `${key}: ${this.getQuote()}\\${char}${this.getQuote()}`;
           }
-          // trim $1 from end of completion
-          if (completionItem.insertText.endsWith('$1') && !isForParentCompletion) {
+          // trim $1 from end of completion only when there is no newline after
+          // the cursor, OR the line before the cursor has no non-whitespace
+          // content. When the caret sits at the end of a line that ends with a
+          // newline and the line has meaningful content before it (e.g. the
+          // sequence marker `- ` from issue #288), preserve the $1 snippet
+          // placeholder so editors can place the caret at the snippet position.
+          const hasNewlineAfterPosition = lineAfterPosition.includes('\n');
+          const lineBeforeCursor = lineContent.substring(0, position.character);
+          const hasNonWhitespaceBeforeCursor = lineBeforeCursor.trim().length > 0;
+          if (
+            completionItem.insertText.endsWith('$1') &&
+            !isForParentCompletion &&
+            !(hasNewlineAfterPosition && hasNonWhitespaceBeforeCursor)
+          ) {
             completionItem.insertText = completionItem.insertText.substr(0, completionItem.insertText.length - 2);
           }
           if (overwriteRange && overwriteRange.start.line === overwriteRange.end.line) {

--- a/test/autoCompletion.test.ts
+++ b/test/autoCompletion.test.ts
@@ -751,6 +751,33 @@ describe('Auto Completion Tests', () => {
         );
       });
 
+      it('Check text edit when there is a newline', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));
+        schemaProvider.addSchema(SCHEMA_ID, schema);
+        const content = '- \n';
+        const result = await parseSetup(content, content.length - 1);
+        assert.equal(result.items.length, 3);
+        assert.deepEqual(
+          result.items[0],
+          createExpectedCompletion('prop1', 'prop1: $1', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
+          })
+        );
+        assert.deepEqual(
+          result.items[1],
+          createExpectedCompletion('prop2', 'prop2: $1', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
+          })
+        );
+        assert.deepEqual(
+          result.items[2],
+          createExpectedCompletion('prop3', 'prop3: $1', 0, 2, 0, 2, 10, 2, {
+            documentation: '',
+          })
+        );
+      });
+
       it('Provide the 2 types when one is provided', async () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const schema = require(path.join(__dirname, './fixtures/testArrayMaxProperties.json'));


### PR DESCRIPTION
## What does this PR do?

Fixes an issue in the completion collector (`yamlCompletion.ts`) where a trailing
`$1` snippet placeholder was unconditionally stripped from `completionItem.insertText`.

This stripping was correct when non-newline content after the cursor needed to
coexist with the inserted text, but incorrect when the cursor sat at the end of
a line that ended with a newline — in that case the `$1` placeholder is the
editor's signal for caret placement and must be preserved.

For example, with content `'- \n'` and the caret at the end of `'- '`, the
service returned `'prop1: '` instead of `'prop1: $1'`.

The fix skips the strip when the cursor is at the end of a line that has both
a trailing newline **and** non-whitespace content before the cursor (e.g. the
sequence marker `'- '`). The strip is still applied for:
- content `'-'` (no newline)
- whitespace-only lines
- empty lines

The existing PR #280 workaround
(`overwriteRange.start.line === overwriteRange.end.line`) is left in place, as
it guards against a separate class of malformed multi-line textEdits unrelated
to this bug.

## What issues does this PR fix or reference?

Fixes #288
References #280 (regression introduced by this PR)
References commit `73567b2` (removed the test that should have caught this)

## Is it tested? How?

Yes. A regression test, **"Check text edit when there is a newline"**, was
added to `test/autoCompletion.test.ts`. It asserts that all three completion
items from `testArrayMaxProperties.json` preserve `$1` for content `'- \n'` at
the end of `'- '`. This mirrors the assertions from the test that was removed
in commit `73567b2`.