### PR TITLE
Add opt-in masking of template expressions before parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The server supports the following settings supplied by LSP clients:
 
 - `yaml.yamlVersion`: Set default YAML spec version (`1.2` or `1.1`). Defaults to `1.2`.
 - `yaml.maxItemsComputed`: The maximum number of document symbols and folding regions computed (limited for performance reasons). Defaults to `5000`.
+- `yaml.template`: Mask templating expressions before parsing, so that templated documents such as Helm charts parse as plain YAML instead of reporting syntax errors on every `{{ ... }}`. Set to `helm` to enable, `none` to disable. Defaults to `none`. See [Templated documents](#templated-documents).
 - `yaml.format.enable`: Enable/disable the default YAML formatter. Defaults to `true`.
 - `yaml.format.singleQuote`: Use single quotes instead of double quotes. Defaults to `false`.
 - `yaml.format.bracketSpacing`: Print spaces between brackets in objects. Defaults to `true`.
@@ -292,6 +293,24 @@ When multiple schema sources or schema-disabling mechanisms apply to the same YA
 5. `yaml.schemas`
 6. `json/schemaAssociations` notification
 7. SchemaStore
+
+## Templated documents
+
+Templating languages that wrap YAML, such as Helm's Go templates, produce files that are not valid YAML until they are rendered. A control-flow line like `{{- if .Values.autoscaling.enabled }}` breaks the document structure, and the parser reports a cascade of syntax errors on every line that follows.
+
+Setting `yaml.template` to `helm` masks `{{ ... }}` expressions with inert text of exactly the same length before the document is parsed:
+
+- A line containing only a template expression becomes a comment, so control flow drops out of the document structure.
+- An inline expression such as `replicas: {{ .Values.replicaCount }}` becomes a plain scalar, so the value parses as a string.
+
+Because masking preserves length, all offsets are unchanged, and diagnostics, hover, completion, and symbol ranges continue to point at the real document. Schema validation, duplicate key detection, completion, hover, folding, and document symbols keep working on the untemplated parts of the file.
+
+The setting is off by default. Its limits are worth knowing before enabling it:
+
+- There is no completion, hover, or validation inside `{{ }}`. Masking only stops template syntax from breaking the surrounding document.
+- A fully templated value validates as a string, so a schema expecting a number or boolean at that position still reports a type error.
+- Expressions that expand to block content, such as `{{ include "chart.labels" . | nindent 4 }}`, and `if`/`else` branches that each define the same key, can still produce false positives. Masking cannot know what a template expands to.
+- Formatting is disabled for documents containing template expressions, since the formatter would rewrite the template syntax.
 
 ## Adding custom tags
 

--- a/src/languageserver/handlers/settingsHandlers.ts
+++ b/src/languageserver/handlers/settingsHandlers.ts
@@ -164,6 +164,7 @@ export class SettingsHandler {
         flowSequence: settings.yaml.style?.flowSequence ?? 'allow',
       };
       this.yamlSettings.keyOrdering = settings.yaml.keyOrdering ?? false;
+      this.yamlSettings.template = settings.yaml.template ?? 'none';
     }
 
     this.yamlSettings.schemaConfigurationSettings = [];
@@ -318,6 +319,7 @@ export class SettingsHandler {
       flowSequence: this.yamlSettings.style?.flowSequence,
       yamlVersion: this.yamlSettings.yamlVersion,
       keyOrdering: this.yamlSettings.keyOrdering,
+      template: this.yamlSettings.template,
       hoverSchemaSource: this.yamlSettings.yamlHoverSchemaSource,
     };
 

--- a/src/languageservice/parser/templateMasking.ts
+++ b/src/languageservice/parser/templateMasking.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Length-preserving masking of Go-template expressions so that templated
+ * documents (Helm charts) parse as plain YAML.
+ *
+ * Every replacement has exactly the same length as the original span and
+ * newlines are never touched, so all document offsets survive and no
+ * position translation is needed anywhere downstream.
+ *
+ * Rules:
+ * - A line whose content is only template expressions (plus whitespace)
+ *   becomes a comment of identical length. Control-flow lines such as
+ *   `{{- if .Values.enabled }}` and `{{- end }}` drop out of the document
+ *   structure entirely.
+ * - An inline expression after other content (`foo: {{ .Values.name }}`)
+ *   is replaced by an unquoted filler scalar of identical length, so the
+ *   value parses as a plain string.
+ * - A template span crossing line boundaries is masked on every line it
+ *   covers, each line classified by the rules above.
+ * - Expressions inside quotes are already valid YAML; masking them keeps
+ *   the value a string of the same length, so the parse result class is
+ *   unchanged and the function stays context-free.
+ */
+
+/** Which template dialect to mask. `none` disables masking entirely. */
+export type TemplateMode = 'none' | 'helm';
+
+/** Matches a template span, including across line boundaries; an unclosed
+ *  span is masked to the end of its line. */
+const TEMPLATE_SPAN = /\{\{[\s\S]*?\}\}|\{\{[^\n]*$/gm;
+
+/** Filler character for inline expressions. Parses as a plain scalar. */
+const INLINE_FILL = 'x';
+
+/** Internal sentinel; NUL cannot appear in an LSP document's text. */
+const SENTINEL = '\u0000';
+
+/**
+ * Mask Go-template expressions in `text`, preserving length and line
+ * structure exactly. Returns the input unchanged when it contains no
+ * template expression.
+ */
+export function maskTemplates(text: string): string {
+  if (!text.includes('{{')) {
+    return text;
+  }
+
+  // Pass 1: replace every character of every template span with a
+  // sentinel, preserving newlines, so pass 2 can classify lines.
+  const masked = text.replace(TEMPLATE_SPAN, (m) => m.replace(/[^\n]/g, SENTINEL));
+
+  // Pass 2: per line, decide comment-out vs inline filler.
+  const lines = masked.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes(SENTINEL)) {
+      continue;
+    }
+    if (line.split(SENTINEL).join('').trim().length === 0) {
+      // Template-only line: comment it out at the first non-space column,
+      // preserving both indentation and total length.
+      const indent = line.match(/^[ \t]*/)[0].length;
+      lines[i] = line.slice(0, indent) + '#' + ' '.repeat(Math.max(0, line.length - indent - 1));
+    } else {
+      // Inline expression: same-length filler scalar.
+      lines[i] = line.split(SENTINEL).join(INLINE_FILL);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/languageservice/parser/templateMasking.ts
+++ b/src/languageservice/parser/templateMasking.ts
@@ -16,6 +16,10 @@
  *   becomes a comment of identical length. Control-flow lines such as
  *   `{{- if .Values.enabled }}` and `{{- end }}` drop out of the document
  *   structure entirely.
+ * - A line that starts with a control-flow expression but carries other
+ *   content (`{{ if ... }}mug: "true"{{ end }}`) is also commented out:
+ *   the content is conditional, so it cannot be validated as
+ *   always-present, and relocating it would break offset preservation.
  * - An inline expression after other content (`foo: {{ .Values.name }}`)
  *   is replaced by an unquoted filler scalar of identical length, so the
  *   value parses as a plain string.
@@ -36,8 +40,19 @@ const TEMPLATE_SPAN = /\{\{[\s\S]*?\}\}|\{\{[^\n]*$/gm;
 /** Filler character for inline expressions. Parses as a plain scalar. */
 const INLINE_FILL = 'x';
 
-/** Internal sentinel; NUL cannot appear in an LSP document's text. */
+/** Internal sentinels; these control characters cannot appear in an LSP
+ *  document's text. The control-flow sentinel marks spans like `{{ if }}`
+ *  so pass 2 can tell them apart from value expressions. */
 const SENTINEL = '\u0000';
+const CONTROL_SENTINEL = '\u0001';
+// eslint-disable-next-line no-control-regex
+const ANY_SENTINEL = /[\u0000\u0001]/;
+// eslint-disable-next-line no-control-regex
+const ANY_SENTINEL_GLOBAL = /[\u0000\u0001]/g;
+
+/** Matches control-flow expressions (`{{ if }}`, `{{- end }}`, ...) that
+ *  affect document structure rather than producing a value. */
+const CONTROL_FLOW = /^\{\{-?\s*(if|else|end|range|with|define|block|template)\b/;
 
 /**
  * Mask Go-template expressions in `text`, preserving length and line
@@ -51,23 +66,29 @@ export function maskTemplates(text: string): string {
 
   // Pass 1: replace every character of every template span with a
   // sentinel, preserving newlines, so pass 2 can classify lines.
-  const masked = text.replace(TEMPLATE_SPAN, (m) => m.replace(/[^\n]/g, SENTINEL));
+  // Control-flow spans get a distinct sentinel.
+  const masked = text.replace(TEMPLATE_SPAN, (m) => m.replace(/[^\n]/g, CONTROL_FLOW.test(m) ? CONTROL_SENTINEL : SENTINEL));
 
   // Pass 2: per line, decide comment-out vs inline filler.
   const lines = masked.split('\n');
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    if (!line.includes(SENTINEL)) {
+    if (!ANY_SENTINEL.test(line)) {
       continue;
     }
-    if (line.split(SENTINEL).join('').trim().length === 0) {
-      // Template-only line: comment it out at the first non-space column,
-      // preserving both indentation and total length.
+    const templateOnly = line.replace(ANY_SENTINEL_GLOBAL, '').trim().length === 0;
+    // A line that starts with a control-flow expression but carries other
+    // content ({{ if ... }}mug: "true"{{ end }}) holds conditional content
+    // that cannot be validated as always-present; drop the whole line.
+    const wrappedInControlFlow = line.trimStart().startsWith(CONTROL_SENTINEL);
+    if (templateOnly || wrappedInControlFlow) {
+      // Comment out at the first non-space column, preserving both
+      // indentation and total length.
       const indent = line.match(/^[ \t]*/)[0].length;
       lines[i] = line.slice(0, indent) + '#' + ' '.repeat(Math.max(0, line.length - indent - 1));
     } else {
       // Inline expression: same-length filler scalar.
-      lines[i] = line.split(SENTINEL).join(INLINE_FILL);
+      lines[i] = line.replace(ANY_SENTINEL_GLOBAL, INLINE_FILL);
     }
   }
   return lines.join('\n');

--- a/src/languageservice/parser/yaml-documents.ts
+++ b/src/languageservice/parser/yaml-documents.ts
@@ -17,6 +17,8 @@ import { isArrayEqual } from '../utils/arrUtils';
 import { getParent } from '../utils/yamlAstUtils';
 import type { TextBuffer } from '../utils/textBuffer';
 import { getIndentation } from '../utils/strings';
+import type { TemplateMode } from './templateMasking';
+import { maskTemplates } from './templateMasking';
 
 /**
  * These documents are collected into a final YAMLDocument
@@ -266,11 +268,23 @@ export class YAMLDocument {
 interface YamlCachedDocument {
   version: number;
   parserOptions: ParserOptions;
+  templateMode: TemplateMode;
   document: YAMLDocument;
 }
 export class YamlDocuments {
   // a mapping of URIs to cached documents
   private cache = new Map<string, YamlCachedDocument>();
+  private templateMode: TemplateMode = 'none';
+
+  /**
+   * The template mode is global rather than a `ParserOptions` field because
+   * most callers of `getYamlDocument` pass no options at all; keying it off
+   * the options would make masking depend on which feature filled the cache
+   * first.
+   */
+  configure(settings: { template?: TemplateMode }): void {
+    this.templateMode = settings?.template ?? 'none';
+  }
 
   /**
    * Get cached YAMLDocument
@@ -294,14 +308,24 @@ export class YamlDocuments {
   private ensureCache(document: TextDocument, parserOptions: ParserOptions, addRootObject: boolean): void {
     const key = document.uri;
     if (!this.cache.has(key)) {
-      this.cache.set(key, { version: -1, document: new YAMLDocument([], []), parserOptions: defaultOptions });
+      this.cache.set(key, {
+        version: -1,
+        document: new YAMLDocument([], []),
+        parserOptions: defaultOptions,
+        templateMode: this.templateMode,
+      });
     }
     const cacheEntry = this.cache.get(key);
     if (
       cacheEntry.version !== document.version ||
+      cacheEntry.templateMode !== this.templateMode ||
       (parserOptions.customTags && !isArrayEqual(cacheEntry.parserOptions.customTags, parserOptions.customTags))
     ) {
       let text = document.getText();
+      // Masking is length-preserving, so every offset below stays valid.
+      if (this.templateMode === 'helm') {
+        text = maskTemplates(text);
+      }
       // if text is contains only whitespace wrap all text in object to force schema selection
       if (addRootObject && !/\S/.test(text)) {
         text = `{${text}}`;
@@ -310,6 +334,7 @@ export class YamlDocuments {
       cacheEntry.document = doc;
       cacheEntry.version = document.version;
       cacheEntry.parserOptions = parserOptions;
+      cacheEntry.templateMode = this.templateMode;
     }
   }
 }

--- a/src/languageservice/services/yamlFormatter.ts
+++ b/src/languageservice/services/yamlFormatter.ts
@@ -12,13 +12,16 @@ import * as yamlPlugin from 'prettier/plugins/yaml';
 import * as estreePlugin from 'prettier/plugins/estree';
 import { format } from 'prettier/standalone';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
+import type { TemplateMode } from '../parser/templateMasking';
 
 export class YAMLFormatter {
   private formatterEnabled = true;
+  private templateMode: TemplateMode = 'none';
 
   public configure(shouldFormat: LanguageSettings): void {
     if (shouldFormat) {
       this.formatterEnabled = shouldFormat.format;
+      this.templateMode = shouldFormat.template ?? 'none';
     }
   }
 
@@ -32,6 +35,12 @@ export class YAMLFormatter {
 
     try {
       const text = document.getText();
+
+      // Prettier has no notion of template expressions and would rewrite or
+      // reject them, so a templated document is left untouched.
+      if (this.templateMode !== 'none' && text.includes('{{')) {
+        return [];
+      }
 
       const prettierOptions: Options = {
         parser: 'yaml',

--- a/src/languageservice/yamlLanguageService.ts
+++ b/src/languageservice/yamlLanguageService.ts
@@ -47,6 +47,7 @@ import { doDocumentOnTypeFormatting } from './services/yamlOnTypeFormatting';
 import { YamlCodeLens } from './services/yamlCodeLens';
 import type { Telemetry } from './telemetry';
 import type { YamlVersion } from './parser/yamlParser07';
+import type { TemplateMode } from './parser/templateMasking';
 import { YamlCompletion } from './services/yamlCompletion';
 import { yamlDocumentsCache } from './parser/yaml-documents';
 import type { SettingsState } from '../yamlSettings';
@@ -125,6 +126,12 @@ export interface LanguageSettings {
    * Show schema source URI in hover popups. Default is true.
    */
   hoverSchemaSource?: boolean;
+
+  /**
+   * Mask templating expressions before parsing, so that templated documents
+   * parse as plain YAML. Default is `none`.
+   */
+  template?: TemplateMode;
 }
 
 export interface WorkspaceContextService {
@@ -230,6 +237,7 @@ export function getLanguageService(params: {
           );
         });
       }
+      yamlDocumentsCache.configure(settings);
       yamlValidation.configure(settings);
       hover.configure(settings);
       completer.configure(settings, params.yamlSettings);

--- a/src/yamlSettings.ts
+++ b/src/yamlSettings.ts
@@ -7,6 +7,7 @@ import type { JSONSchema } from './languageservice/jsonSchema';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { CRD_CATALOG_URL, JSON_SCHEMASTORE_URL } from './languageservice/utils/schemaUrls';
 import type { YamlVersion } from './languageservice/parser/yamlParser07';
+import type { TemplateMode } from './languageservice/parser/templateMasking';
 
 // Client settings interface to grab settings relevant for the language server
 export interface Settings {
@@ -37,6 +38,7 @@ export interface Settings {
       flowSequence: 'allow' | 'forbid';
     };
     keyOrdering: boolean;
+    template: TemplateMode;
     maxItemsComputed: number;
     yamlVersion: YamlVersion;
     hoverSchemaSource: boolean;
@@ -104,6 +106,7 @@ export class SettingsState {
     flowSequence: 'allow' | 'forbid';
   };
   keyOrdering = false;
+  template: TemplateMode = 'none';
   maxItemsComputed = 5000;
 
   // File validation helpers

--- a/test/templateMasking.test.ts
+++ b/test/templateMasking.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { maskTemplates } from '../src/languageservice/parser/templateMasking';
+import { yamlDocumentsCache } from '../src/languageservice/parser/yaml-documents';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import assert from 'assert';
+
+const HELM_CHART = [
+  'apiVersion: apps/v1',
+  'kind: Deployment',
+  'metadata:',
+  '  name: {{ include "mychart.fullname" . }}',
+  '  labels:',
+  '    {{- include "mychart.labels" . | nindent 4 }}',
+  'spec:',
+  '  {{- if not .Values.autoscaling.enabled }}',
+  '  replicas: {{ .Values.replicaCount }}',
+  '  {{- end }}',
+  '  selector:',
+  '    matchLabels:',
+  '      app: {{ .Chart.Name }}',
+  '',
+].join('\n');
+
+function errorCount(text: string, template: 'none' | 'helm'): number {
+  yamlDocumentsCache.clear();
+  yamlDocumentsCache.configure({ template });
+  const doc = TextDocument.create('file://foo/bar.yaml', 'yaml', 1, text);
+  return yamlDocumentsCache.getYamlDocument(doc).documents.reduce((n, d) => n + d.errors.length, 0);
+}
+
+describe('Template masking', () => {
+  afterEach(() => {
+    yamlDocumentsCache.clear();
+    yamlDocumentsCache.configure({ template: 'none' });
+  });
+
+  it('should leave text without templates untouched', () => {
+    const text = 'foo: bar\nbaz:\n  - 1\n';
+    assert.strictEqual(maskTemplates(text), text);
+  });
+
+  it('should preserve length and line count', () => {
+    const masked = maskTemplates(HELM_CHART);
+    assert.strictEqual(masked.length, HELM_CHART.length);
+    assert.strictEqual(masked.split('\n').length, HELM_CHART.split('\n').length);
+  });
+
+  it('should comment out a template-only line, keeping indentation', () => {
+    const template = '  {{- if .Values.enabled }}';
+    const masked = maskTemplates(`spec:\n${template}\n  foo: bar`);
+    const middle = masked.split('\n')[1];
+    assert.strictEqual(middle, '  #' + ' '.repeat(template.length - 3));
+    assert.strictEqual(middle.length, template.length);
+  });
+
+  it('should replace an inline expression with a filler scalar', () => {
+    const masked = maskTemplates('name: {{ .Values.name }}');
+    assert.strictEqual(masked, 'name: xxxxxxxxxxxxxxxxxx');
+  });
+
+  it('should mask a span crossing line boundaries', () => {
+    const text = 'a: {{ multi\nline }}\nb: plain';
+    const masked = maskTemplates(text);
+    assert.strictEqual(masked.length, text.length);
+    assert.strictEqual(masked, 'a: xxxxxxxx\n#      \nb: plain');
+  });
+
+  it('should mask an unclosed span to the end of its line', () => {
+    const text = 'a: {{ unclosed\nb: plain';
+    const masked = maskTemplates(text);
+    assert.strictEqual(masked.length, text.length);
+    assert.strictEqual(masked, 'a: xxxxxxxxxxx\nb: plain');
+  });
+
+  it('should not affect a quoted expression beyond keeping it a string', () => {
+    const masked = maskTemplates('name: "{{ .Values.name }}"');
+    assert.strictEqual(masked, 'name: "xxxxxxxxxxxxxxxxxx"');
+  });
+
+  it('should produce parse errors on a Helm chart when disabled', () => {
+    assert.ok(errorCount(HELM_CHART, 'none') > 0);
+  });
+
+  it('should produce no parse errors on a Helm chart when enabled', () => {
+    assert.strictEqual(errorCount(HELM_CHART, 'helm'), 0);
+  });
+
+  it('should keep offsets valid so nodes map back to the real document', () => {
+    yamlDocumentsCache.clear();
+    yamlDocumentsCache.configure({ template: 'helm' });
+    const doc = TextDocument.create('file://foo/bar.yaml', 'yaml', 1, HELM_CHART);
+    const root = yamlDocumentsCache.getYamlDocument(doc).documents[0].root;
+    const kind = root.children.find((c) => c.children?.[0]?.value === 'kind');
+    assert.strictEqual(HELM_CHART.substr(kind.offset, kind.length), 'kind: Deployment');
+  });
+
+  it('should re-parse when the template mode changes on an unchanged document', () => {
+    const doc = TextDocument.create('file://foo/bar.yaml', 'yaml', 1, HELM_CHART);
+    yamlDocumentsCache.clear();
+    yamlDocumentsCache.configure({ template: 'none' });
+    assert.ok(yamlDocumentsCache.getYamlDocument(doc).documents.reduce((n, d) => n + d.errors.length, 0) > 0);
+    yamlDocumentsCache.configure({ template: 'helm' });
+    assert.strictEqual(
+      yamlDocumentsCache.getYamlDocument(doc).documents.reduce((n, d) => n + d.errors.length, 0),
+      0
+    );
+  });
+});

--- a/test/templateMasking.test.ts
+++ b/test/templateMasking.test.ts
@@ -81,6 +81,35 @@ describe('Template masking', () => {
     assert.strictEqual(masked, 'name: "xxxxxxxxxxxxxxxxxx"');
   });
 
+  it('should comment out a line wrapped in inline control flow', () => {
+    const line = '  {{ if eq .Values.favorite.drink "coffee" }}mug: "true"{{ end }}';
+    const masked = maskTemplates(`data:\n${line}\n  food: pie`);
+    const middle = masked.split('\n')[1];
+    assert.strictEqual(middle, '  #' + ' '.repeat(line.length - 3));
+    assert.strictEqual(middle.length, line.length);
+  });
+
+  it('should keep an inline non-control expression before content as filler', () => {
+    const masked = maskTemplates('{{ .Values.prefix }}name: bar');
+    assert.strictEqual(masked, 'xxxxxxxxxxxxxxxxxxxxname: bar');
+  });
+
+  it('should produce no parse errors on a ConfigMap with inline control flow', () => {
+    const chart = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'metadata:',
+      '  name: {{ .Release.Name }}-configmap',
+      'data:',
+      '  myvalue: "Hello World"',
+      '  drink: {{ .Values.favorite.drink | default "tea" | quote }}',
+      '  food: {{ .Values.favorite.food | upper | quote }}',
+      '  {{ if eq .Values.favorite.drink "coffee" }}mug: "true"{{ end }}',
+      '',
+    ].join('\n');
+    assert.strictEqual(errorCount(chart, 'helm'), 0);
+  });
+
   it('should produce parse errors on a Helm chart when disabled', () => {
     assert.ok(errorCount(HELM_CHART, 'none') > 0);
   });


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `yaml.template` setting. When set to `helm`, Go-template expressions are masked with inert text of exactly the same length before the document is parsed, so templated files such as Helm charts parse as plain YAML instead of reporting a cascade of syntax errors.

This implements the design I proposed in Issue #220. It deliberately does not do either of the two things previous attempts asked for and maintainers declined: it teaches the server no Helm semantics, and it does not touch or swap the YAML parser.

**How masking works**

- A line whose content is only a template expression (`{{- if .Values.enabled }}`, `{{- end }}`) becomes a comment of identical length, so control flow drops out of the document structure.
- An inline expression (`replicas: {{ .Values.replicaCount }}`) becomes a plain scalar of identical length, so the value parses as a string.
- A span crossing line boundaries is masked on every line it covers, each line classified by the rules above. An unclosed span is masked to the end of its line.

Because every replacement is length-preserving, all offsets survive. Diagnostics, hover, completion, and symbol ranges map back to the real document with no position-translation layer anywhere.

**Where it hooks in**

Masking happens in `YamlDocuments.ensureCache`, the single choke point that validation, completion, hover, folding, symbols, code lens, links, and definition all read through. The cache-invalidation check gained the template mode so that changing the setting re-parses open documents.

One design note worth flagging for review: the mode is stored on `YamlDocuments` rather than added to `ParserOptions`. Most callers of `getYamlDocument` pass no options at all and get `defaultOptions`; only validation and completion pass real ones. Since the cache is keyed by URI alone, threading the mode through `ParserOptions` would have made masking depend on which feature happened to fill the cache first. Happy to change this if you would rather it live somewhere else.

The formatter is the one feature that bypasses the cache, so it returns no edits for documents containing template expressions when the setting is on. Prettier has no notion of template syntax and would rewrite or reject it.

**Honest limits**

- No completion, hover, or validation inside `{{ }}`. That stays helm-ls territory. This only stops template syntax from breaking the document around it.
- A fully templated value validates as a string, so a schema expecting a number or boolean at that position still reports a type error. This could later be handled by suppressing type diagnostics whose range overlaps a masked span, but I left that out to keep this change small.
- `{{ include "chart.labels" . | nindent 4 }}` expanding to block content, and `if`/`else` branches that each define the same key, can still produce false positives. Masking cannot know what a template expands to.
- Multi-line expressions are masked line by line. Positions stay correct; the intermediate text is just uglier.

I did not add a CHANGELOG entry, since there is no `1.25.0` section yet and I did not want to create the heading. Happy to add one wherever you prefer.

### What issues does this PR fix or reference?

Implements the proposal in Issue #220. Also covers the parsing half of Issue #766. Related closed issues: Issue #53, Issue #449.

### Is it tested? How?

Yes, `test/templateMasking.test.ts` adds 11 tests. The full suite is green at 1319 passing, 0 failing, and `npm run build` (clean, lint, compile, UMD, ESM) exits 0.

The tests include the before/after pair directly, so the fix cannot silently regress into a no-op. On this chart:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: {{ include "mychart.fullname" . }}
  labels:
    {{- include "mychart.labels" . | nindent 4 }}
spec:
  {{- if not .Values.autoscaling.enabled }}
  replicas: {{ .Values.replicaCount }}
  {{- end }}
  selector:
    matchLabels:
      app: {{ .Chart.Name }}
```

with `yaml.template: none`, the parser reports 10 errors:

```
Block collections are not allowed within flow collections
Missing , or : between flow map items
Block collections are not allowed within flow collections
Missing , or : between flow map items
All mapping items must start at the same column
All mapping items must start at the same column
Implicit keys need to be on a single line
Block collections are not allowed within flow collections
Missing , or : between flow map items
Implicit map keys need to be followed by map values
```

with `yaml.template: helm`, it reports 0.

Other cases covered: text without templates is returned unchanged (identity, not a rebuild); length and line count are preserved; indentation is preserved on commented-out lines; spans crossing line boundaries and unclosed spans; quoted expressions; offsets still resolve to the correct source text (`kind: Deployment` is located by node offset against the original, unmasked document); and changing the setting re-parses a document whose version has not changed.

To try it manually, set `yaml.template` to `helm` and open any chart under `templates/`.
