### PR TITLE
Fix: keep constraints on cyclic cross-file $refs in unindexed resources

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -1161,11 +1161,10 @@ export class YAMLSchemaService implements IJSONSchemaService {
 
         const _mergeIfResourceAlreadyInResolutionStack = (ref: string, resolvedResource: string, frag: string): boolean => {
           if (!resolutionStack.has(resolvedResource)) return false;
+          const source = resourceIndexByUri.get(resolvedResource)?.root;
+          if (!source || typeof source !== 'object') return false;
           if (!seenRefs.has(ref)) {
-            const source = resourceIndexByUri.get(resolvedResource)?.root;
-            if (source && typeof source === 'object') {
-              _merge(next, source, resolvedResource, frag, !!recursiveAnchorBase);
-            }
+            _merge(next, source, resolvedResource, frag, !!recursiveAnchorBase);
             seenRefs.add(ref);
           }
           return true;

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -305,6 +305,53 @@ describe('YAML Schema Service', () => {
       });
     });
 
+    it('should keep constraints on cyclic cross-file $refs when the resources have no $id', async () => {
+      const content = `# yaml-language-server: $schema=file:///schemas/node.json\nname: root\nchildren:\n  - name: child`;
+      const yamlDock = parse(content);
+
+      // draft-07, split across files, relative $refs, no $id anywhere:
+      // node.json -> wrapper.json -> node.json
+      const nodeSchema = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        required: ['name'],
+        additionalProperties: false,
+        properties: {
+          name: { type: 'string' },
+          children: { type: 'array', items: { $ref: 'wrapper.json' } },
+        },
+      };
+      const wrapperSchema = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        oneOf: [{ $ref: 'node.json' }],
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === 'file:///schemas/node.json') {
+          return Promise.resolve(JSON.stringify(nodeSchema));
+        }
+        if (uri === 'file:///schemas/wrapper.json') {
+          return Promise.resolve(JSON.stringify(wrapperSchema));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      const schema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const children = schema.schema.properties.children as JSONSchema;
+      const wrapper = children.items as JSONSchema;
+      expect(wrapper.oneOf, 'wrapper lost its oneOf branches').to.have.length(1);
+
+      // This is the node that closes the cycle back to node.json. An empty schema
+      // here would silently accept anything nested under `children`.
+      const cycleTarget = wrapper.oneOf[0] as JSONSchema;
+      expect(cycleTarget.type, 'cycle target lost its type').to.equal('object');
+      expect(cycleTarget.properties, 'cycle target lost its properties').to.have.property('name');
+      expect(cycleTarget.required, 'cycle target lost its required list').to.eql(['name']);
+      expect(cycleTarget.additionalProperties, 'cycle target lost additionalProperties').to.equal(false);
+    });
+
     it('should resolve nested local sibling refs relative to the loaded sibling schema file', async () => {
       const content = `# yaml-language-server: $schema=file:///schemas/primary.json\nitem: ok`;
       const yamlDock = parse(content);


### PR DESCRIPTION
Fixes #1325.

## Problem

When a schema recurses through a `$ref` that names a **file** rather than a local `#/...` pointer, everything below the first level of recursion silently stops being validated. The nested subschema resolves to `{}`, which accepts anything, so no error is reported and the schema appears to work.

A single self-referencing file is enough to reproduce it (full reproducer in #1325):

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "additionalProperties": false,
  "properties": {
    "name": { "type": "string" },
    "children": { "type": "array", "items": { "$ref": "node.json" } }
  }
}
```

The same recursion expressed as `#/$defs/node` behaves correctly, so only the file-name form is affected.

Regression from #1195, present in 1.21.0 through 1.24.0 and on `main`.

## Cause

`_mergeIfResourceAlreadyInResolutionStack()` returns `true` — meaning "I have handled this `$ref`" — whenever the target resource is on the resolution stack, *even when `resourceIndexByUri` holds no entry for that resource*:

```ts
if (!resolutionStack.has(resolvedResource)) return false;
if (!seenRefs.has(ref)) {
  const source = resourceIndexByUri.get(resolvedResource)?.root;
  if (source && typeof source === 'object') {   // <- skipped when the resource is not indexed
    _merge(next, source, resolvedResource, frag, !!recursiveAnchorBase);
  }
  seenRefs.add(ref);
}
return true;                                     // <- but the ref is claimed anyway
```

Doing the work is conditional; claiming it is not. When the resource is not indexed nothing gets merged, and because the caller has already deleted `next.$ref` and treats `true` as "skip `resolveExternalLink()`", the subschema is left empty.

`resourceIndexByUri` is only populated for resources identifiable via `$id`/anchors. Schemas that reference each other by relative file path — normal for draft-07 bundles — never appear in it, so for them every recursive file `$ref` degrades into an empty, always-valid schema. Logged at the point the guard fires:

```
ref=node.json  inStack=true  indexHasKey=false  sourceType=undefined
index keys: []
```

## Fix

Only claim the `$ref` when there is actually something to merge; otherwise fall through to the regular `resolveExternalLink()` path as before #1195. Reaching `_merge` is now the guarantee rather than a conditional:

```diff
   if (!resolutionStack.has(resolvedResource)) return false;
+  const source = resourceIndexByUri.get(resolvedResource)?.root;
+  if (!source || typeof source !== 'object') return false;
   if (!seenRefs.has(ref)) {
-    const source = resourceIndexByUri.get(resolvedResource)?.root;
-    if (source && typeof source === 'object') {
-      _merge(next, source, resolvedResource, frag, !!recursiveAnchorBase);
-    }
+    _merge(next, source, resolvedResource, frag, !!recursiveAnchorBase);
     seenRefs.add(ref);
   }
   return true;
```

The cycle short-circuit still applies whenever the resource *is* indexed, so the infinite `$ref` resolution loops fixed in #1195 stay fixed.

## Testing

Added `should keep constraints on cyclic cross-file $refs when the resources have no $id` to `test/yamlSchemaService.test.ts`. It asserts that the node closing the cycle keeps its `type`, `properties`, `required` and `additionalProperties`. It fails before this change (`cycle target lost its type: expected undefined to equal 'object'`) and passes after.

Verified across three shapes, comparing 1.20.0 (before #1195), 1.24.0 as released, and 1.24.0 with this fix:

| case | 1.20.0 | 1.24.0 | 1.24.0 + fix |
| --- | --- | --- | --- |
| cyclic `$ref` with siblings (the #1195 case) | hangs | pass | pass |
| multi-file cycle **with** `$id` | pass | pass | pass |
| multi-file cycle, relative refs, no `$id` (#1325) | pass | **fail** | pass |

Note the first row: reverting #1195 is not an alternative, since 1.20.0 hangs on the case it fixed. Its regression test (`does not infinite loop on cyclic $ref with siblings`) still passes with this change.

The full suite produces an identical set of failures before and after, plus the one new passing test (the pre-existing failures are Kubernetes/SchemaStore tests that need network access I do not have):

- without the fix: 1272 passing, 24 failing
- with the fix: 1273 passing, 23 failing

## Notes

Found while debugging a real draft-07 schema bundle split into one file per type, whose recursive `elements` property stopped reporting diagnostics for nested entries after a language-server update.
