### PR TITLE
Fix enum and const validation for nested boolean values

### DIFF
--- a/src/languageservice/utils/astNodeUtils.ts
+++ b/src/languageservice/utils/astNodeUtils.ts
@@ -21,7 +21,7 @@ export function getNodeValue(node: ASTNode): any {
     case 'number':
       return node.value;
     case 'boolean':
-      return node.source;
+      return node.value;
     default:
       return undefined;
   }

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -208,6 +208,72 @@ describe('Validation Tests', () => {
       assert.deepStrictEqual(result, []);
     });
 
+    it('Test object enum value containing a nested boolean', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          parameter: {
+            type: 'object',
+            enum: [
+              {
+                required: true,
+              },
+            ],
+          },
+        },
+      });
+      const content = 'parameter:\n  required: true';
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
+    });
+
+    it('Test array enum value containing a nested boolean', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          flags: {
+            type: 'array',
+            enum: [[true]],
+          },
+        },
+      });
+      const content = 'flags:\n  - true';
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
+    });
+
+    it('Test object const value containing a nested boolean', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          parameter: {
+            type: 'object',
+            const: {
+              required: true,
+            },
+          },
+        },
+      });
+      const content = 'parameter:\n  required: true';
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
+    });
+
+    it('Test array const value containing a nested boolean', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        type: 'object',
+        properties: {
+          flags: {
+            type: 'array',
+            const: [true],
+          },
+        },
+      });
+      const content = 'flags:\n  - true';
+      const result = await parseSetup(content);
+      assert.deepStrictEqual(result, []);
+    });
+
     it('Test that YAML 1.1 boolean "True" can be used in enum', async () => {
       // This test requires YAML 1.1 mode where "True" is parsed as a boolean
       languageService.configure(languageSettingsSetup.withYamlVersion('1.1').languageSettings);


### PR DESCRIPTION
### What does this PR do?

Updates `getNodeValue()` to return the parsed value for boolean nodes instead of their raw YAML source

Previously, booleans nested inside object or array `enum`/`const` values were reconstructed as strings. For example, the YAML value:

```yaml
parameter:
  required: true
```

was compared as `{ "required": "true" }` against the schema value `{ "required": true }`. This caused the diagnostic `Value is not accepted. Valid values: {"required":true}.`.

### What issues does this PR fix or reference?

Fixes https://github.com/redhat-developer/yaml-language-server/issues/1320

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- [x] New automated tests by codex
- [x] Manual test: https://github.com/redhat-developer/yaml-language-server/issues/1320#issuecomment-5285388916