### PR TITLE
fix: preserve list-element indentation in onTypeFormatting

### DIFF
--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -53,24 +53,26 @@ export function doDocumentOnTypeFormatting(
       if (currentLine.trim().length !== 0) {
         // non-space content, do nothing
         return;
-      } else if (currentLine.length === expectedText.length) {
+      }
+      if (currentLine === expectedText) {
         // already right; do nothing
         return;
-      } else if (currentLine.length < expectedText.length) {
-        // insert after whatever indentation is already on the line, so a leading
-        // dash never lands before existing spaces (e.g. client-side auto-indent)
-        const insertPosition = Position.create(position.line, currentLine.length);
-        return [TextEdit.insert(insertPosition, expectedText.slice(currentLine.length))];
-      } else {
-        return [
-          TextEdit.del(
-            Range.create(
-              Position.create(position.line, 0),
-              Position.create(position.line, currentLine.length - expectedText.length)
-            )
-          ),
-        ];
       }
+      if (position.character >= indentation.length) {
+        // The client already auto-indented the line and placed the cursor at
+        // (or past) the indentation; just append the dash.
+        return [TextEdit.insert(Position.create(position.line, currentLine.length), '- ')];
+      }
+      // The client sent a position before the existing whitespace
+      // (e.g. lsp-mode, eglot send column 0 even though the line already has
+      // auto-indented spaces).  Replace the whole line content so the
+      // result is always correct.
+      return [
+        TextEdit.replace(
+          Range.create(Position.create(position.line, 0), Position.create(position.line, currentLine.length)),
+          expectedText
+        ),
+      ];
     }
 
     if (previousLine.includes(' - ') && previousLine.includes(': ')) {

--- a/src/languageservice/services/yamlOnTypeFormatting.ts
+++ b/src/languageservice/services/yamlOnTypeFormatting.ts
@@ -46,8 +46,31 @@ export function doDocumentOnTypeFormatting(
       return [TextEdit.insert(position, ' '.repeat(params.options.tabSize))];
     }
 
-    if (previousLine.includes(' - ') && !previousLine.includes(': ')) {
-      return [TextEdit.insert(position, '- ')];
+    if (previousLine.trimStart().startsWith('-') && !previousLine.includes(': ')) {
+      const indentation = previousLine.slice(0, previousLine.length - previousLine.trimStart().length);
+      const expectedText = indentation + '- ';
+      const currentLine = tb.getLineContent(position.line).replace('\r', '').replace('\n', '');
+      if (currentLine.trim().length !== 0) {
+        // non-space content, do nothing
+        return;
+      } else if (currentLine.length === expectedText.length) {
+        // already right; do nothing
+        return;
+      } else if (currentLine.length < expectedText.length) {
+        // insert after whatever indentation is already on the line, so a leading
+        // dash never lands before existing spaces (e.g. client-side auto-indent)
+        const insertPosition = Position.create(position.line, currentLine.length);
+        return [TextEdit.insert(insertPosition, expectedText.slice(currentLine.length))];
+      } else {
+        return [
+          TextEdit.del(
+            Range.create(
+              Position.create(position.line, 0),
+              Position.create(position.line, currentLine.length - expectedText.length)
+            )
+          ),
+        ];
+      }
     }
 
     if (previousLine.includes(' - ') && previousLine.includes(': ')) {

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -53,7 +53,7 @@ describe('YAML On Type Formatter', () => {
     const pos = Position.create(3, 0);
     const params = createParams(pos);
     const result = doDocumentOnTypeFormatting(doc, params);
-    expect(result[0]).to.eql(TextEdit.insert(Position.create(3, 2), '- '));
+    expect(result[0]).to.eql(TextEdit.replace(Range.create(Position.create(3, 0), Position.create(3, 2)), '  - '));
   });
 
   it('should add indentation for mapping in array', () => {

--- a/test/yamlOnTypeFormatting.test.ts
+++ b/test/yamlOnTypeFormatting.test.ts
@@ -40,6 +40,22 @@ describe('YAML On Type Formatter', () => {
     expect(result[0]).to.eqls(TextEdit.insert(pos, '- '));
   });
 
+  it('should preserve list element indentation after newline', () => {
+    const doc = setupTextDocument('test:\n  - hello\n  - world\n');
+    const pos = Position.create(3, 0);
+    const params = createParams(pos);
+    const result = doDocumentOnTypeFormatting(doc, params);
+    expect(result[0]).to.eql(TextEdit.insert(pos, '  - '));
+  });
+
+  it('should align list element dash after existing client-side indentation', () => {
+    const doc = setupTextDocument('test:\n  - hello\n  - world\n  ');
+    const pos = Position.create(3, 0);
+    const params = createParams(pos);
+    const result = doDocumentOnTypeFormatting(doc, params);
+    expect(result[0]).to.eql(TextEdit.insert(Position.create(3, 2), '- '));
+  });
+
   it('should add indentation for mapping in array', () => {
     const doc = setupTextDocument('some:\n  - arr:\n  ');
     const pos = Position.create(2, 2);


### PR DESCRIPTION
This PR fixes wrong indentation of list items when pressing enter in an existing list,  having `onTypeFormatting` enabled.

The onTypeFormatting handler currently returns an unconditional "- " at params.position, dropping the sequence indentation and placing the dash at column 0 (invalid YAML).

It also ignores whitespace the client had already auto-inserted on the line, putting the dash *before* those existing spaces.

This is the LSP-spec-correct behavior to expect: the server advertises documentOnTypeFormattingProvider with firstTriggerCharacter "\n", and DocumentOnTypeFormattingParams explicitly notes that position is "not necessarily the exact position where the character denoted by the property ch got typed" and that a client "could auto insert characters as well" (e.g. automatic indentation/brace completion). A compliant client like lsp-mode or eglot sends the request with the line already carrying client-side indentation, so the edit must merge with it rather than overwrite it.

Verified live in Emacs with lsp-mode: the stock 1.24.0 server produced a dash at column 0, while the fixed server leaves the line correctly indented with the dash in place.

### What does this PR do?

Changes the behavior of onTypeFormatting to insert list items in the correct location and align the server with LSP spec.

When pressing Enter after a block-sequence item, the server's `onTypeFormatting` handler returns an edit that drops the sequence indentation, producing an invalid dash at column 0. Example (cursor at end of the last line, hit Enter):

### What issues does this PR fix or reference?

Fixes wrong indentation:

```yaml
test:
  - hello
  - world
-      <- wrong, server returns "- " at column 0 (invalid YAML)
```

Expected: the new item is aligned with the existing `-` (dash at the same column as the preceding item):

```yaml
test:
  - hello
  - world
  -    <- correct
```

#### LSP spec

The handler is invoked because this server advertises the capability:

> **Server Capability** -- `documentOnTypeFormattingProvider` (`DocumentOnTypeFormattingOptions`)
>
> ```ts
> firstTriggerCharacter: string;   // "\n" in our case
> ```
>
> -- LSP 3.17, [Document On Type Formatting Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_onTypeFormatting)

Advertising the capability is an explicit invitation for clients to delegate newline formatting to the server, so it is expected that a spec-compliant client will call the server on Enter.

`DocumentOnTypeFormattingParams.position` is explicitly *not* guaranteed to be where the dash should land:

> ```ts
> interface DocumentOnTypeFormattingParams {
>     /**
>      * The position around which the on type formatting should happen.
>      * This is not necessarily the exact position where the character denoted
>      * by the property `ch` got typed.
>      */
>     position: Position;
>     ...
>     /**
>      * ... That is not necessarily the last character that got inserted into
>      * the document since the client could auto insert characters as well
>      * (e.g. like automatic brace completion).
>      */
>     ch: string;
> }
> ```
>
> -- LSP 3.17, `DocumentOnTypeFormattingParams` (emphasis added)

The fix therefore computes the target `indentation + '- '` from the preceding item and inserts only the missing text **after whatever whitespace already exists on the line**, rather than assuming `position` = insertion point.

No issues in this project, but I reported the symptoms of this (perhaps erroneously) on Emacs' lsp-mode: https://github.com/emacs-lsp/lsp-mode/issues/5112


### Is it tested? How?

Tested via a live Emacs client, connecting to 1.24.0 and this patched server to observe the correct/wrong behavior.

The behavior occurs both with lsp-mode and with eglot.

Also automated tests are included.

# LLM note

I am just a meat proxy/flesh goblin but I put Opencode's Big Pickle through its paces and tried to double and triple-verify that this is indeed the correct behavior according to spec. However, I don't know a thing about LSP server implementations so there could be a whale-sized problem here I'm not seeing.

What I know is that emacs lsp-mode behaves properly with this patched server and VS Code is unaffected because it never seems to make any use of this functionality.

# DCO note

As far as I know, the legal standing of LLM code and its licensing has never been decided in any court of law, so it's also unclear if this contribution can adhere to the DCO.