### PR TITLE
Fix schema references through non-standard containers

### DIFF
--- a/src/languageservice/services/yamlSchemaService.ts
+++ b/src/languageservice/services/yamlSchemaService.ts
@@ -737,6 +737,14 @@ export class YAMLSchemaService implements IJSONSchemaService {
     type PlainNameFragmentMap = Map<string, FragmentEntry>;
     type ResourceIndex = { root?: JSONSchema; fragments: PlainNameFragmentMap };
     const resourceIndexByUri = new Map<string, ResourceIndex>();
+    const lookupRoots = new WeakMap<JSONSchema, JSONSchema>();
+
+    // Preserve root keys before $ref processing removes or rewrites siblings
+    const _preserveLookupRoot = (root: JSONSchema): void => {
+      if (root && typeof root === 'object' && !lookupRoots.has(root)) {
+        lookupRoots.set(root, { ...root });
+      }
+    };
 
     const _getResourceIndex = (resourceUri: string): ResourceIndex => {
       let entry = resourceIndexByUri.get(resourceUri);
@@ -745,6 +753,14 @@ export class YAMLSchemaService implements IJSONSchemaService {
         resourceIndexByUri.set(resourceUri, entry);
       }
       return entry;
+    };
+
+    const _registerResourceRoot = (resourceUri: string, root: JSONSchema): void => {
+      const entry = _getResourceIndex(resourceUri);
+      if (entry.root) return;
+
+      entry.root = root;
+      _preserveLookupRoot(root);
     };
 
     /**
@@ -811,12 +827,11 @@ export class YAMLSchemaService implements IJSONSchemaService {
           } else {
             // $id without fragment creates a new embedded resource scope
             baseUri = resolvedBaseUri;
-            const entry = _getResourceIndex(resolvedBaseUri);
-            if (!entry.root) {
-              entry.root = node;
-            }
+            _registerResourceRoot(resolvedBaseUri, node);
           }
         }
+        // keep the retrieval URI usable even when $id changes the base URI
+        if (node === root) _registerResourceRoot(initialBaseUri, node);
         // Draft 2019-09+: $anchor keyword
         if (node.$anchor) {
           _getResourceIndex(baseUri).fragments.set(node.$anchor, { node });
@@ -887,7 +902,7 @@ export class YAMLSchemaService implements IJSONSchemaService {
 
       // JSON pointer style
       if (refPath[0] === PATH_SEP) {
-        let current = schemaRoot;
+        let current = lookupRoots.get(schemaRoot) ?? schemaRoot;
         const parts = refPath.substring(1).split(PATH_SEP);
         for (const part of parts) {
           // in JSON Pointer: ~ must be escaped as ~0, / must be escaped as ~1
@@ -1088,6 +1103,7 @@ export class YAMLSchemaService implements IJSONSchemaService {
         },
       ];
       const seen = new WeakSet<JSONSchema>(); // prevents re-walking the same schema object graph
+      _preserveLookupRoot(parentSchema);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const openPromises: Promise<any>[] = [];
@@ -1379,7 +1395,7 @@ export class YAMLSchemaService implements IJSONSchemaService {
         const item = toWalk.pop();
         const next = item.node;
         const nodeBaseUri = next._baseUri || item.baseUri;
-        const nodeSourceUri = next._sourceUri || nodeBaseUri;
+        const nodeSourceUri = next._sourceUri || item.sourceUri || nodeBaseUri;
         const nodeSchemaDraft = next._schemaDraft || item.schemaDraft;
         const nodeRecursiveAnchorBase = item.recursiveAnchorBase ?? (next.$recursiveAnchor ? nodeBaseUri : undefined);
         if (seen.has(next)) continue;

--- a/test/schemaValidation.test.ts
+++ b/test/schemaValidation.test.ts
@@ -2392,6 +2392,117 @@ option: local
       expect(bad[0].message).to.include('string');
     });
 
+    it('Resolving $refs: should resolve a root $ref through non-standard schema container', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $ref: '#/customSchemas/Root',
+        customSchemas: {
+          Root: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              child: { $ref: '#/customSchemas/Child' },
+            },
+          },
+          Child: {
+            type: 'object',
+            properties: {
+              value: { type: 'integer' },
+            },
+          },
+        },
+      } as JSONSchema);
+
+      expect(await parseSetup(`name: hello\nchild:\n  value: 42`)).to.be.empty;
+      const bad = await parseSetup(`name: 123`);
+      expect(bad[0].message).to.include('Incorrect type. Expected');
+      expect(bad[0].message).to.include('string');
+    });
+
+    it('Resolving $refs: should resolve a nested Draft-07 $ref through non-standard schema container and ignore constraint siblings', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          config: {
+            $ref: '#/customSchemas/Config',
+            type: 'number',
+          },
+        },
+        customSchemas: {
+          Config: {
+            type: 'object',
+            properties: {
+              enabled: { type: 'boolean' },
+            },
+          },
+        },
+      } as JSONSchema);
+
+      expect(await parseSetup(`config:\n  enabled: true`)).to.be.empty;
+      const bad = await parseSetup(`config:\n  enabled: 1`);
+      expect(bad[0].message).to.include('Incorrect type. Expected');
+      expect(bad[0].message).to.include('boolean');
+    });
+
+    it('Resolving $refs: should resolve canonical $id self-references through non-standard schema container', async () => {
+      schemaProvider.addSchema(SCHEMA_ID, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: SCHEMA_ID,
+        $ref: '#/customSchemas/Root',
+        customSchemas: {
+          Root: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              child: { $ref: `${SCHEMA_ID}#/customSchemas/Child` },
+            },
+          },
+          Child: {
+            type: 'object',
+            properties: {
+              value: { type: 'integer' },
+            },
+          },
+        },
+      } as JSONSchema);
+
+      expect(await parseSetup(`name: hello\nchild:\n  value: 42`)).to.be.empty;
+      const bad = await parseSetup(`name: hello\nchild:\n  value: not_int`);
+      expect(bad[0].message).to.include('Incorrect type. Expected');
+      expect(bad[0].message).to.include('integer');
+    });
+
+    it('Resolving $refs: should validate a relative local self-reference through non-standard schema container after an absolute root reference', async () => {
+      const schemaUri = 'file:///schemas/schema3.json';
+      schemaProvider.addSchemaWithUri(SCHEMA_ID, schemaUri, {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'https://example.com/test-schema',
+        $ref: 'https://example.com/test-schema#/customSchemas/Root',
+        customSchemas: {
+          Root: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              child: { $ref: './schema3.json#/customSchemas/Child' },
+            },
+          },
+          Child: {
+            type: 'object',
+            properties: {
+              value: { type: 'integer' },
+            },
+          },
+        },
+      } as JSONSchema);
+
+      expect(await parseSetup(`name: hello\nchild:\n  value: 42`)).to.be.empty;
+      const bad = await parseSetup(`name: hello\nchild:\n  value: e`);
+      expect(bad).to.have.length(1);
+      expect(bad[0].message).to.include('Incorrect type. Expected');
+      expect(bad[0].message).to.include('integer');
+    });
+
     it('schema should validate additionalProp oneOf', async () => {
       const schema = {
         properties: {

--- a/test/yamlSchemaService.test.ts
+++ b/test/yamlSchemaService.test.ts
@@ -352,6 +352,114 @@ describe('YAML Schema Service', () => {
       expect(cycleTarget.additionalProperties, 'cycle target lost additionalProperties').to.equal(false);
     });
 
+    it('should resolve a relative local self-reference through non-standard schema container without a remote request', async () => {
+      const schemaUri = 'file:///schemas/schema3.json';
+      const content = `# yaml-language-server: $schema=${schemaUri}\nname: hello\nchild:\n  value: invalid`;
+      const yamlDock = parse(content);
+
+      const schema3 = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'https://example.com/test-schema',
+        $ref: 'https://example.com/test-schema#/customSchemas/Root',
+        customSchemas: {
+          Root: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              child: {
+                $ref: './schema3.json#/customSchemas/Child',
+              },
+            },
+          },
+          Child: {
+            type: 'object',
+            properties: {
+              value: { type: 'integer' },
+            },
+          },
+        },
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === schemaUri) {
+          return Promise.resolve(JSON.stringify(schema3));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      const resolvedSchema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      expect(resolvedSchema.schema._sourceUri).to.equal(schemaUri);
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.eql([schemaUri]);
+      expect(resolvedSchema.errors).to.eql([]);
+      expect(resolvedSchema.schema.properties.child).to.deep.include({ type: 'object' });
+      expect((resolvedSchema.schema.properties.child as JSONSchema).properties.value).to.deep.include({ type: 'integer' });
+      expect(requestServiceMock).calledOnceWithExactly(schemaUri);
+    });
+
+    it('should resolve a relative local sibling-file reference through non-standard schema containers', async () => {
+      const schema3Uri = 'file:///schemas/schema3.json';
+      const schema2Uri = 'file:///schemas/schema2.json';
+      const content = `# yaml-language-server: $schema=${schema3Uri}\nname: hello\nchild:\n  value: invalid`;
+      const yamlDock = parse(content);
+
+      const schema3 = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'https://example.com/test-schema',
+        $ref: 'https://example.com/test-schema#/customSchemas/Root',
+        customSchemas: {
+          Root: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              child: {
+                $ref: './schema2.json#/customSchemas/Child',
+              },
+            },
+          },
+        },
+      };
+      const schema2 = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'https://example.com/schema2',
+        customSchemas: {
+          Child: {
+            type: 'object',
+            properties: {
+              value: { type: 'integer' },
+            },
+          },
+        },
+      };
+
+      requestServiceMock = sandbox.fake((uri: string) => {
+        if (uri === schema3Uri) {
+          return Promise.resolve(JSON.stringify(schema3));
+        }
+        if (uri === schema2Uri) {
+          return Promise.resolve(JSON.stringify(schema2));
+        }
+        return Promise.reject<string>(`Resource ${uri} not found.`);
+      });
+
+      const service = new SchemaService.YAMLSchemaService(requestServiceMock, workspaceContext);
+      const resolvedSchema = await service.getSchemaForResource('', yamlDock.documents[0]);
+
+      const requestedUris = requestServiceMock.getCalls().map((call) => call.args[0]);
+      expect(requestedUris).to.eql([schema3Uri, schema2Uri]);
+      expect(resolvedSchema.errors).to.eql([]);
+      expect(resolvedSchema.schema.properties.child).to.deep.include({
+        type: 'object',
+        url: schema2Uri,
+      });
+      expect((resolvedSchema.schema.properties.child as JSONSchema).properties.value).to.deep.include({ type: 'integer' });
+      expect(requestServiceMock).calledWithExactly(schema3Uri);
+      expect(requestServiceMock).calledWithExactly(schema2Uri);
+      expect(requestServiceMock).callCount(2);
+    });
+
     it('should resolve nested local sibling refs relative to the loaded sibling schema file', async () => {
       const content = `# yaml-language-server: $schema=file:///schemas/primary.json\nitem: ok`;
       const yamlDock = parse(content);


### PR DESCRIPTION
### What does this PR do?

Fixes `$ref` resolution when a root reference points into a non-standard schema container, such as `#/components/schemas/pipelines_configuration`, instead of a standard container such as `$defs` or `definitions`. The fix also covers nested references that target the same local schema file or a sibling file.

In Draft-07 and earlier, spec mentions that keywords alongside `$ref` should be ignored. During resolution, `YAMLSchemaService` removed constraint sibling keys, including non-standard schema containers. This made the referenced JSON Pointer through non-standard containers unavailable for subsequent lookups.

Schemas reached through these containers could also lose their local source URI. As a result, relative references such as `./schema.json` could be resolved against the schema’s remote `$id` instead of the local file location.

The fix preserves root keys for JSON Pointer lookup, indexes schemas by their retrieval URI as well as their `$id`, and propagates the local source URI through nested reference resolution.

### What issues does this PR fix or reference?

Fixes https://github.com/redhat-developer/yaml-language-server/issues/1322

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
- Added new tests for non-standard container lookups, local self-references, and local sibling-file references
- Tested manually with the cases in new tests